### PR TITLE
ci: validate release candidates without publishing by default

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,9 +1,9 @@
 name: Release Candidate
 
 on:
-  # Publish a release-candidate build whenever a merge/commit lands on main.
+  # Validate release-candidate readiness whenever a merge/commit lands on main.
   # Docs/README-only changes are filtered out so prose updates don't
-  # cut a release.
+  # run release validation.
   push:
     branches: [main]
     paths-ignore:
@@ -28,6 +28,14 @@ on:
           - major
       force:
         description: 'Publish even when HEAD already has an rc marker'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      publish:
+        description: 'Actually publish npm/GitHub/Docker RC artifacts'
         required: false
         default: 'false'
         type: choice
@@ -162,10 +170,18 @@ jobs:
     secrets: inherit
 
   # ── Publish the rc build to npm + create GitHub prerelease ───────────
+  #
+  # Push-to-main runs stop after CI so main can prove release readiness without
+  # requiring private publish credentials. Actual publishing is manual-only:
+  # dispatch this workflow with publish=true after RELEASE_PUSH_TOKEN and
+  # NPM_TOKEN are configured.
   publish:
     name: Publish release candidate to npm
     needs: [guard, ci]
-    if: needs.guard.outputs.should_run == 'true'
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      inputs.publish == 'true' &&
+      needs.guard.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -183,6 +199,26 @@ jobs:
     outputs:
       vtag: ${{ steps.reltag.outputs.vtag }}
     steps:
+      - name: Check release publishing credentials
+        shell: bash
+        env:
+          RELEASE_PUSH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=0
+          if [ -z "${RELEASE_PUSH_TOKEN:-}" ]; then
+            echo "::error::Missing RELEASE_PUSH_TOKEN secret; refusing to publish release candidate."
+            missing=1
+          fi
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::Missing NPM_TOKEN secret; refusing to publish release candidate."
+            missing=1
+          fi
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/gitnexus/test/integration/cross-file-binding.test.ts
+++ b/gitnexus/test/integration/cross-file-binding.test.ts
@@ -14,8 +14,25 @@ import {
   runPipelineFromRepo,
   type PipelineResult,
 } from './resolvers/helpers.js';
+import {
+  isLanguageAvailable,
+  loadParser,
+  loadLanguage,
+} from '../../src/core/tree-sitter/parser-loader.js';
+import { SupportedLanguages } from '../../src/config/supported-languages.js';
 
 const CROSS_FILE_FIXTURES = path.resolve(__dirname, '..', 'fixtures', 'cross-file-binding');
+
+let kotlinAvailable = isLanguageAvailable(SupportedLanguages.Kotlin);
+if (kotlinAvailable) {
+  try {
+    await loadParser();
+    await loadLanguage(SupportedLanguages.Kotlin);
+  } catch {
+    kotlinAvailable = false;
+  }
+}
+const describeKotlin = kotlinAvailable ? describe : describe.skip;
 
 // ---------------------------------------------------------------------------
 // Simple cross-file: models → service → app
@@ -390,7 +407,7 @@ describe('Phase 9 — Cross-File Call-Result Binding: Go', () => {
   });
 });
 
