### PR TITLE
fix: normalize parameter aliases for impact and context tools

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -310,10 +310,24 @@ export class LocalBackend {
         const raw = await this.cypher(repo, params);
         return this.formatCypherAsMarkdown(raw);
       }
-      case 'context':
-        return this.context(repo, params);
-      case 'impact':
-        return this.impact(repo, params);
+      case 'context': {
+        // Normalize aliases: file → file_path, symbol → name
+        const ctxParams = { ...params };
+        if (ctxParams.file && !ctxParams.file_path) ctxParams.file_path = ctxParams.file;
+        if (ctxParams.symbol && !ctxParams.name) ctxParams.name = ctxParams.symbol;
+        return this.context(repo, ctxParams);
+      }
+      case 'impact': {
+        // Normalize aliases: name/symbol → target
+        const impactParams = { ...params };
+        if (!impactParams.target) {
+          impactParams.target = impactParams.name || impactParams.symbol;
+        }
+        if (!impactParams.direction) {
+          impactParams.direction = 'upstream'; // sensible default
+        }
+        return this.impact(repo, impactParams);
+      }
       case 'detect_changes':
         return this.detectChanges(repo, params);
       case 'rename':


### PR DESCRIPTION
## Problem

**Issue #3:** `/tool/impact` returns `Error: Target 'undefined' not found` for ALL symbols when callers send `{"name": "...", ...}` or `{"symbol": "...", ...}` instead of `{"target": "...", ...}`.

**Issue #4:** `/tool/context` ignores the `file` parameter for disambiguation. When callers send `{"file": "path"}`, the internal function expects `file_path` and never receives it.

## Root Cause

Parameter name mismatch between what the HTTP API / SKILL.md documents and what the internal functions expect:

| Tool | API sends | Internal expects |
|------|-----------|-----------------|
| impact | `name` or `symbol` | `target` |
| context | `file` | `file_path` |

## Fix

Added parameter normalization in `callTool()` dispatch:
- **impact:** `name`/`symbol` → `target`, default `direction` to `'upstream'`
- **context:** `file` → `file_path`, `symbol` → `name`

## Testing

Verified all three endpoints work after fix:
- `/tool/impact` with `symbol`, `name`, and `target` params — all return real blast radius data
- `/tool/context` with `file` param — correctly disambiguates when multiple symbols share a name
- Existing `target`/`file_path` params still work (no breaking change)

Fixes #3, Fixes #4
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/100yenadmin/gitnexus/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
