### PR TITLE
fix: --skip-agents-md/--skip-claude-md flags (Commander --no- prefix bug)

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -49,8 +49,8 @@ export interface AnalyzeOptions {
   skills?: boolean;
   verbose?: boolean;
   exclude?: string[];
-  noAgentsMd?: boolean;
-  noClaudeMd?: boolean;
+  skipAgentsMd?: boolean;
+  skipClaudeMd?: boolean;
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
@@ -355,8 +355,8 @@ export const analyzeCommand = async (
     clusters: aggregatedClusterCount,
     processes: pipelineResult.processResult?.stats.totalProcesses,
   }, generatedSkills, {
-    noAgentsMd: options?.noAgentsMd,
-    noClaudeMd: options?.noClaudeMd,
+    noAgentsMd: options?.skipAgentsMd,
+    noClaudeMd: options?.skipClaudeMd,
   });
 
   await closeLbug();

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -28,8 +28,8 @@ program
   .option('--embeddings', 'Enable embedding generation for semantic search (off by default)')
   .option('--skills', 'Generate repo-specific skill files from detected communities')
   .option('-e, --exclude <pattern...>', 'Glob patterns to exclude from indexing (e.g. "tests/**" "benchmarks/**")')
-  .option('--no-agents-md', 'Skip AGENTS.md generation')
-  .option('--no-claude-md', 'Skip CLAUDE.md generation')
+  .option('--skip-agents-md', 'Skip AGENTS.md generation')
+  .option('--skip-claude-md', 'Skip CLAUDE.md generation')
   .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
   .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 


### PR DESCRIPTION
Commander.js `--no-X` convention parses `--no-agents-md` as `{ agentsMd: false }`, not `{ noAgentsMd: true }`. The flags were never working.

Renamed to `--skip-agents-md` / `--skip-claude-md` to avoid the prefix collision.

Verified: `gitnexus analyze --force --skip-agents-md --skip-claude-md` → no AGENTS.md/CLAUDE.md generated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/100yenadmin/gitnexus/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