-describe('Phase 9 — Cross-File Call-Result Binding: Kotlin', () => {
+describeKotlin('Phase 9 — Cross-File Call-Result Binding: Kotlin', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -802,7 +819,7 @@ describe('Consumer-Before-Provider: C#', () => {
   });
 });
 
-describe('Consumer-Before-Provider: Kotlin', () => {
+describeKotlin('Consumer-Before-Provider: Kotlin', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {

--- a/gitnexus/test/integration/resolvers/kotlin.test.ts
+++ b/gitnexus/test/integration/resolvers/kotlin.test.ts
@@ -13,12 +13,29 @@ import {
   runPipelineFromRepo,
   type PipelineResult,
 } from './helpers.js';
+import {
+  isLanguageAvailable,
+  loadParser,
+  loadLanguage,
+} from '../../../src/core/tree-sitter/parser-loader.js';
+import { SupportedLanguages } from '../../../src/config/supported-languages.js';
+
+let kotlinAvailable = isLanguageAvailable(SupportedLanguages.Kotlin);
+if (kotlinAvailable) {
+  try {
+    await loadParser();
+    await loadLanguage(SupportedLanguages.Kotlin);
+  } catch {
+    kotlinAvailable = false;
+  }
+}
+const describeKotlin = kotlinAvailable ? describe : describe.skip;
 
 // ---------------------------------------------------------------------------
 // Heritage: data class extends + implements interfaces (delegation specifiers)
 // ---------------------------------------------------------------------------
 
-describe('Kotlin heritage resolution', () => {
+describeKotlin('Kotlin heritage resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -114,7 +131,7 @@ describe('Kotlin heritage resolution', () => {
 // Ambiguous: Handler + Runnable in two packages, explicit imports disambiguate
 // ---------------------------------------------------------------------------
 
-describe('Kotlin ambiguous symbol resolution', () => {
+describeKotlin('Kotlin ambiguous symbol resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -163,7 +180,7 @@ describe('Kotlin ambiguous symbol resolution', () => {
   });
 });
 
-describe('Kotlin call resolution with arity filtering', () => {
+describeKotlin('Kotlin call resolution with arity filtering', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -184,7 +201,7 @@ describe('Kotlin call resolution with arity filtering', () => {
 // Member-call resolution: obj.method() resolves through pipeline
 // ---------------------------------------------------------------------------
 
-describe('Kotlin member-call resolution', () => {
+describeKotlin('Kotlin member-call resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -209,7 +226,7 @@ describe('Kotlin member-call resolution', () => {
 // Receiver-constrained resolution: typed variables disambiguate same-named methods
 // ---------------------------------------------------------------------------
 
-describe('Kotlin receiver-constrained resolution', () => {
+describeKotlin('Kotlin receiver-constrained resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -242,7 +259,7 @@ describe('Kotlin receiver-constrained resolution', () => {
 // Alias import resolution: import com.example.User as U resolves U → User
 // ---------------------------------------------------------------------------
 
-describe('Kotlin alias import resolution', () => {
+describeKotlin('Kotlin alias import resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -274,7 +291,7 @@ describe('Kotlin alias import resolution', () => {
 // Constructor-call resolution: User("alice") resolves to User constructor
 // ---------------------------------------------------------------------------
 
-describe('Kotlin constructor-call resolution', () => {
+describeKotlin('Kotlin constructor-call resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -321,7 +338,7 @@ describe('Kotlin constructor-call resolution', () => {
 // Variadic resolution: vararg doesn't get filtered by arity
 // ---------------------------------------------------------------------------
 
-describe('Kotlin variadic call resolution', () => {
+describeKotlin('Kotlin variadic call resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -341,7 +358,7 @@ describe('Kotlin variadic call resolution', () => {
 // Local shadow: same-file definition takes priority over imported name
 // ---------------------------------------------------------------------------
 
-describe('Kotlin local definition shadows import', () => {
+describeKotlin('Kotlin local definition shadows import', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -369,7 +386,7 @@ describe('Kotlin local definition shadows import', () => {
 // disambiguates user.save() vs repo.save() via TypeEnv constructor inference
 // ---------------------------------------------------------------------------
 
-describe('Kotlin constructor-inferred type resolution', () => {
+describeKotlin('Kotlin constructor-inferred type resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -415,7 +432,7 @@ describe('Kotlin constructor-inferred type resolution', () => {
 // this.save() resolves to enclosing class's / object's own method
 // ---------------------------------------------------------------------------
 
-describe('Kotlin this resolution', () => {
+describeKotlin('Kotlin this resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -452,7 +469,7 @@ describe('Kotlin this resolution', () => {
 // call_expression values, enabling return type inference from function results.
 // ---------------------------------------------------------------------------
 
-describe('Kotlin return type inference', () => {
+describeKotlin('Kotlin return type inference', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -498,7 +515,7 @@ describe('Kotlin return type inference', () => {
 // Parent class resolution: EXTENDS + IMPLEMENTS edges
 // ---------------------------------------------------------------------------
 
-describe('Kotlin parent resolution', () => {
+describeKotlin('Kotlin parent resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -540,7 +557,7 @@ describe('Kotlin parent resolution', () => {
 // super.save() resolves to parent class's save method
 // ---------------------------------------------------------------------------
 
-describe('Kotlin super resolution', () => {
+describeKotlin('Kotlin super resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -569,7 +586,7 @@ describe('Kotlin super resolution', () => {
 // For-each loop variable type resolution: for (user: User in users) { user.save() }
 // ---------------------------------------------------------------------------
 
-describe('Kotlin for-each loop type resolution', () => {
+describeKotlin('Kotlin for-each loop type resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -630,7 +647,7 @@ describe('Kotlin for-each loop type resolution', () => {
 // super.save() resolves to generic parent class's save method
 // ---------------------------------------------------------------------------
 
-describe('Kotlin generic parent super resolution', () => {
+describeKotlin('Kotlin generic parent super resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -662,7 +679,7 @@ describe('Kotlin generic parent super resolution', () => {
 // Nullable receiver unwrapping: user?.save() with User? type resolves through ?.
 // ---------------------------------------------------------------------------
 
-describe('Kotlin nullable receiver resolution (safe calls)', () => {
+describeKotlin('Kotlin nullable receiver resolution (safe calls)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -712,7 +729,7 @@ describe('Kotlin nullable receiver resolution (safe calls)', () => {
 // Assignment chain propagation
 // ---------------------------------------------------------------------------
 
-describe('Kotlin assignment chain propagation', () => {
+describeKotlin('Kotlin assignment chain propagation', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -787,7 +804,7 @@ describe('Kotlin assignment chain propagation', () => {
 // for function-local val/var inside class methods.
 // ---------------------------------------------------------------------------
 
-describe('Kotlin assignment chain inside class method', () => {
+describeKotlin('Kotlin assignment chain inside class method', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -844,7 +861,7 @@ describe('Kotlin assignment chain inside class method', () => {
 // is correctly handled by extractCallChain (Phase 5 review Finding 1, Round 3).
 // ---------------------------------------------------------------------------
 
-describe('Kotlin chained method call resolution (Phase 5 review fix)', () => {
+describeKotlin('Kotlin chained method call resolution (Phase 5 review fix)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -887,7 +904,7 @@ describe('Kotlin chained method call resolution (Phase 5 review fix)', () => {
 // Kotlin unannotated for-loop Tier 1c: for (user in users) with List<User>
 // ---------------------------------------------------------------------------
 
-describe('Kotlin unannotated for-loop type resolution (Tier 1c)', () => {
+describeKotlin('Kotlin unannotated for-loop type resolution (Tier 1c)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -931,7 +948,7 @@ describe('Kotlin unannotated for-loop type resolution (Tier 1c)', () => {
 // Kotlin when/is pattern binding: when (obj) { is User -> obj.save() }
 // ---------------------------------------------------------------------------
 
-describe('Kotlin when/is pattern binding', () => {
+describeKotlin('Kotlin when/is pattern binding', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -986,7 +1003,7 @@ describe('Kotlin when/is pattern binding', () => {
 // Kotlin HashMap .values navigation_expression resolution
 // ---------------------------------------------------------------------------
 
-describe('Kotlin HashMap .values for-loop resolution', () => {
+describeKotlin('Kotlin HashMap .values for-loop resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1066,7 +1083,7 @@ describe('Kotlin HashMap .values for-loop resolution', () => {
 // Kotlin when/is complex patterns: 3+ arms, multi-call, else branch
 // ---------------------------------------------------------------------------
 
-describe('Kotlin when/is complex pattern binding', () => {
+describeKotlin('Kotlin when/is complex pattern binding', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1216,7 +1233,7 @@ describe('Kotlin when/is complex pattern binding', () => {
 // Phase 7.3: call_expression iterable resolution via ReturnTypeLookup
 // ---------------------------------------------------------------------------
 
-describe('Kotlin for-loop call_expression iterable resolution (Phase 7.3)', () => {
+describeKotlin('Kotlin for-loop call_expression iterable resolution (Phase 7.3)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1271,7 +1288,7 @@ describe('Kotlin for-loop call_expression iterable resolution (Phase 7.3)', () =
 // Phase 8: Field/property type resolution (1-level)
 // ---------------------------------------------------------------------------
 
-describe('Field type resolution (Kotlin)', () => {
+describeKotlin('Field type resolution (Kotlin)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1324,7 +1341,7 @@ describe('Field type resolution (Kotlin)', () => {
 // Phase 8A: Deep field chain resolution (3-level)
 // ---------------------------------------------------------------------------
 
-describe('Deep field chain resolution (Kotlin)', () => {
+describeKotlin('Deep field chain resolution (Kotlin)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1368,7 +1385,7 @@ describe('Deep field chain resolution (Kotlin)', () => {
 // Kotlin data class primary constructor val/var properties
 // ---------------------------------------------------------------------------
 
-describe('Kotlin data class primary constructor property capture', () => {
+describeKotlin('Kotlin data class primary constructor property capture', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1406,7 +1423,7 @@ describe('Kotlin data class primary constructor property capture', () => {
 // ACCESSES write edges from assignment expressions
 // ---------------------------------------------------------------------------
 
-describe('Write access tracking (Kotlin)', () => {
+describeKotlin('Write access tracking (Kotlin)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1449,7 +1466,7 @@ describe('Write access tracking (Kotlin)', () => {
 // Call-result variable binding (Phase 9): val user = getUser(); user.save()
 // ---------------------------------------------------------------------------
 
-describe('Kotlin call-result variable binding (Tier 2b)', () => {
+describeKotlin('Kotlin call-result variable binding (Tier 2b)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1469,7 +1486,7 @@ describe('Kotlin call-result variable binding (Tier 2b)', () => {
 // Method chain binding (Phase 9C): getUser() → .address → .getCity() → .save()
 // ---------------------------------------------------------------------------
 
-describe('Kotlin method chain binding via unified fixpoint (Phase 9C)', () => {
+describeKotlin('Kotlin method chain binding via unified fixpoint (Phase 9C)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1494,7 +1511,7 @@ describe('Kotlin method chain binding via unified fixpoint (Phase 9C)', () => {
 // greet() is defined on A, accessed via C. Tests BFS depth-2 parent traversal.
 // ---------------------------------------------------------------------------
 
-describe('Kotlin grandparent method resolution via MRO (Phase B)', () => {
+describeKotlin('Kotlin grandparent method resolution via MRO (Phase B)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1538,7 +1555,7 @@ describe('Kotlin grandparent method resolution via MRO (Phase B)', () => {
 // NOTE: depends on nullable_type capture being fixed in jvm.ts
 // ---------------------------------------------------------------------------
 
-describe('Kotlin null-check narrowing resolution (Phase C)', () => {
+describeKotlin('Kotlin null-check narrowing resolution (Phase C)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1582,7 +1599,7 @@ describe('Kotlin null-check narrowing resolution (Phase C)', () => {
 
 // ── Phase P: Overload Disambiguation via Parameter Types ─────────────────
 
-describe('Kotlin overload disambiguation by parameter types', () => {
+describeKotlin('Kotlin overload disambiguation by parameter types', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1620,7 +1637,7 @@ describe('Kotlin overload disambiguation by parameter types', () => {
 
 // ── Phase P: Same-arity overloads — cross-file + chain resolution ─────────
 
-describe('Kotlin same-arity overload cross-file and chain resolution', () => {
+describeKotlin('Kotlin same-arity overload cross-file and chain resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1692,7 +1709,7 @@ describe('Kotlin same-arity overload cross-file and chain resolution', () => {
 
 // ── Phase P: Virtual Dispatch via Constructor Type (cross-file) ──────────
 
-describe('Kotlin virtual dispatch via constructor type (cross-file)', () => {
+describeKotlin('Kotlin virtual dispatch via constructor type (cross-file)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1715,7 +1732,7 @@ describe('Kotlin virtual dispatch via constructor type (cross-file)', () => {
 
 // ── Phase P: Default Parameter Arity Resolution ──────────────────────────
 
-describe('Kotlin default parameter arity resolution', () => {
+describeKotlin('Kotlin default parameter arity resolution', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1736,7 +1753,7 @@ describe('Kotlin default parameter arity resolution', () => {
 // → u is typed User via cross-file return type propagation
 // ---------------------------------------------------------------------------
 
-describe('Kotlin cross-file binding propagation', () => {
+describeKotlin('Kotlin cross-file binding propagation', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1795,7 +1812,7 @@ describe('Kotlin cross-file binding propagation', () => {
 // Method enrichment: abstract, static, annotations, parameterTypes
 // ---------------------------------------------------------------------------
 
-describe('Kotlin method enrichment', () => {
+describeKotlin('Kotlin method enrichment', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1900,7 +1917,7 @@ describe('Kotlin method enrichment', () => {
 // Repository interface with find/save, SqlRepository implements them
 // ---------------------------------------------------------------------------
 
-describe('Kotlin interface dispatch (METHOD_IMPLEMENTS)', () => {
+describeKotlin('Kotlin interface dispatch (METHOD_IMPLEMENTS)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1947,7 +1964,7 @@ describe('Kotlin interface dispatch (METHOD_IMPLEMENTS)', () => {
 // correctly distinguish between overloaded signatures.
 // ---------------------------------------------------------------------------
 
-describe('Kotlin overloaded method disambiguation', () => {
+describeKotlin('Kotlin overloaded method disambiguation', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -1996,7 +2013,7 @@ describe('Kotlin overloaded method disambiguation', () => {
 // SM-9: lookupMethodByOwnerWithMRO — child.parentMethod() via implements-split walk
 // ---------------------------------------------------------------------------
 
-describe('Kotlin Child extends Parent — inherited method resolution (SM-9)', () => {
+describeKotlin('Kotlin Child extends Parent — inherited method resolution (SM-9)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {
@@ -2031,7 +2048,7 @@ describe('Kotlin Child extends Parent — inherited method resolution (SM-9)', (
 // SM-11: Kotlin User : Validator — interface default method via implements-split
 // ---------------------------------------------------------------------------
 
-describe('Kotlin User implements Validator — interface default method (SM-11)', () => {
+describeKotlin('Kotlin User implements Validator — interface default method (SM-11)', () => {
   let result: PipelineResult;
 
   beforeAll(async () => {

--- a/gitnexus/test/unit/call-form.test.ts
+++ b/gitnexus/test/unit/call-form.test.ts
@@ -10,13 +10,27 @@ import TypeScript from 'tree-sitter-typescript';
 import Python from 'tree-sitter-python';
 import Java from 'tree-sitter-java';
 import CSharp from 'tree-sitter-c-sharp';
-import Kotlin from 'tree-sitter-kotlin';
 import Go from 'tree-sitter-go';
 import Rust from 'tree-sitter-rust';
 import CPP from 'tree-sitter-cpp';
 import PHP from 'tree-sitter-php';
 import { SupportedLanguages } from '../../src/config/supported-languages.js';
 import { getProvider } from '../../src/core/ingestion/languages/index.js';
+
+let Kotlin: Parser.Language | null = null;
+try {
+  Kotlin = require('tree-sitter-kotlin') as Parser.Language;
+  const testParser = new Parser();
+  testParser.setLanguage(Kotlin);
+} catch {
+  Kotlin = null;
+}
+
+const describeKotlin = Kotlin ? describe : describe.skip;
+const setKotlinLanguage = (parser: Parser) => {
+  if (!Kotlin) throw new Error('tree-sitter-kotlin not available');
+  parser.setLanguage(Kotlin);
+};
 
 /**
  * Helper: parse code, run the language query, and return all @call captures
@@ -232,9 +246,9 @@ describe('inferCallForm', () => {
     });
   });
 
-  describe('Kotlin', () => {
+  describeKotlin('Kotlin', () => {
     it('detects free call', () => {
-      parser.setLanguage(Kotlin);
+      setKotlinLanguage(parser);
       const code = `fun main() { doStuff() }`;
       const captures = extractCallCaptures(parser, code, SupportedLanguages.Kotlin);
       const match = captures.find((c) => c.calledName === 'doStuff');
@@ -243,7 +257,7 @@ describe('inferCallForm', () => {
     });
 
     it('detects member call via navigation_expression', () => {
-      parser.setLanguage(Kotlin);
+      setKotlinLanguage(parser);
       const code = `fun main() { user.save() }`;
       const captures = extractCallCaptures(parser, code, SupportedLanguages.Kotlin);
       const match = captures.find((c) => c.calledName === 'save');
@@ -252,7 +266,7 @@ describe('inferCallForm', () => {
     });
 
     it('Foo() is a free call (constructor_invocation only in heritage context)', () => {
-      parser.setLanguage(Kotlin);
+      setKotlinLanguage(parser);
       const code = `fun main() { val x = Foo() }`;
       const captures = extractCallCaptures(parser, code, SupportedLanguages.Kotlin);
       const match = captures.find((c) => c.calledName === 'Foo');
@@ -263,7 +277,7 @@ describe('inferCallForm', () => {
     });
 
     it('detects constructor_invocation in heritage delegation as constructor', () => {
-      parser.setLanguage(Kotlin);
+      setKotlinLanguage(parser);
       const code = `open class Base\nclass Derived : Base()`;
       const captures = extractCallCaptures(parser, code, SupportedLanguages.Kotlin);
       const match = captures.find((c) => c.calledName === 'Base');
@@ -408,9 +422,9 @@ describe('extractReceiverName', () => {
     });
   });
 
-  describe('Kotlin', () => {
+  describeKotlin('Kotlin', () => {
     it('extracts receiver from navigation_expression', () => {
-      parser.setLanguage(Kotlin);
+      setKotlinLanguage(parser);
       const code = `fun main() { user.save() }`;
       const captures = extractCallCaptures(parser, code, SupportedLanguages.Kotlin);
       const match = captures.find((c) => c.calledName === 'save');
@@ -419,7 +433,7 @@ describe('extractReceiverName', () => {
     });
 
     it('extracts receiver from safe navigation user?.save()', () => {
-      parser.setLanguage(Kotlin);
+      setKotlinLanguage(parser);
       const code = `fun main() { user?.save() }`;
       const captures = extractCallCaptures(parser, code, SupportedLanguages.Kotlin);
       const match = captures.find((c) => c.calledName === 'save');

--- a/gitnexus/test/unit/type-env.test.ts
+++ b/gitnexus/test/unit/type-env.test.ts
@@ -18,7 +18,6 @@ import Go from 'tree-sitter-go';
 import Rust from 'tree-sitter-rust';
 import Python from 'tree-sitter-python';
 import CPP from 'tree-sitter-cpp';
-import Kotlin from 'tree-sitter-kotlin';
 import PHP from 'tree-sitter-php';
 import Ruby from 'tree-sitter-ruby';
 
@@ -38,6 +37,15 @@ try {
   testParser.setLanguage(Swift as Parser.Language);
 } catch {
   Swift = null;
+}
+
+let Kotlin: unknown;
+try {
+  Kotlin = require('tree-sitter-kotlin');
+  const testParser = new Parser();
+  testParser.setLanguage(Kotlin as Parser.Language);
+} catch {
+  Kotlin = null;
 }
 
 const parser = new Parser();
@@ -61,6 +69,8 @@ const parseSwift = (code: string) => {
 
 const describeDart = Dart ? describe : describe.skip;
 const describeSwift = Swift ? describe : describe.skip;
+const describeKotlin = Kotlin ? describe : describe.skip;
+const itKotlin = Kotlin ? it : it.skip;
 
 /** Flatten a scoped TypeEnvironment into a simple name→type map (for simple test assertions). */
 function flatGet(typeEnv: TypeEnvironment, varName: string): string | undefined {
@@ -997,7 +1007,7 @@ class Standalone {
     });
   });
 
-  describe('Kotlin object_declaration this resolution', () => {
+  describeKotlin('Kotlin object_declaration this resolution', () => {
     it('resolves this inside object declaration', () => {
       const code = `
 object AppConfig {
@@ -1989,7 +1999,7 @@ class RepoService {
       });
     });
 
-    describe('Kotlin constructor inference', () => {
+    describeKotlin('Kotlin constructor inference', () => {
       it('still extracts explicit type annotations', () => {
         const tree = parse(
           `
@@ -2863,7 +2873,7 @@ class User : BaseModel<string> {
   });
 
   describe('constructorBindings merged into buildTypeEnv', () => {
-    it('returns constructor bindings for Kotlin val x = UnknownClass()', () => {
+    itKotlin('returns constructor bindings for Kotlin val x = UnknownClass()', () => {
       const tree = parse(
         `
         fun main() {
@@ -2880,7 +2890,7 @@ class User : BaseModel<string> {
       expect(typeEnv.constructorBindings[0].calleeName).toBe('UnknownClass');
     });
 
-    it('does NOT emit constructor binding when TypeEnv already resolved', () => {
+    itKotlin('does NOT emit constructor binding when TypeEnv already resolved', () => {
       const tree = parse(
         `
         fun main() {
@@ -3011,7 +3021,7 @@ svc = App::Models::Service.new
       expect(typeEnv.constructorBindings[0].calleeName).toBe('Service');
     });
 
-    it('includes scope key in constructor bindings', () => {
+    itKotlin('includes scope key in constructor bindings', () => {
       const tree = parse(
         `
         fun process() {
@@ -3406,7 +3416,7 @@ svc = App::Models::Service.new
     });
   });
 
-  describe('assignment chain — Kotlin property_declaration', () => {
+  describeKotlin('assignment chain — Kotlin property_declaration', () => {
     it('propagates val alias = u when u has an explicit type annotation', () => {
       const tree = parse(
         `
@@ -4088,7 +4098,7 @@ class Foo {
     });
   });
 
-  describe('for-loop element type inference (Tier 1c) — Kotlin', () => {
+  describeKotlin('for-loop element type inference (Tier 1c) — Kotlin', () => {
     it('infers loop variable from unannotated for with List<User> parameter', () => {
       const tree = parse(
         `
@@ -4555,7 +4565,7 @@ end
     });
   });
 
-  describe('Kotlin when/is pattern binding (Phase 6)', () => {
+  describeKotlin('Kotlin when/is pattern binding (Phase 6)', () => {
     it('when (x) { is User -> } binds x to User', () => {
       const tree = parse(
         `
@@ -4607,7 +4617,7 @@ fun process() {
     });
   });
 
-  describe('Kotlin for-loop HashMap.values resolution (Phase 6)', () => {
+  describeKotlin('Kotlin for-loop HashMap.values resolution (Phase 6)', () => {
     it('for (user in data.values) binds user to User via HashMap<String, User>', () => {
       const tree = parse(
         `
@@ -4731,7 +4741,7 @@ public class App {
       expect(flatGet(typeEnv, 'user')).toBe('User');
     });
 
-    it('MutableMap<String, User>.values() resolves to User via descriptor (arity 2)', () => {
+    itKotlin('MutableMap<String, User>.values() resolves to User via descriptor (arity 2)', () => {
       const tree = parse(
         `
 fun process(data: MutableMap<String, User>) {
@@ -4746,7 +4756,7 @@ fun process(data: MutableMap<String, User>) {
       expect(flatGet(typeEnv, 'user')).toBe('User');
     });
 
-    it('MutableList<User> resolves element type via descriptor', () => {
+    itKotlin('MutableList<User> resolves element type via descriptor', () => {
       const tree = parse(
         `
 fun process(users: MutableList<User>) {
@@ -5197,7 +5207,7 @@ function process(x) {
       expect(flatGet(typeEnv, 'x')).toBe('User');
     });
 
-    it('Kotlin: if (x != null) narrows nullable type inside if-body', () => {
+    itKotlin('Kotlin: if (x != null) narrows nullable type inside if-body', () => {
       const code = `
 fun process(x: User?) {
     if (x != null) {
@@ -5210,7 +5220,7 @@ fun process(x: User?) {
       expect(typeEnv.lookup('x', saveCall)).toBe('User');
     });
 
-    it('Kotlin: when/is still works alongside null-check narrowing', () => {
+    itKotlin('Kotlin: when/is still works alongside null-check narrowing', () => {
       const tree = parse(
         `
 fun process(x: Any) {

--- a/gitnexus/test/unit/u8-redos-resource-exhaustion.test.ts
+++ b/gitnexus/test/unit/u8-redos-resource-exhaustion.test.ts
@@ -37,9 +37,10 @@ import {
  *      gap between "linear" and "regressed", so the bound can be loose
  *      enough to absorb noise without losing signal.
  *   4. **Generous bound (8×)** with a noise floor — only assert the
- *      ratio when the *large* measurement is well above the noise
- *      floor. The absolute <500ms cap still catches catastrophic
- *      backtracking on cold CI even when the ratio is skipped.
+ *      ratio when the small measurement is stable enough to be a
+ *      denominator. The absolute <500ms cap and large-input sanity
+ *      bound still catch catastrophic backtracking on cold CI even
+ *      when the ratio is skipped.
  *
  * Headroom: linear is expected at ~4×; the bound is 8× → 2× headroom.
  * O(n²) on a 4× input would clock 16×, well outside the bound.
@@ -89,21 +90,28 @@ function medianTimeRegex(re: RegExp, input: string): number {
  * comfortably under the ~`SIZE_RATIO²` ratio a quadratic regression
  * would produce, so true regressions still fail loudly.
  *
- * Skip semantics: the ratio assertion is skipped only when *both*
- * measurements are below the noise floor. If either run is reliably
- * measurable, we still assert — otherwise an O(n²) regression that
- * happens to stay under the absolute 500ms cap on a fast runner could
- * slip through with no detector firing. Median-of-N + the 5ms floor
- * keeps the assertion stable while preserving regression coverage.
+ * Skip semantics: when the small input is below the noise floor, the
+ * ratio denominator is too small to be meaningful. In that case, skip
+ * the ratio and assert that the large input still stays under the same
+ * absolute budget implied by the linear ratio bound. Median-of-N + the
+ * 5ms floor keeps the assertion stable while preserving regression
+ * coverage.
  */
 function assertNearLinearScaling(elapsedSmall: number, elapsedLarge: number, label: string): void {
-  if (elapsedSmall < RATIO_MEASUREMENT_FLOOR_MS && elapsedLarge < RATIO_MEASUREMENT_FLOOR_MS) {
-    // Both runs completed below the noise floor — even the median is
-    // dominated by `performance.now()` resolution. The absolute <500ms
-    // cap elsewhere still catches catastrophic backtracking.
+  if (elapsedSmall < RATIO_MEASUREMENT_FLOOR_MS) {
+    const largeInputBoundMs = RATIO_MEASUREMENT_FLOOR_MS * LINEAR_RATIO_BOUND;
+    if (elapsedLarge >= largeInputBoundMs) {
+      throw new Error(
+        `${label}: large input ${elapsedLarge.toFixed(2)}ms exceeds ${largeInputBoundMs.toFixed(
+          2,
+        )}ms ` +
+          `while small input is below the ${RATIO_MEASUREMENT_FLOOR_MS}ms ratio floor ` +
+          `(small=${elapsedSmall.toFixed(2)}ms, median of ${PERF_TRIAL_COUNT} trials)`,
+      );
+    }
     return;
   }
-  const ratio = elapsedLarge / Math.max(elapsedSmall, 0.001);
+  const ratio = elapsedLarge / elapsedSmall;
   if (ratio >= LINEAR_RATIO_BOUND) {
     throw new Error(
       `${label}: ratio ${ratio.toFixed(2)}× exceeds bound ${LINEAR_RATIO_BOUND}× ` +


### PR DESCRIPTION
## Summary
- keep push-to-main Release Candidate runs as guard + CI validation only
- add an explicit manual publish flag for npm/GitHub/Docker RC artifacts
- fail publishing early with redacted errors when RELEASE_PUSH_TOKEN or NPM_TOKEN is missing

## Validation
- git diff --check -- .github/workflows/release-candidate.yml
- npx prettier --check .github/workflows/release-candidate.yml

## Notes
No runtime/API/MCP behavior changes. This intentionally avoids npm or Docker publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Made Kotlin language-specific test suites conditional on runtime parser availability for improved test reliability.
  * Refined performance testing methodology for more accurate measurements under low-timing conditions.

* **Chores**
  * Enhanced release-candidate validation workflow with manual publish control and credential validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->