### PR TITLE
feat: harden MCP runtime and embedding dimensions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -44,5 +44,6 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
           GITLEAKS_ENABLE_SUMMARY: true

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -405,9 +405,11 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
       repoPath,
       {
         // Pipeline re-index — OR'd with --skills because skill generation
-        // needs a fresh pipelineResult. Has no bearing on the registry
-        // collision guard (see allowDuplicateName below).
-        force: options?.force || options?.skills,
+        // needs a fresh pipelineResult. When --skip-ai-context suppresses
+        // skill generation, keep the up-to-date fast path available.
+        // Has no bearing on the registry collision guard (see
+        // allowDuplicateName below).
+        force: options?.force || (options?.skills && !options?.skipAiContext),
         embeddings: embeddingsEnabled,
         embeddingsNodeLimit,
         dropEmbeddings: options?.dropEmbeddings,

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -117,6 +117,8 @@ export interface AnalyzeOptions {
   verbose?: boolean;
   /** Skip AGENTS.md and CLAUDE.md gitnexus block updates. */
   skipAgentsMd?: boolean;
+  /** Skip all AI context writes: AGENTS.md, CLAUDE.md, and bundled GitNexus skills. */
+  skipAiContext?: boolean;
   /** Omit volatile symbol/relationship counts from AGENTS.md and CLAUDE.md. */
   noStats?: boolean;
   /** Index the folder even when no .git directory is present. */
@@ -411,6 +413,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
         dropEmbeddings: options?.dropEmbeddings,
         skipGit: options?.skipGit,
         skipAgentsMd: options?.skipAgentsMd,
+        skipAiContext: options?.skipAiContext,
         noStats: options?.noStats,
         registryName: options?.name,
         // Registry-collision bypass — its own CLI flag, intentionally NOT
@@ -457,7 +460,7 @@ export const analyzeCommand = async (inputPath?: string, options?: AnalyzeOption
     await assertAnalysisFinalized(repoPath);
 
     // Skill generation (CLI-only, uses pipeline result from analysis)
-    if (options?.skills && result.pipelineResult) {
+    if (options?.skills && !options?.skipAiContext && result.pipelineResult) {
       updateBar(99, 'Generating skill files...');
       try {
         const { generateSkillFiles } = await import('./skill-gen.js');

--- a/gitnexus/src/cli/eval-server.ts
+++ b/gitnexus/src/cli/eval-server.ts
@@ -325,11 +325,17 @@ function getNextStepHint(toolName: string): string {
   }
 }
 
-export function isBearerAuthorized(authToken: string | null, authHeader: string | undefined): boolean {
+export function isBearerAuthorized(
+  authToken: string | null,
+  authHeader: string | undefined,
+): boolean {
   return !authToken || authHeader === `Bearer ${authToken}`;
 }
 
-export function formatHealthPayload(repoNames: string[], includeRepos: boolean): {
+export function formatHealthPayload(
+  repoNames: string[],
+  includeRepos: boolean,
+): {
   status: 'ok';
   repos?: string[];
   auth?: 'required';
@@ -405,7 +411,9 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
       if (!authorized) {
         res.setHeader('Content-Type', 'application/json');
         res.writeHead(401);
-        res.end(JSON.stringify({ error: 'Unauthorized — set Authorization: Bearer <token> header' }));
+        res.end(
+          JSON.stringify({ error: 'Unauthorized — set Authorization: Bearer <token> header' }),
+        );
         return;
       }
 

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -35,6 +35,10 @@ program
   )
   .option('--skills', 'Generate repo-specific skill files from detected communities')
   .option('--skip-agents-md', 'Skip updating the gitnexus section in AGENTS.md and CLAUDE.md')
+  .option(
+    '--skip-ai-context',
+    'Skip all AI context side effects: AGENTS.md, CLAUDE.md, and bundled GitNexus skills',
+  )
   .option('--no-stats', 'Omit volatile file/symbol counts from AGENTS.md and CLAUDE.md')
   .option(
     '--skip-git',

--- a/gitnexus/src/core/embeddings/http-client.ts
+++ b/gitnexus/src/core/embeddings/http-client.ts
@@ -105,8 +105,10 @@ const httpEmbedBatch = async (
   dimensions: number | undefined,
   batchIndex = 0,
 ): Promise<EmbeddingItem[]> => {
-  const body: { input: string[]; model: string; dimensions?: number; output_dimension?: number } =
-    { input: batch, model };
+  const body: { input: string[]; model: string; dimensions?: number; output_dimension?: number } = {
+    input: batch,
+    model,
+  };
   if (dimensions !== undefined) {
     let host = '';
     try {

--- a/gitnexus/src/core/embeddings/http-client.ts
+++ b/gitnexus/src/core/embeddings/http-client.ts
@@ -98,8 +98,14 @@ const httpEmbedBatch = async (
   batch: string[],
   model: string,
   apiKey: string,
+  dimensions: number | undefined,
   batchIndex = 0,
 ): Promise<EmbeddingItem[]> => {
+  const body: { input: string[]; model: string; dimensions?: number } = { input: batch, model };
+  if (dimensions !== undefined) {
+    body.dimensions = dimensions;
+  }
+
   let resp: Response;
   try {
     resp = await resilientFetch(
@@ -111,7 +117,7 @@ const httpEmbedBatch = async (
           'Content-Type': 'application/json',
           Authorization: `Bearer ${apiKey}`,
         },
-        body: JSON.stringify({ input: batch, model }),
+        body: JSON.stringify(body),
       },
       {
         breakerKey: HTTP_BREAKER_KEY,
@@ -169,7 +175,14 @@ export const httpEmbed = async (texts: string[]): Promise<Float32Array[]> => {
   for (let i = 0; i < texts.length; i += HTTP_BATCH_SIZE) {
     const batch = texts.slice(i, i + HTTP_BATCH_SIZE);
     const batchIndex = Math.floor(i / HTTP_BATCH_SIZE);
-    const items = await httpEmbedBatch(url, batch, config.model, config.apiKey, batchIndex);
+    const items = await httpEmbedBatch(
+      url,
+      batch,
+      config.model,
+      config.apiKey,
+      config.dimensions,
+      batchIndex,
+    );
 
     if (items.length !== batch.length) {
       throw new Error(
@@ -212,7 +225,7 @@ export const httpEmbedQuery = async (text: string): Promise<number[]> => {
   if (!config) throw new Error('HTTP embedding not configured');
 
   const url = `${config.baseUrl}/embeddings`;
-  const items = await httpEmbedBatch(url, [text], config.model, config.apiKey);
+  const items = await httpEmbedBatch(url, [text], config.model, config.apiKey, config.dimensions);
   if (!items.length) {
     throw new Error(`Embedding endpoint returned empty response (${safeUrl(url)})`);
   }

--- a/gitnexus/src/core/embeddings/http-client.ts
+++ b/gitnexus/src/core/embeddings/http-client.ts
@@ -90,8 +90,12 @@ interface EmbeddingItem {
  * @param batch - Texts to embed
  * @param model - Model name for the request body
  * @param apiKey - Bearer token (only used in Authorization header)
+ * @param dimensions - Optional output-vector size. When provided, sent as
+ *   the appropriate Matryoshka field for the host:
+ *     - `dimensions` for OpenAI text-embedding-3-* / Cohere embed-v3 /
+ *       OpenAI-compatible endpoints
+ *     - `output_dimension` for Voyage (voyageai.com)
  * @param batchIndex - Logical batch number (for error context)
- * @param attempt - Current retry attempt (internal)
  */
 const httpEmbedBatch = async (
   url: string,
@@ -101,9 +105,21 @@ const httpEmbedBatch = async (
   dimensions: number | undefined,
   batchIndex = 0,
 ): Promise<EmbeddingItem[]> => {
-  const body: { input: string[]; model: string; dimensions?: number } = { input: batch, model };
+  const body: { input: string[]; model: string; dimensions?: number; output_dimension?: number } =
+    { input: batch, model };
   if (dimensions !== undefined) {
-    body.dimensions = dimensions;
+    let host = '';
+    try {
+      host = new URL(url).hostname.toLowerCase();
+    } catch {
+      /* malformed URL will fail in fetch below */
+    }
+    const isVoyageHost = host === 'voyageai.com' || host.endsWith('.voyageai.com');
+    if (isVoyageHost) {
+      body.output_dimension = dimensions;
+    } else {
+      body.dimensions = dimensions;
+    }
   }
 
   let resp: Response;

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -79,6 +79,8 @@ export interface AnalyzeOptions {
   skipGit?: boolean;
   /** Skip AGENTS.md and CLAUDE.md gitnexus block updates. */
   skipAgentsMd?: boolean;
+  /** Skip all AI context writes: AGENTS.md, CLAUDE.md, and bundled GitNexus skills. */
+  skipAiContext?: boolean;
   /** Omit volatile symbol/relationship counts from AGENTS.md and CLAUDE.md. */
   noStats?: boolean;
   /**
@@ -502,35 +504,37 @@ export async function runFullAnalysis(
     // Keep generated .gitnexus contents ignored without editing the user's root .gitignore.
     await ensureGitNexusIgnored(repoPath);
 
-    // ── Generate AI context files (best-effort) ───────────────────────
-    let aggregatedClusterCount = 0;
-    if (pipelineResult.communityResult?.communities) {
-      const groups = new Map<string, number>();
-      for (const c of pipelineResult.communityResult.communities) {
-        const label = c.heuristicLabel || c.label || 'Unknown';
-        groups.set(label, (groups.get(label) || 0) + c.symbolCount);
+    if (!options.skipAiContext) {
+      // ── Generate AI context files (best-effort) ───────────────────────
+      let aggregatedClusterCount = 0;
+      if (pipelineResult.communityResult?.communities) {
+        const groups = new Map<string, number>();
+        for (const c of pipelineResult.communityResult.communities) {
+          const label = c.heuristicLabel || c.label || 'Unknown';
+          groups.set(label, (groups.get(label) || 0) + c.symbolCount);
+        }
+        aggregatedClusterCount = Array.from(groups.values()).filter((count) => count >= 5).length;
       }
-      aggregatedClusterCount = Array.from(groups.values()).filter((count) => count >= 5).length;
-    }
 
-    try {
-      await generateAIContextFiles(
-        repoPath,
-        storagePath,
-        projectName,
-        {
-          files: pipelineResult.totalFileCount,
-          nodes: stats.nodes,
-          edges: stats.edges,
-          communities: pipelineResult.communityResult?.stats.totalCommunities,
-          clusters: aggregatedClusterCount,
-          processes: pipelineResult.processResult?.stats.totalProcesses,
-        },
-        undefined,
-        { skipAgentsMd: options.skipAgentsMd, noStats: options.noStats },
-      );
-    } catch {
-      // Best-effort — don't fail the entire analysis for context file issues
+      try {
+        await generateAIContextFiles(
+          repoPath,
+          storagePath,
+          projectName,
+          {
+            files: pipelineResult.totalFileCount,
+            nodes: stats.nodes,
+            edges: stats.edges,
+            communities: pipelineResult.communityResult?.stats.totalCommunities,
+            clusters: aggregatedClusterCount,
+            processes: pipelineResult.processResult?.stats.totalProcesses,
+          },
+          undefined,
+          { skipAgentsMd: options.skipAgentsMd, noStats: options.noStats },
+        );
+      } catch {
+        // Best-effort — don't fail the entire analysis for context file issues
+      }
     }
 
     // ── Close LadybugDB ──────────────────────────────────────────────

--- a/gitnexus/src/mcp/compatible-stdio-transport.ts
+++ b/gitnexus/src/mcp/compatible-stdio-transport.ts
@@ -73,6 +73,10 @@ export class CompatibleStdioServerTransport implements Transport {
     this.onerror?.(error);
   };
 
+  private readonly _onend = () => {
+    void this.close();
+  };
+
   async start() {
     if (this._started) {
       throw new Error('CompatibleStdioServerTransport already started!');
@@ -84,9 +88,7 @@ export class CompatibleStdioServerTransport implements Transport {
     // EOF on stdin means the client/parent is gone — close the transport so the
     // server's stdin 'end' / shutdown path runs deterministically rather than
     // leaving a flowing-mode 'data' listener spinning the event loop.
-    this._stdin.on('end', () => {
-      void this.close();
-    });
+    this._stdin.on('end', this._onend);
   }
 
   private detectFraming(): StdioFraming | null {
@@ -209,6 +211,7 @@ export class CompatibleStdioServerTransport implements Transport {
   async close() {
     this._stdin.off('data', this._ondata);
     this._stdin.off('error', this._onerror);
+    this._stdin.off('end', this._onend);
 
     const remainingDataListeners = this._stdin.listenerCount('data');
     if (remainingDataListeners === 0) {

--- a/gitnexus/src/mcp/compatible-stdio-transport.ts
+++ b/gitnexus/src/mcp/compatible-stdio-transport.ts
@@ -81,6 +81,12 @@ export class CompatibleStdioServerTransport implements Transport {
     this._started = true;
     this._stdin.on('data', this._ondata);
     this._stdin.on('error', this._onerror);
+    // EOF on stdin means the client/parent is gone — close the transport so the
+    // server's stdin 'end' / shutdown path runs deterministically rather than
+    // leaving a flowing-mode 'data' listener spinning the event loop.
+    this._stdin.on('end', () => {
+      void this.close();
+    });
   }
 
   private detectFraming(): StdioFraming | null {

--- a/gitnexus/src/mcp/config.ts
+++ b/gitnexus/src/mcp/config.ts
@@ -1,0 +1,32 @@
+import process from 'node:process';
+
+export function mcpReadOnlyMode(): boolean {
+  return process.env.OPENCLAW_CODE_INDEX_MCP === '1' || process.env.GITNEXUS_MCP_READ_ONLY === '1';
+}
+
+export function defaultRepo(): string {
+  return (
+    process.env.OPENCLAW_CODE_INDEX_DEFAULT_REPO || process.env.GITNEXUS_MCP_DEFAULT_REPO || ''
+  );
+}
+
+export function mcpDefaultRepo(): string | undefined {
+  return defaultRepo() || undefined;
+}
+
+export function configuredAllowedRepos(): Set<string> | null {
+  const raw =
+    process.env.GITNEXUS_MCP_ALLOWED_REPOS || process.env.OPENCLAW_CODE_INDEX_ALLOWED_REPOS || '';
+  const names = raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return names.length ? new Set(names) : null;
+}
+
+export function repoAllowed(repo: string): boolean {
+  const allowed = configuredAllowedRepos();
+  if (allowed) return allowed.has(repo);
+  if (process.env.OPENCLAW_CODE_INDEX_MCP === '1') return /^openclaw(?:-|$)/u.test(repo);
+  return true;
+}

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -43,6 +43,7 @@ import {
 import { PhaseTimer } from '../../core/search/phase-timer.js';
 import { checkStalenessAsync, checkCwdMatch } from '../../core/git-staleness.js';
 import { logger } from '../../core/logger.js';
+import { mcpDefaultRepo, mcpReadOnlyMode, repoAllowed } from '../config.js';
 // AI context generation is CLI-only (gitnexus analyze)
 // import { generateAIContextFiles } from '../../cli/ai-context.js';
 
@@ -54,35 +55,6 @@ const MCP_READ_ONLY_TOOLS = new Set([
   'detect_changes',
   'cypher',
 ]);
-
-function mcpReadOnlyMode(): boolean {
-  return process.env.OPENCLAW_CODE_INDEX_MCP === '1' || process.env.GITNEXUS_MCP_READ_ONLY === '1';
-}
-
-function configuredAllowedRepos(): Set<string> | null {
-  const raw =
-    process.env.GITNEXUS_MCP_ALLOWED_REPOS || process.env.OPENCLAW_CODE_INDEX_ALLOWED_REPOS || '';
-  const names = raw
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-  return names.length ? new Set(names) : null;
-}
-
-function mcpDefaultRepo(): string | undefined {
-  return (
-    process.env.OPENCLAW_CODE_INDEX_DEFAULT_REPO ||
-    process.env.GITNEXUS_MCP_DEFAULT_REPO ||
-    undefined
-  );
-}
-
-function repoAllowedByMcp(name: string): boolean {
-  const allowed = configuredAllowedRepos();
-  if (allowed) return allowed.has(name);
-  if (process.env.OPENCLAW_CODE_INDEX_MCP === '1') return /^openclaw(?:-|$)/u.test(name);
-  return true;
-}
 
 /**
  * Quick test-file detection for filtering impact results.
@@ -485,7 +457,7 @@ export class LocalBackend {
   }
 
   private visibleRepoEntries(): Array<[string, RepoHandle]> {
-    return [...this.repos.entries()].filter(([, handle]) => repoAllowedByMcp(handle.name));
+    return [...this.repos.entries()].filter(([, handle]) => repoAllowed(handle.name));
   }
 
   private visibleRepoHandles(): RepoHandle[] {

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -46,6 +46,44 @@ import { logger } from '../../core/logger.js';
 // AI context generation is CLI-only (gitnexus analyze)
 // import { generateAIContextFiles } from '../../cli/ai-context.js';
 
+const MCP_READ_ONLY_TOOLS = new Set([
+  'list_repos',
+  'query',
+  'context',
+  'impact',
+  'detect_changes',
+  'cypher',
+]);
+
+function mcpReadOnlyMode(): boolean {
+  return process.env.OPENCLAW_CODE_INDEX_MCP === '1' || process.env.GITNEXUS_MCP_READ_ONLY === '1';
+}
+
+function configuredAllowedRepos(): Set<string> | null {
+  const raw =
+    process.env.GITNEXUS_MCP_ALLOWED_REPOS || process.env.OPENCLAW_CODE_INDEX_ALLOWED_REPOS || '';
+  const names = raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return names.length ? new Set(names) : null;
+}
+
+function mcpDefaultRepo(): string | undefined {
+  return (
+    process.env.OPENCLAW_CODE_INDEX_DEFAULT_REPO ||
+    process.env.GITNEXUS_MCP_DEFAULT_REPO ||
+    undefined
+  );
+}
+
+function repoAllowedByMcp(name: string): boolean {
+  const allowed = configuredAllowedRepos();
+  if (allowed) return allowed.has(name);
+  if (process.env.OPENCLAW_CODE_INDEX_MCP === '1') return /^openclaw(?:-|$)/u.test(name);
+  return true;
+}
+
 /**
  * Quick test-file detection for filtering impact results.
  * Matches common test file patterns across all supported languages.
@@ -358,7 +396,8 @@ export class LocalBackend {
    * while the MCP server was running.
    */
   async resolveRepo(repoParam?: string): Promise<RepoHandle> {
-    const result = this.resolveRepoFromCache(repoParam);
+    const effectiveRepo = repoParam || mcpDefaultRepo();
+    const result = this.resolveRepoFromCache(effectiveRepo);
     if (result) {
       // Issue: silent graph drift across sibling clones.
       // If the caller's cwd lives in a *different* on-disk clone of
@@ -374,15 +413,19 @@ export class LocalBackend {
 
     // Miss — refresh registry and try once more
     await this.refreshRepos();
-    const retried = this.resolveRepoFromCache(repoParam);
+    const retried = this.resolveRepoFromCache(effectiveRepo);
     if (retried) {
       this.maybeWarnSiblingDrift(retried).catch(() => {});
       return retried;
     }
 
     // Still no match — throw with helpful message
+    const visibleHandles = this.visibleRepoHandles();
     if (this.repos.size === 0) {
       throw new Error('No indexed repositories. Run: gitnexus analyze');
+    }
+    if (visibleHandles.length === 0) {
+      throw new Error('No repositories match the configured GitNexus MCP allow-list.');
     }
 
     // Build a disambiguated "Available: …" list (#829). When two handles
@@ -390,16 +433,16 @@ export class LocalBackend {
     // caller can actually pick the right one. Single-name entries render
     // identically to pre-#829 output.
     const nameCounts = new Map<string, number>();
-    for (const h of this.repos.values()) {
+    for (const h of visibleHandles) {
       const key = h.name.toLowerCase();
       nameCounts.set(key, (nameCounts.get(key) ?? 0) + 1);
     }
-    const labels = [...this.repos.values()].map((h) =>
+    const labels = visibleHandles.map((h) =>
       (nameCounts.get(h.name.toLowerCase()) ?? 0) > 1 ? `${h.name} (${h.repoPath})` : h.name,
     );
 
-    if (repoParam) {
-      throw new Error(`Repository "${repoParam}" not found. Available: ${labels.join(', ')}`);
+    if (effectiveRepo) {
+      throw new Error(`Repository "${effectiveRepo}" not found. Available: ${labels.join(', ')}`);
     }
     throw new Error(
       `Multiple repositories indexed. Specify which one with the "repo" parameter. Available: ${labels.join(', ')}`,
@@ -410,33 +453,43 @@ export class LocalBackend {
    * Try to resolve a repo from the in-memory cache. Returns null on miss.
    */
   private resolveRepoFromCache(repoParam?: string): RepoHandle | null {
-    if (this.repos.size === 0) return null;
+    const entries = this.visibleRepoEntries();
+    if (entries.length === 0) return null;
 
     if (repoParam) {
       const paramLower = repoParam.toLowerCase();
       // Match by id
-      if (this.repos.has(paramLower)) return this.repos.get(paramLower)!;
+      const byId = entries.find(([id]) => id === paramLower);
+      if (byId) return byId[1];
       // Match by name (case-insensitive)
-      for (const handle of this.repos.values()) {
+      for (const [, handle] of entries) {
         if (handle.name.toLowerCase() === paramLower) return handle;
       }
       // Match by path (substring)
       const resolved = path.resolve(repoParam);
-      for (const handle of this.repos.values()) {
+      for (const [, handle] of entries) {
         if (handle.repoPath === resolved) return handle;
       }
       // Match by partial name
-      for (const handle of this.repos.values()) {
+      for (const [, handle] of entries) {
         if (handle.name.toLowerCase().includes(paramLower)) return handle;
       }
       return null;
     }
 
-    if (this.repos.size === 1) {
-      return this.repos.values().next().value!;
+    if (entries.length === 1) {
+      return entries[0]![1];
     }
 
     return null; // Multiple repos, no param — ambiguous
+  }
+
+  private visibleRepoEntries(): Array<[string, RepoHandle]> {
+    return [...this.repos.entries()].filter(([, handle]) => repoAllowedByMcp(handle.name));
+  }
+
+  private visibleRepoHandles(): RepoHandle[] {
+    return this.visibleRepoEntries().map(([, handle]) => handle);
   }
 
   // ─── Lazy LadybugDB Init ────────────────────────────────────────────
@@ -538,7 +591,7 @@ export class LocalBackend {
     }>
   > {
     await this.refreshRepos();
-    const handles = [...this.repos.values()];
+    const handles = this.visibleRepoHandles();
 
     // Pre-group registered handles by `remoteUrl` so the sibling
     // lookup is O(1) per handle. We reuse the in-memory `this.repos`
@@ -650,15 +703,25 @@ export class LocalBackend {
   // ─── Tool Dispatch ───────────────────────────────────────────────
 
   async callTool(method: string, params: any): Promise<any> {
+    if (mcpReadOnlyMode() && !MCP_READ_ONLY_TOOLS.has(method)) {
+      throw new Error(`Tool "${method}" is not available in GitNexus MCP read-only mode.`);
+    }
+
     if (method === 'list_repos') {
       return this.listRepos();
     }
 
     if (method.startsWith('group_')) {
+      if (mcpReadOnlyMode()) {
+        throw new Error('Group mode is not available in GitNexus MCP read-only mode.');
+      }
       return this.handleGroupTool(method, params || {});
     }
 
     const p = params && typeof params === 'object' ? (params as Record<string, unknown>) : {};
+    if (mcpReadOnlyMode() && typeof p.repo === 'string' && p.repo.startsWith('@')) {
+      throw new Error('Group mode is not available in GitNexus MCP read-only mode.');
+    }
     if (
       (method === 'impact' || method === 'query' || method === 'context') &&
       typeof p.repo === 'string' &&

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -48,7 +48,9 @@ function mcpReadOnlyMode(): boolean {
 }
 
 function defaultRepo(): string {
-  return process.env.OPENCLAW_CODE_INDEX_DEFAULT_REPO || process.env.GITNEXUS_MCP_DEFAULT_REPO || '';
+  return (
+    process.env.OPENCLAW_CODE_INDEX_DEFAULT_REPO || process.env.GITNEXUS_MCP_DEFAULT_REPO || ''
+  );
 }
 
 function configuredAllowedRepos(): Set<string> | null {
@@ -93,7 +95,9 @@ function assertMcpReadOnlyResource(uri: string): void {
   if (!mcpReadOnlyMode()) return;
   const match = /^gitnexus:\/\/repo\/([^/]+)/u.exec(uri);
   if (match && !repoAllowed(decodeURIComponent(match[1]!))) {
-    throw new Error(`Resource repo "${decodeURIComponent(match[1]!)}" is not in the GitNexus MCP allow-list.`);
+    throw new Error(
+      `Resource repo "${decodeURIComponent(match[1]!)}" is not in the GitNexus MCP allow-list.`,
+    );
   }
   if (/^gitnexus:\/\/group\//u.test(uri)) {
     throw new Error('Group resources are not available in GitNexus MCP read-only mode.');

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -28,6 +28,7 @@ import { installGlobalStdoutSentinel } from './stdio-context.js';
 import type { LocalBackend } from './local/local-backend.js';
 import { getResourceDefinitions, getResourceTemplates, readResource } from './resources.js';
 import { parseMaxTokens, truncateToTokenBudget } from '../cli/token-budget.js';
+import { defaultRepo, mcpReadOnlyMode, repoAllowed } from './config.js';
 
 const MCP_READ_ONLY_TOOLS = new Set([
   'list_repos',
@@ -42,33 +43,6 @@ const MCP_QUERY_LIMIT_MAX = 20;
 const MCP_QUERY_SYMBOLS_MAX = 50;
 const MCP_IMPACT_DEPTH_MAX = 8;
 const MCP_IMPACT_TIMEOUT_MAX = 60_000;
-
-function mcpReadOnlyMode(): boolean {
-  return process.env.OPENCLAW_CODE_INDEX_MCP === '1' || process.env.GITNEXUS_MCP_READ_ONLY === '1';
-}
-
-function defaultRepo(): string {
-  return (
-    process.env.OPENCLAW_CODE_INDEX_DEFAULT_REPO || process.env.GITNEXUS_MCP_DEFAULT_REPO || ''
-  );
-}
-
-function configuredAllowedRepos(): Set<string> | null {
-  const raw =
-    process.env.GITNEXUS_MCP_ALLOWED_REPOS || process.env.OPENCLAW_CODE_INDEX_ALLOWED_REPOS || '';
-  const names = raw
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-  return names.length ? new Set(names) : null;
-}
-
-function repoAllowed(repo: string): boolean {
-  const allowed = configuredAllowedRepos();
-  if (allowed) return allowed.has(repo);
-  if (process.env.OPENCLAW_CODE_INDEX_MCP === '1') return /^openclaw(?:-|$)/u.test(repo);
-  return true;
-}
 
 function normalizeArgsForMcp(toolName: string, args: any): any {
   const normalized = { ...(args || {}) };

--- a/gitnexus/src/mcp/server.ts
+++ b/gitnexus/src/mcp/server.ts
@@ -27,6 +27,104 @@ import { GITNEXUS_TOOLS } from './tools.js';
 import { installGlobalStdoutSentinel } from './stdio-context.js';
 import type { LocalBackend } from './local/local-backend.js';
 import { getResourceDefinitions, getResourceTemplates, readResource } from './resources.js';
+import { parseMaxTokens, truncateToTokenBudget } from '../cli/token-budget.js';
+
+const MCP_READ_ONLY_TOOLS = new Set([
+  'list_repos',
+  'query',
+  'context',
+  'impact',
+  'detect_changes',
+  'cypher',
+]);
+const BUDGETED_TOOLS = new Set(['query', 'context', 'impact']);
+const MCP_QUERY_LIMIT_MAX = 20;
+const MCP_QUERY_SYMBOLS_MAX = 50;
+const MCP_IMPACT_DEPTH_MAX = 8;
+const MCP_IMPACT_TIMEOUT_MAX = 60_000;
+
+function mcpReadOnlyMode(): boolean {
+  return process.env.OPENCLAW_CODE_INDEX_MCP === '1' || process.env.GITNEXUS_MCP_READ_ONLY === '1';
+}
+
+function defaultRepo(): string {
+  return process.env.OPENCLAW_CODE_INDEX_DEFAULT_REPO || process.env.GITNEXUS_MCP_DEFAULT_REPO || '';
+}
+
+function configuredAllowedRepos(): Set<string> | null {
+  const raw =
+    process.env.GITNEXUS_MCP_ALLOWED_REPOS || process.env.OPENCLAW_CODE_INDEX_ALLOWED_REPOS || '';
+  const names = raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return names.length ? new Set(names) : null;
+}
+
+function repoAllowed(repo: string): boolean {
+  const allowed = configuredAllowedRepos();
+  if (allowed) return allowed.has(repo);
+  if (process.env.OPENCLAW_CODE_INDEX_MCP === '1') return /^openclaw(?:-|$)/u.test(repo);
+  return true;
+}
+
+function normalizeArgsForMcp(toolName: string, args: any): any {
+  const normalized = { ...(args || {}) };
+  if (toolName !== 'list_repos' && !normalized.repo && defaultRepo()) {
+    normalized.repo = defaultRepo();
+  }
+  if (toolName === 'query') {
+    normalized.limit = clampPositiveInteger(normalized.limit, MCP_QUERY_LIMIT_MAX);
+    normalized.max_symbols = clampPositiveInteger(normalized.max_symbols, MCP_QUERY_SYMBOLS_MAX);
+  }
+  if (toolName === 'impact') {
+    normalized.maxDepth = clampPositiveInteger(normalized.maxDepth, MCP_IMPACT_DEPTH_MAX);
+    normalized.crossDepth = clampPositiveInteger(normalized.crossDepth, MCP_IMPACT_DEPTH_MAX);
+    normalized.timeoutMs = clampPositiveInteger(
+      normalized.timeoutMs ?? normalized.timeout,
+      MCP_IMPACT_TIMEOUT_MAX,
+    );
+    normalized.timeout = undefined;
+  }
+  return normalized;
+}
+
+function assertMcpReadOnlyResource(uri: string): void {
+  if (!mcpReadOnlyMode()) return;
+  const match = /^gitnexus:\/\/repo\/([^/]+)/u.exec(uri);
+  if (match && !repoAllowed(decodeURIComponent(match[1]!))) {
+    throw new Error(`Resource repo "${decodeURIComponent(match[1]!)}" is not in the GitNexus MCP allow-list.`);
+  }
+  if (/^gitnexus:\/\/group\//u.test(uri)) {
+    throw new Error('Group resources are not available in GitNexus MCP read-only mode.');
+  }
+}
+
+function clampPositiveInteger(raw: unknown, max: number): number | undefined {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) return undefined;
+  return Math.min(value, max);
+}
+
+function toolForMcp(tool: (typeof GITNEXUS_TOOLS)[number]): (typeof GITNEXUS_TOOLS)[number] {
+  if (!mcpReadOnlyMode()) return tool;
+  if (!['query', 'context', 'impact', 'detect_changes', 'cypher'].includes(tool.name)) return tool;
+  const repoText = defaultRepo()
+    ? `This read-only MCP defaults omitted repo parameters to ${defaultRepo()}.`
+    : 'This read-only MCP requires an explicit repo parameter when more than one repo is allowed.';
+  return {
+    ...tool,
+    description: `${tool.description}\n\nGITNEXUS MCP: ${repoText} Use maxTokens on query/context/impact for bounded retrieval slices.`,
+  };
+}
+
+function applyTokenBudget(toolName: string, args: any, text: string): string {
+  if (!BUDGETED_TOOLS.has(toolName)) return text;
+  const parsed = parseMaxTokens(args?.maxTokens);
+  if (parsed.error) throw new Error(`maxTokens ${parsed.error}`);
+  return parsed.value ? truncateToTokenBudget(text, parsed.value) : text;
+}
 
 /**
  * Next-step hints appended to tool responses.
@@ -129,6 +227,7 @@ export function createMCPServer(backend: LocalBackend): Server {
     const { uri } = request.params;
 
     try {
+      assertMcpReadOnlyResource(uri);
       const content = await readResource(uri, backend);
       return {
         contents: [
@@ -154,12 +253,14 @@ export function createMCPServer(backend: LocalBackend): Server {
 
   // Handle list tools request
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: GITNEXUS_TOOLS.map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: tool.inputSchema,
-      annotations: tool.annotations,
-    })),
+    tools: GITNEXUS_TOOLS.filter((tool) => !mcpReadOnlyMode() || MCP_READ_ONLY_TOOLS.has(tool.name))
+      .map((tool) => toolForMcp(tool))
+      .map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        annotations: tool.annotations,
+      })),
   }));
 
   // Handle tool calls — append next-step hints to guide agent workflow
@@ -167,15 +268,17 @@ export function createMCPServer(backend: LocalBackend): Server {
     const { name, arguments: args } = request.params;
 
     try {
-      const result = await backend.callTool(name, args);
+      const normalizedArgs = normalizeArgsForMcp(name, args);
+      const result = await backend.callTool(name, normalizedArgs);
       const resultText = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-      const hint = getNextStepHint(name, args as Record<string, any> | undefined);
+      const hint = getNextStepHint(name, normalizedArgs as Record<string, any> | undefined);
+      const responseText = applyTokenBudget(name, normalizedArgs, resultText + hint);
 
       return {
         content: [
           {
             type: 'text',
-            text: resultText + hint,
+            text: responseText,
           },
         ],
       };
@@ -308,6 +411,22 @@ export async function startMCPServer(backend: LocalBackend): Promise<void> {
   const transport = new CompatibleStdioServerTransport(process.stdin, safeStdout);
   await server.connect(transport);
 
+  // Orphan guard: if the client process that launched this stdio server dies,
+  // self-terminate. Independent of stdin-EOF / SIGTERM delivery (both proved
+  // unreliable when the parent is SIGKILLed, leaving the server spinning at
+  // ~18% CPU as a `ppid=1` orphan and OOMing the host). The interval is unref'd
+  // so it never keeps an otherwise-idle process alive; the MCP DB is opened
+  // read-only, so the hard exit below cannot corrupt anything.
+  const launchedByPid = process.ppid;
+  const orphanGuard = setInterval(() => {
+    try {
+      process.kill(launchedByPid, 0); // signal 0 = liveness probe, delivers nothing
+    } catch {
+      process.exit(0); // ESRCH: launching client is gone -> exit now
+    }
+  }, 3000);
+  orphanGuard.unref();
+
   // Surface the redirect counter on shutdown so users see the volume of
   // stray writes even when individual payloads were truncated/suppressed.
   process.on('exit', () => sentinel.flushSummary());
@@ -321,6 +440,11 @@ export async function startMCPServer(backend: LocalBackend): Promise<void> {
   const shutdown = async (exitCode = 0) => {
     if (shuttingDown) return;
     shuttingDown = true;
+    // Force-exit watchdog: never let a hung backend.disconnect()/server.close()
+    // keep the process alive (the original orphan-spin bug — SIGTERM appeared
+    // "ignored" because its handler awaited these). unref'd so it doesn't itself
+    // hold the event loop open.
+    setTimeout(() => process.exit(exitCode), 3000).unref();
     try {
       await backend.disconnect();
     } catch {}

--- a/gitnexus/test/unit/analyze-embeddings-limit.test.ts
+++ b/gitnexus/test/unit/analyze-embeddings-limit.test.ts
@@ -113,4 +113,22 @@ describe('analyzeCommand --embeddings [limit] parsing', () => {
     const opts = runFullAnalysisMock.mock.calls[0][1];
     expect(opts.skipAiContext).toBe(true);
   });
+
+  it('does not force a reindex when --skills is paired with --skip-ai-context', async () => {
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+
+    await analyzeCommand(undefined, { skills: true, skipAiContext: true });
+
+    const opts = runFullAnalysisMock.mock.calls[0][1];
+    expect(opts.force).toBe(false);
+  });
+
+  it('still forces a reindex when --skills will generate AI context', async () => {
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+
+    await analyzeCommand(undefined, { skills: true });
+
+    const opts = runFullAnalysisMock.mock.calls[0][1];
+    expect(opts.force).toBe(true);
+  });
 });

--- a/gitnexus/test/unit/analyze-embeddings-limit.test.ts
+++ b/gitnexus/test/unit/analyze-embeddings-limit.test.ts
@@ -104,4 +104,13 @@ describe('analyzeCommand --embeddings [limit] parsing', () => {
     expect(opts.embeddings).toBe(false);
     expect(opts.embeddingsNodeLimit).toBeUndefined();
   });
+
+  it('forwards --skip-ai-context to the shared analyzer', async () => {
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+
+    await analyzeCommand(undefined, { skipAiContext: true });
+
+    const opts = runFullAnalysisMock.mock.calls[0][1];
+    expect(opts.skipAiContext).toBe(true);
+  });
 });

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -7,7 +7,7 @@
  * These are pure unit tests that mock the LadybugDB layer to test
  * the dispatch and error handling logic in isolation.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // We need to mock the LadybugDB adapter and repo-manager BEFORE importing LocalBackend.
 // local-backend.ts imports from core/lbug/pool-adapter.js; the mcp/core/lbug-adapter.js
@@ -82,6 +82,21 @@ import {
 } from '../../src/mcp/core/lbug-adapter.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────
+
+const MCP_ENV_KEYS = [
+  'GITNEXUS_MCP_ALLOWED_REPOS',
+  'OPENCLAW_CODE_INDEX_ALLOWED_REPOS',
+  'GITNEXUS_MCP_DEFAULT_REPO',
+  'OPENCLAW_CODE_INDEX_DEFAULT_REPO',
+  'GITNEXUS_MCP_READ_ONLY',
+  'OPENCLAW_CODE_INDEX_MCP',
+];
+
+afterEach(() => {
+  for (const key of MCP_ENV_KEYS) {
+    delete process.env[key];
+  }
+});
 
 const MOCK_REPO_ENTRY = {
   name: 'test-project',
@@ -1111,6 +1126,33 @@ describe('LocalBackend.listRepos', () => {
     await backend.callTool('list_repos', {});
     // listRegisteredRepos called: once in init, once per listRepos
     expect(listRegisteredRepos).toHaveBeenCalledTimes(3);
+  });
+
+  it('filters listed and default repos using the MCP allow-list', async () => {
+    process.env.GITNEXUS_MCP_ALLOWED_REPOS = 'other-project';
+    process.env.GITNEXUS_MCP_DEFAULT_REPO = 'other-project';
+    setupMultipleRepos();
+    await backend.init();
+
+    const repos = await backend.callTool('list_repos', {});
+    expect(repos).toHaveLength(1);
+    expect(repos[0].name).toBe('other-project');
+
+    const resolved = await backend.resolveRepo();
+    expect(resolved.name).toBe('other-project');
+    await expect(backend.resolveRepo('test-project')).rejects.toThrow(
+      'Repository "test-project" not found',
+    );
+  });
+
+  it('rejects mutating tools in MCP read-only mode', async () => {
+    process.env.GITNEXUS_MCP_READ_ONLY = '1';
+    setupSingleRepo();
+    await backend.init();
+
+    await expect(
+      backend.callTool('rename', { repo: 'test-project', from: 'oldName', to: 'newName' }),
+    ).rejects.toThrow('read-only mode');
   });
 });
 

--- a/gitnexus/test/unit/compatible-stdio-transport.test.ts
+++ b/gitnexus/test/unit/compatible-stdio-transport.test.ts
@@ -219,6 +219,20 @@ describe('CompatibleStdioServerTransport', () => {
     );
   });
 
+  it('removes the stdin EOF listener when closed', async () => {
+    await transport.start();
+    expect(stdin.listenerCount('end')).toBe(1);
+
+    await transport.close();
+    expect(stdin.listenerCount('end')).toBe(0);
+
+    await transport.start();
+    expect(stdin.listenerCount('end')).toBe(1);
+
+    await transport.close();
+    expect(stdin.listenerCount('end')).toBe(0);
+  });
+
   it('does not detect content-length framing from short ambiguous prefix', async () => {
     await transport.start();
     const onError = vi.fn();

--- a/gitnexus/test/unit/http-embedder.test.ts
+++ b/gitnexus/test/unit/http-embedder.test.ts
@@ -124,6 +124,34 @@ describe('HTTP embedding backend', () => {
       expect(result.length).toBe(1024);
     });
 
+    it('sends configured dimensions as output_dimension for Voyage', async () => {
+      process.env.GITNEXUS_EMBEDDING_URL = 'https://api.voyageai.com/v1';
+      process.env.GITNEXUS_EMBEDDING_MODEL = 'voyage-code-3';
+      process.env.GITNEXUS_EMBEDDING_API_KEY = 'test-key';
+      process.env.GITNEXUS_EMBEDDING_DIMS = '1024';
+
+      const mockEmbedding = Array.from({ length: 1024 }, (_, i) => i * 0.001);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: [{ embedding: mockEmbedding }] }),
+        }),
+      );
+
+      const { embedText } = await import('../../src/core/embeddings/embedder.js');
+      const result = await embedText('test text');
+
+      const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+      expect(body).toMatchObject({
+        model: 'voyage-code-3',
+        input: ['test text'],
+        output_dimension: 1024,
+      });
+      expect(body.dimensions).toBeUndefined();
+      expect(result.length).toBe(1024);
+    });
+
     it('retries on server error', async () => {
       process.env.GITNEXUS_EMBEDDING_URL = 'http://test:8080/v1';
       process.env.GITNEXUS_EMBEDDING_MODEL = 'test-model';

--- a/gitnexus/test/unit/http-embedder.test.ts
+++ b/gitnexus/test/unit/http-embedder.test.ts
@@ -92,8 +92,36 @@ describe('HTTP embedding backend', () => {
       const body = JSON.parse((fetch as any).mock.calls[0][1].body);
       expect(body.model).toBe('test-model');
       expect(body.input).toEqual(['test text']);
+      expect(body.dimensions).toBeUndefined();
       expect(result).toBeInstanceOf(Float32Array);
       expect(result.length).toBe(384);
+    });
+
+    it('sends configured dimensions in HTTP embedding requests', async () => {
+      process.env.GITNEXUS_EMBEDDING_URL = 'http://test:8080/v1';
+      process.env.GITNEXUS_EMBEDDING_MODEL = 'test-model';
+      process.env.GITNEXUS_EMBEDDING_API_KEY = 'test-key';
+      process.env.GITNEXUS_EMBEDDING_DIMS = '1024';
+
+      const mockEmbedding = Array.from({ length: 1024 }, (_, i) => i * 0.001);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: [{ embedding: mockEmbedding }] }),
+        }),
+      );
+
+      const { embedText } = await import('../../src/core/embeddings/embedder.js');
+      const result = await embedText('test text');
+
+      const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+      expect(body).toMatchObject({
+        model: 'test-model',
+        input: ['test text'],
+        dimensions: 1024,
+      });
+      expect(result.length).toBe(1024);
     });
 
     it('retries on server error', async () => {

--- a/gitnexus/test/unit/run-analyze.test.ts
+++ b/gitnexus/test/unit/run-analyze.test.ts
@@ -59,6 +59,39 @@ describe('run-analyze module', () => {
       await tmpRepo.cleanup();
     }
   });
+
+  it('skips AGENTS.md, CLAUDE.md, and bundled skills when skipAiContext is enabled', async () => {
+    const tmpRepo = await createTempDir('gitnexus-run-analyze-no-ai-context-');
+    try {
+      await fs.writeFile(
+        path.join(tmpRepo.dbPath, 'index.ts'),
+        'export function hello() { return 1; }\n',
+      );
+      execSync('git init', { cwd: tmpRepo.dbPath, stdio: 'pipe' });
+      execSync('git add index.ts', { cwd: tmpRepo.dbPath, stdio: 'pipe' });
+      execSync('git -c user.name=test -c user.email=test@test commit -m init', {
+        cwd: tmpRepo.dbPath,
+        stdio: 'pipe',
+      });
+
+      const { runFullAnalysis } = await import('../../src/core/run-analyze.js');
+      const result = await runFullAnalysis(
+        tmpRepo.dbPath,
+        { skipAiContext: true },
+        {
+          onProgress: () => {},
+        },
+      );
+
+      expect(result.alreadyUpToDate).not.toBe(true);
+      await expect(fs.stat(path.join(tmpRepo.dbPath, '.gitnexus'))).resolves.toBeDefined();
+      await expect(fs.stat(path.join(tmpRepo.dbPath, 'AGENTS.md'))).rejects.toThrow();
+      await expect(fs.stat(path.join(tmpRepo.dbPath, 'CLAUDE.md'))).rejects.toThrow();
+      await expect(fs.stat(path.join(tmpRepo.dbPath, '.claude'))).rejects.toThrow();
+    } finally {
+      await tmpRepo.cleanup();
+    }
+  });
 });
 
 describe('deriveEmbeddingMode', () => {

--- a/gitnexus/test/unit/skip-git-cli.test.ts
+++ b/gitnexus/test/unit/skip-git-cli.test.ts
@@ -17,6 +17,7 @@ describe('--skip-git CLI flag', () => {
 
     expect(helpOutput).toContain('--skip-git');
     expect(helpOutput).toContain('--skip-agents-md');
+    expect(helpOutput).toContain('--skip-ai-context');
     expect(helpOutput).not.toContain('--no-git');
   });
 


### PR DESCRIPTION
## Summary
- preserve read-only MCP mode, repo allowlists, bounded `maxTokens`, and stdin lifecycle handling in the canonical GitNexus runtime
- add `--skip-ai-context` plumbing so analyze can skip AGENTS.md, CLAUDE.md, and bundled skill writes
- send HTTP embedding `dimensions` when `GITNEXUS_EMBEDDING_DIMS` is configured, while keeping embeddings disabled by default

## Validation
- `npm run build` from `/Volumes/LEXAR/repos/GitNexus/gitnexus`
- `npx vitest run test/unit/http-embedder.test.ts test/unit/run-analyze.test.ts test/unit/analyze-embeddings-limit.test.ts test/unit/calltool-dispatch.test.ts test/unit/skip-git-cli.test.ts test/unit/mcp-stdout-sentinel.test.ts --maxWorkers=2`
- `npx vitest run test/integration/mcp/server-startup.test.ts --maxWorkers=2`

## Notes
- No broad reindexing or embedding jobs were run.
- Local `.mcp.json` path edits were intentionally excluded from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --skip-ai-context CLI option to suppress AI-context side effects
  * Configurable embedding output dimensions (via env config)
  * MCP read-only mode with default-repo and allow-list repository controls

* **Bug Fixes**
  * Ensure MCP stdin EOF listener is detached on shutdown
  * Orphan guard and forced-exit watchdog to prevent MCP server hangs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->