### PR TITLE
fix: harden VECTOR index diagnostics and creation

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -661,6 +661,7 @@ export interface AnalyzeOptions {
   embeddingModel?: string;
   embeddingAuthToken?: string;
   embeddingDims?: string;
+  allowExactScanFallback?: boolean;
 }
 
 /**
@@ -1129,6 +1130,7 @@ const analyzeCommandImpl = async (
         // be able to accept the duplicate name without also paying the
         // cost of a full pipeline re-index. See #829 review round 2.
         allowDuplicateName: options.allowDuplicateName,
+        allowExactScanFallback: options.allowExactScanFallback,
         // Worker pool size threaded from --workers, replacing the previous
         // GITNEXUS_WORKER_POOL_SIZE env mutation. `undefined` defers to the
         // env / auto-formula fallback inside the pipeline.

--- a/gitnexus/src/cli/doctor.ts
+++ b/gitnexus/src/cli/doctor.ts
@@ -4,6 +4,8 @@ import { isHttpMode } from '../core/embeddings/http-client.js';
 import { getLocalEmbeddingRuntimeBlocker } from '../core/embeddings/runtime-support.js';
 import { checkLbugNative } from '../core/lbug/native-check.js';
 import { getExtensionInstallPolicy } from '../core/lbug/extension-loader.js';
+import { getStoragePaths, loadMeta, type RepoMeta } from '../storage/repo-manager.js';
+import { getGitRoot } from '../storage/git.js';
 import { t } from './i18n/index.js';
 
 function isCombiningMark(codePoint: number): boolean {
@@ -78,6 +80,44 @@ export function localEmbeddingDoctorStatus(opts: {
   return { status: '✓ local embeddings supported', detail: null };
 }
 
+type RepoMetaWithCapabilities = RepoMeta & {
+  capabilities?: {
+    vectorSearch?: {
+      provider?: string;
+      status?: string;
+      reason?: string;
+      exactScanLimit?: number;
+    };
+  };
+};
+
+export function repoVectorDoctorStatus(meta: RepoMetaWithCapabilities | null | undefined): {
+  status: string;
+  detail: string | null;
+} {
+  if (!meta) return { status: 'not indexed in current repo', detail: null };
+  const embeddings = Number(meta.stats?.embeddings ?? 0);
+  if (embeddings <= 0) return { status: 'no embeddings in current repo index', detail: null };
+
+  const vectorSearch = meta.capabilities?.vectorSearch;
+  const status =
+    typeof vectorSearch?.status === 'string'
+      ? vectorSearch.status
+      : vectorSearch?.provider === 'ladybugdb-vector'
+        ? 'vector-index'
+        : 'exact-scan-extension-missing';
+  const reason = typeof vectorSearch?.reason === 'string' ? vectorSearch.reason : null;
+  const limit =
+    typeof vectorSearch?.exactScanLimit === 'number'
+      ? ` exact scan limit: ${vectorSearch.exactScanLimit} chunks.`
+      : '';
+
+  return {
+    status,
+    detail: reason ? `${reason}${limit}` : limit.trim() || null,
+  };
+}
+
 export const doctorCommand = async () => {
   const fingerprint = getRuntimeFingerprint();
   const capabilities = getRuntimeCapabilities();
@@ -119,6 +159,13 @@ export const doctorCommand = async () => {
   );
   if (capabilities.reason)
     console.log(`  ${label('doctor.labels.note', 18)}${capabilities.reason}`);
+  const repoRoot = getGitRoot(process.cwd()) ?? process.cwd();
+  const repoMeta = await loadMeta(getStoragePaths(repoRoot).storagePath).catch(() => null);
+  const repoVector = repoVectorDoctorStatus(repoMeta);
+  console.log(`  ${padDisplayEnd('Repo VECTOR:', 18)}${repoVector.status}`);
+  if (repoVector.detail) {
+    console.log(`  ${padDisplayEnd('Repo VECTOR note:', 18)}${repoVector.detail}`);
+  }
   console.log('');
   console.log(t('doctor.embeddings'));
   console.log(`  ${label('doctor.labels.backend', 12)}${isHttpMode() ? 'http' : 'local'}`);

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -109,6 +109,10 @@ program
   .option('--embedding-model <model>', 'HTTP embedding model name')
   .option('--embedding-auth-token <token>', 'HTTP embedding bearer token')
   .option('--embedding-dims <n>', 'HTTP embedding output dimensions')
+  .option(
+    '--allow-exact-scan-fallback',
+    'Allow premium Voyage embeddings to register without a VECTOR index (small approved repos only)',
+  )
   .addHelpText('after', () => t('help.analyze.environment'))
   .action(createLbugLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 

--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -36,13 +36,12 @@ import {
 } from './types.js';
 import { resolveEmbeddingConfig } from './config.js';
 import { rankExactEmbeddingRows, type ExactEmbeddingRow } from './exact-search.js';
+import { EMBEDDING_TABLE_NAME, EMBEDDING_INDEX_NAME, STALE_HASH_SENTINEL } from '../lbug/schema.js';
 import {
-  EMBEDDING_TABLE_NAME,
-  EMBEDDING_INDEX_NAME,
-  CREATE_VECTOR_INDEX_QUERY,
-  STALE_HASH_SENTINEL,
-} from '../lbug/schema.js';
-import { loadVectorExtension } from '../lbug/lbug-adapter.js';
+  createCodeEmbeddingVectorIndex,
+  getVectorExtensionUnavailableReason,
+  loadVectorExtension,
+} from '../lbug/lbug-adapter.js';
 import type { ExtensionInstallPolicy } from '../lbug/extension-loader.js';
 import { getExactScanLimit } from '../platform/capabilities.js';
 import { logger } from '../logger.js';
@@ -76,6 +75,18 @@ export const resolveEmbeddingInstallPolicy = (): ExtensionInstallPolicy => {
 const ensureVectorExtensionAvailable = async (): Promise<boolean> => {
   return loadVectorExtension(undefined, { policy: resolveEmbeddingInstallPolicy() });
 };
+
+export type VectorIndexState =
+  | 'vector-index'
+  | 'exact-scan-extension-missing'
+  | 'exact-scan-index-create-failed'
+  | 'exact-scan-disabled';
+
+export interface VectorIndexDiagnostic {
+  ready: boolean;
+  state: VectorIndexState;
+  error?: string;
+}
 /**
  * Bump this when the embedding text template changes in a way that should
  * invalidate existing vectors, such as metadata/header shape changes,
@@ -222,18 +233,39 @@ export const batchInsertEmbeddings = async (
  * which owns the VECTOR extension lifecycle and state tracking.
 
  */
-const createVectorIndex = async (
-  executeQuery: (cypher: string) => Promise<any[]>,
-): Promise<boolean> => {
-  if (!(await ensureVectorExtensionAvailable())) return false;
+const createVectorIndex = async (): Promise<VectorIndexDiagnostic> => {
+  const policy = resolveEmbeddingInstallPolicy();
+  if (policy === 'never') {
+    return {
+      ready: false,
+      state: 'exact-scan-disabled',
+      error:
+        'VECTOR index creation disabled by GITNEXUS_LBUG_EXTENSION_INSTALL=never; semantic embeddings fall back to exact scan.',
+    };
+  }
+
+  if (!(await loadVectorExtension(undefined, { policy }))) {
+    const reason = getVectorExtensionUnavailableReason();
+    return {
+      ready: false,
+      state: 'exact-scan-extension-missing',
+      error: reason ? `${vectorUnavailableMessage} (${reason})` : vectorUnavailableMessage,
+    };
+  }
+
   try {
-    await executeQuery(CREATE_VECTOR_INDEX_QUERY);
-    return true;
+    await createCodeEmbeddingVectorIndex();
+    return { ready: true, state: 'vector-index' };
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     if (isDev) {
       logger.warn({ error }, 'Vector index creation warning:');
     }
-    return false;
+    return {
+      ready: false,
+      state: 'exact-scan-index-create-failed',
+      error: `CREATE_VECTOR_INDEX failed: ${message}`,
+    };
   }
 };
 
@@ -242,6 +274,8 @@ export interface EmbeddingPipelineResult {
   chunksProcessed: number;
   vectorIndexReady: boolean;
   semanticMode: 'vector-index' | 'exact-scan';
+  vectorIndexState: VectorIndexState;
+  vectorIndexError?: string;
 }
 
 /**
@@ -383,7 +417,7 @@ export const runEmbeddingPipeline = async (
       // Ensure the vector index exists even when no new nodes need embedding.
       // A prior crash or first-time incremental run may have left CodeEmbedding
       // rows without ever reaching index creation.
-      const vectorIndexReady = await createVectorIndex(executeQuery);
+      const vectorIndex = await createVectorIndex();
 
       onProgress({
         phase: 'ready',
@@ -394,8 +428,10 @@ export const runEmbeddingPipeline = async (
       return {
         nodesProcessed: 0,
         chunksProcessed: 0,
-        vectorIndexReady,
-        semanticMode: vectorIndexReady ? 'vector-index' : 'exact-scan',
+        vectorIndexReady: vectorIndex.ready,
+        semanticMode: vectorIndex.ready ? 'vector-index' : 'exact-scan',
+        vectorIndexState: vectorIndex.state,
+        vectorIndexError: vectorIndex.error,
       };
     }
 
@@ -544,7 +580,7 @@ export const runEmbeddingPipeline = async (
       logger.info('📇 Creating vector index...');
     }
 
-    const vectorIndexReady = await createVectorIndex(executeQuery);
+    const vectorIndex = await createVectorIndex();
 
     onProgress({
       phase: 'ready',
@@ -561,8 +597,10 @@ export const runEmbeddingPipeline = async (
     return {
       nodesProcessed: totalNodes,
       chunksProcessed: totalChunks,
-      vectorIndexReady,
-      semanticMode: vectorIndexReady ? 'vector-index' : 'exact-scan',
+      vectorIndexReady: vectorIndex.ready,
+      semanticMode: vectorIndex.ready ? 'vector-index' : 'exact-scan',
+      vectorIndexState: vectorIndex.state,
+      vectorIndexError: vectorIndex.error,
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/gitnexus/src/core/lbug/extension-loader.ts
+++ b/gitnexus/src/core/lbug/extension-loader.ts
@@ -175,6 +175,7 @@ export const installDuckDbExtensionOutOfProcess = async (
 export class ExtensionManager {
   private readonly capabilities = new Map<string, ExtensionCapability>();
   private readonly installAttempted = new Map<string, ExtensionInstallResult>();
+  private readonly lastLoadErrors = new Map<string, string>();
   private readonly warnedKeys = new Set<string>();
 
   constructor(private readonly options: ExtensionManagerOptions = {}) {}
@@ -183,6 +184,7 @@ export class ExtensionManager {
   reset(): void {
     this.capabilities.clear();
     this.installAttempted.clear();
+    this.lastLoadErrors.clear();
     this.warnedKeys.clear();
   }
 
@@ -223,8 +225,16 @@ export class ExtensionManager {
       return true;
     }
 
+    const loadError = this.lastLoadErrors.get(name);
     if (policy === 'load-only') {
-      this.markUnavailable(name, label, 'load-only policy: extension not pre-installed', warn);
+      this.markUnavailable(
+        name,
+        label,
+        loadError
+          ? `LOAD EXTENSION ${name} failed: ${loadError}; load-only policy: extension not pre-installed`
+          : 'load-only policy: extension not pre-installed',
+        warn,
+      );
       return false;
     }
 
@@ -245,17 +255,31 @@ export class ExtensionManager {
       return true;
     }
 
-    this.markUnavailable(name, label, `LOAD ${name} failed after successful INSTALL`, warn);
+    const postInstallLoadError = this.lastLoadErrors.get(name);
+    this.markUnavailable(
+      name,
+      label,
+      postInstallLoadError
+        ? `LOAD EXTENSION ${name} failed after successful INSTALL: ${postInstallLoadError}`
+        : `LOAD ${name} failed after successful INSTALL`,
+      warn,
+    );
     return false;
   }
 
   private async tryLoad(query: (sql: string) => Promise<unknown>, name: string): Promise<boolean> {
     try {
       await query(`LOAD EXTENSION ${name}`);
+      this.lastLoadErrors.delete(name);
       return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      return alreadyAvailable(msg);
+      if (alreadyAvailable(msg)) {
+        this.lastLoadErrors.delete(name);
+        return true;
+      }
+      this.lastLoadErrors.set(name, msg);
+      return false;
     }
   }
 

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -13,6 +13,7 @@ import {
   NODE_TABLES,
   REL_TABLE_NAME,
   SCHEMA_QUERIES,
+  CREATE_VECTOR_INDEX_QUERY,
   EMBEDDING_TABLE_NAME,
   STALE_HASH_SENTINEL,
   NodeTableName,
@@ -1908,6 +1909,18 @@ export const loadVectorExtension = async (
   );
   if (loaded && useModuleState) vectorExtensionLoaded = true;
   return loaded;
+};
+
+export const getVectorExtensionUnavailableReason = (): string | undefined =>
+  extensionManager
+    .getCapabilities()
+    .find((capability) => capability.name === 'VECTOR' && !capability.loaded)?.reason;
+
+export const createCodeEmbeddingVectorIndex = async (): Promise<void> => {
+  if (!conn) {
+    throw new Error('LadybugDB not initialized. Call initLbug first.');
+  }
+  await queryAndDrain(conn, CREATE_VECTOR_INDEX_QUERY);
 };
 /**
  * Create a full-text search index on a table

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -17,7 +17,7 @@
 
 import fs from 'fs/promises';
 import lbug from '@ladybugdb/core';
-import { isReadOnlyDbError, loadFTSExtension } from './lbug-adapter.js';
+import { isReadOnlyDbError, loadFTSExtension, loadVectorExtension } from './lbug-adapter.js';
 import { closeQueryResults } from './query-result-utils.js';
 import {
   createLbugDatabase,
@@ -91,6 +91,7 @@ interface SharedDB {
   db: lbug.Database;
   refCount: number;
   ftsLoaded: boolean;
+  vectorLoaded: boolean;
   /** When true, closeOne skips db.close() — the Database is owned externally. */
   external?: boolean;
 }
@@ -235,6 +236,7 @@ function closeOne(repoId: string): void {
         // for the same dbPath reuse it instead of hitting a file lock.
         shared.refCount = 0;
         shared.ftsLoaded = false;
+        shared.vectorLoaded = false;
       } else {
         shared.db.close().catch(() => {});
         dbCache.delete(entry.dbPath);
@@ -543,7 +545,7 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
     for (let attempt = 1; attempt <= LOCK_RETRY_ATTEMPTS; attempt++) {
       try {
         const db = await openReadOnlyDatabase(dbPath);
-        shared = { db, refCount: 0, ftsLoaded: false };
+        shared = { db, refCount: 0, ftsLoaded: false, vectorLoaded: false };
         dbCache.set(dbPath, shared);
         break;
       } catch (err: any) {
@@ -552,7 +554,7 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
         if (isWalCorruptionError(lastError)) {
           try {
             const db = await tryQuarantineAndReopen(dbPath, repoId);
-            shared = { db, refCount: 0, ftsLoaded: false };
+            shared = { db, refCount: 0, ftsLoaded: false, vectorLoaded: false };
             dbCache.set(dbPath, shared);
             break;
           } catch (retryErr) {
@@ -657,7 +659,13 @@ export async function initLbugWithDb(
   // closeOne() respects the external flag and skips db.close().
   let shared = dbCache.get(dbPath);
   if (!shared) {
-    shared = { db: existingDb, refCount: 0, ftsLoaded: false, external: true };
+    shared = {
+      db: existingDb,
+      refCount: 0,
+      ftsLoaded: false,
+      vectorLoaded: false,
+      external: true,
+    };
     dbCache.set(dbPath, shared);
   }
   shared.refCount++;
@@ -779,6 +787,37 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
 
 export const executeQuery = async (repoId: string, cypher: string): Promise<any[]> => {
   return await executeParameterized(repoId, cypher, {});
+};
+
+/**
+ * Load the VECTOR extension on the read-only pool's shared Database.
+ *
+ * Analyze owns installation/index creation. Query/MCP paths are strictly
+ * `load-only`: if VECTOR was not pre-installed on this machine, callers get a
+ * clean `false` and can fall back to exact scan with an explicit diagnostic.
+ */
+export const ensureVectorExtensionForRepo = async (repoId: string): Promise<boolean> => {
+  const entry = pool.get(repoId);
+  if (!entry) {
+    throw new Error(`LadybugDB not initialized for repo "${repoId}". Call initLbug first.`);
+  }
+
+  entry.lastUsed = Date.now();
+  const shared = dbCache.get(entry.dbPath);
+  if (shared?.vectorLoaded) return true;
+
+  const conn = await checkout(entry);
+  silenceStdout();
+  activeQueryCount++;
+  try {
+    const loaded = await loadVectorExtension(conn, { policy: 'load-only' });
+    if (loaded && shared) shared.vectorLoaded = true;
+    return loaded;
+  } finally {
+    activeQueryCount--;
+    restoreStdout();
+    checkin(entry, conn);
+  }
 };
 
 /**

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -67,6 +67,7 @@ import {
   resolveRepoIdentityRoot,
 } from '../storage/git.js';
 import type { CachedEmbedding } from './embeddings/types.js';
+import type { VectorIndexState } from './embeddings/embedding-pipeline.js';
 import { generateAIContextFiles } from '../cli/ai-context.js';
 import { EMBEDDING_TABLE_NAME } from './lbug/schema.js';
 import { STALE_HASH_SENTINEL } from './lbug/schema.js';
@@ -141,6 +142,12 @@ export interface AnalyzeOptions {
    */
   allowDuplicateName?: boolean;
   /**
+   * Allow premium Voyage embedding runs to register/query through exact scan
+   * when VECTOR index creation fails. Defaults to false for premium repos so
+   * large paid indexes cannot silently degrade into expensive linear scans.
+   */
+  allowExactScanFallback?: boolean;
+  /**
    * Worker pool size override, threaded from the CLI `--workers` flag.
    * Forwarded to `PipelineOptions.workerPoolSize` so the parse phase
    * sizes the pool without `analyzeCommand` mutating `process.env`.
@@ -148,6 +155,27 @@ export interface AnalyzeOptions {
    * removed); `undefined` defers to the env / auto-formula fallback.
    */
   workerPoolSize?: number;
+}
+
+export function exactScanFallbackAllowed(
+  options: Pick<AnalyzeOptions, 'allowExactScanFallback'>,
+): boolean {
+  const raw = process.env.GITNEXUS_ALLOW_EXACT_SCAN_FALLBACK;
+  return options.allowExactScanFallback === true || raw === '1' || raw === 'true';
+}
+
+export function shouldBlockPremiumExactScanFallback(opts: {
+  isVoyageHttpMode: boolean;
+  premiumRepoAllowed: boolean;
+  semanticMode: 'vector-index' | 'exact-scan';
+  allowExactScanFallback: boolean;
+}): boolean {
+  return (
+    opts.isVoyageHttpMode &&
+    opts.premiumRepoAllowed &&
+    opts.semanticMode === 'exact-scan' &&
+    !opts.allowExactScanFallback
+  );
 }
 
 export interface AnalyzeResult {
@@ -886,6 +914,8 @@ export async function runFullAnalysis(
     const stats = await getLbugStats();
     let embeddingSkipped = true;
     let semanticMode: 'vector-index' | 'exact-scan' | undefined;
+    let vectorIndexState: VectorIndexState | undefined;
+    let vectorIndexReason: string | undefined;
 
     if (shouldGenerateEmbeddings) {
       const { skipForCap, capDisabled, nodeLimit } = deriveEmbeddingCap(
@@ -915,6 +945,8 @@ export async function runFullAnalysis(
     if (!embeddingSkipped) {
       const { isHttpMode, isVoyageHttpMode } = await import('./embeddings/http-client.js');
       const httpMode = isHttpMode();
+      const voyageHttpMode = isVoyageHttpMode();
+      let premiumVoyageRepoAllowed = false;
       // Mirror the registry's name-resolution chain so premium embedding gates,
       // server mapping, and the final registry name all agree (#1259):
       //   --name → remote-derived → canonical-root basename
@@ -922,9 +954,10 @@ export async function runFullAnalysis(
         options.registryName ??
         getInferredRepoName(repoPath) ??
         path.basename(resolveRepoIdentityRoot(repoPath));
-      if (isVoyageHttpMode()) {
+      if (voyageHttpMode) {
         const { premiumRepoAllowed } = await import('./rerank/voyage-reranker.js');
-        if (!premiumRepoAllowed(projectName)) {
+        premiumVoyageRepoAllowed = premiumRepoAllowed(projectName);
+        if (!premiumVoyageRepoAllowed) {
           embeddingSkipped = true;
           log(
             `Voyage embeddings skipped for "${projectName}": repo is not listed in ` +
@@ -1022,12 +1055,36 @@ export async function runFullAnalysis(
             await pendingCheckpoint.catch(() => undefined);
           }
         })();
+        vectorIndexState = embeddingResult.vectorIndexState;
+        vectorIndexReason = embeddingResult.vectorIndexError;
         if (embeddingResult.semanticMode === 'exact-scan') {
           semanticMode = 'exact-scan';
-          log(
+          const diagnostic =
             'Semantic embeddings were generated without a VECTOR index; ' +
-              'queries will use exact-scan fallback within the configured limit.',
-          );
+            'queries will use exact-scan fallback within the configured limit.' +
+            (embeddingResult.vectorIndexState
+              ? ` State: ${embeddingResult.vectorIndexState}.`
+              : '') +
+            (embeddingResult.vectorIndexError
+              ? ` Reason: ${embeddingResult.vectorIndexError}`
+              : '');
+          log(diagnostic);
+          if (
+            shouldBlockPremiumExactScanFallback({
+              isVoyageHttpMode: voyageHttpMode,
+              premiumRepoAllowed: premiumVoyageRepoAllowed,
+              semanticMode: embeddingResult.semanticMode,
+              allowExactScanFallback: exactScanFallbackAllowed(options),
+            })
+          ) {
+            throw new Error(
+              `Premium Voyage embeddings for "${projectName}" fell back to exact scan ` +
+                `(${embeddingResult.vectorIndexState}). ${embeddingResult.vectorIndexError ?? ''} ` +
+                'Install/load VECTOR and create the vector index, or rerun with ' +
+                '--allow-exact-scan-fallback / GITNEXUS_ALLOW_EXACT_SCAN_FALLBACK=1 ' +
+                'if this small repo is explicitly approved for exact scan.',
+            );
+          }
         } else {
           semanticMode = 'vector-index';
         }
@@ -1061,6 +1118,13 @@ export async function runFullAnalysis(
     const effectiveSemanticMode =
       semanticMode ??
       (runtimeCapabilities.semanticMode === 'vector-index' ? 'vector-index' : 'exact-scan');
+    const effectiveVectorIndexState: VectorIndexState | 'unavailable' =
+      embeddingCount > 0
+        ? (vectorIndexState ??
+          (effectiveSemanticMode === 'vector-index'
+            ? 'vector-index'
+            : 'exact-scan-extension-missing'))
+        : 'unavailable';
 
     // Convert the post-run file-hash map to the on-disk Record<string,string>
     // shape consumed by RepoMeta.fileHashes.
@@ -1097,10 +1161,12 @@ export async function runFullAnalysis(
           status: ftsAvailable ? runtimeCapabilities.fts : 'unavailable',
         },
         vectorSearch: {
-          provider: effectiveSemanticMode === 'vector-index' ? 'ladybugdb-vector' : 'exact-scan',
-          status: embeddingCount > 0 ? effectiveSemanticMode : 'unavailable',
+          provider:
+            effectiveVectorIndexState === 'vector-index' ? 'ladybugdb-vector' : 'exact-scan',
+          status: effectiveVectorIndexState,
+          mode: embeddingCount > 0 ? effectiveSemanticMode : 'unavailable',
           exactScanLimit: runtimeCapabilities.exactScanLimit,
-          reason: runtimeCapabilities.reason,
+          reason: vectorIndexReason ?? runtimeCapabilities.reason,
         },
       },
       // Incremental-indexing fields. Populated for git repos so the next

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -15,6 +15,7 @@ import {
   executeParameterized,
   closeLbug,
   isLbugReady,
+  ensureVectorExtensionForRepo,
 } from '../../core/lbug/pool-adapter.js';
 import { isValidQueryParams } from '../../core/lbug/query-params.js';
 import { isWalCorruptionError, WAL_RECOVERY_SUGGESTION } from '../../core/lbug/lbug-config.js';
@@ -69,6 +70,16 @@ const MCP_READ_ONLY_TOOLS = new Set([
   'detect_changes',
   'cypher',
 ]);
+
+interface SemanticSearchDegradation {
+  mode: 'exact-scan';
+  reason: string;
+}
+
+interface SemanticSearchOutput {
+  results: any[];
+  degraded?: SemanticSearchDegradation;
+}
 
 /**
  * Quick test-file detection for filtering impact results.
@@ -1273,7 +1284,7 @@ export class LocalBackend {
     // each so both get independent wall-time records without fighting
     // over a single `current` phase slot.
     const searchLimit = processLimit * maxSymbolsPerProcess; // fetch enough raw results
-    const [bm25SearchResult, semanticResults] = await Promise.all([
+    const [bm25SearchResult, semanticSearchOutput] = await Promise.all([
       timer.time('bm25', this.bm25Search(repo, searchQuery, searchLimit)),
       timer.time('vector', this.semanticSearch(repo, searchQuery, searchLimit)),
     ]);
@@ -1299,7 +1310,7 @@ export class LocalBackend {
       }
     }
 
-    const safeSemanticResults = semanticResults ?? [];
+    const safeSemanticResults = semanticSearchOutput?.results ?? [];
     for (let i = 0; i < safeSemanticResults.length; i++) {
       const result = safeSemanticResults[i];
       const key = result.nodeId || result.filePath;
@@ -1591,6 +1602,12 @@ export class LocalBackend {
     if (rerankWarning) {
       warnings.push(rerankWarning);
     }
+    if (semanticSearchOutput?.degraded) {
+      warnings.push(
+        `Semantic vector search degraded: ${semanticSearchOutput.degraded.reason}. ` +
+          'Using exact-scan fallback within the configured limit.',
+      );
+    }
 
     return {
       processes,
@@ -1799,14 +1816,20 @@ export class LocalBackend {
   /**
    * Semantic vector search helper
    */
-  private async semanticSearch(repo: RepoHandle, query: string, limit: number): Promise<any[]> {
+  private async semanticSearch(
+    repo: RepoHandle,
+    query: string,
+    limit: number,
+  ): Promise<SemanticSearchOutput> {
     try {
       // Check if embedding table exists before loading the model (avoids heavy model init when embeddings are off)
       const tableCheck = await executeQuery(
         repo.lbugPath,
         `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN COUNT(*) AS cnt LIMIT 1`,
       );
-      if (!tableCheck.length || (tableCheck[0].cnt ?? tableCheck[0][0]) === 0) return [];
+      if (!tableCheck.length || (tableCheck[0].cnt ?? tableCheck[0][0]) === 0) {
+        return { results: [] };
+      }
 
       const { embedQuery, getEmbeddingDims } = await import('../core/embedder.js');
       const queryVec = await embedQuery(query);
@@ -1817,10 +1840,19 @@ export class LocalBackend {
         string,
         { distance: number; chunkIndex: number; startLine: number; endLine: number }
       >();
+      let degraded: SemanticSearchDegradation | undefined;
       if (isVectorExtensionSupportedByPlatform()) {
-        try {
-          bestChunks = await collectBestChunks(limit, async (fetchLimit) => {
-            const vectorQuery = `
+        const vectorLoaded = await ensureVectorExtensionForRepo(repo.lbugPath);
+        if (!vectorLoaded) {
+          degraded = {
+            mode: 'exact-scan',
+            reason: 'VECTOR extension unavailable on the query path',
+          };
+        }
+        if (vectorLoaded) {
+          try {
+            bestChunks = await collectBestChunks(limit, async (fetchLimit) => {
+              const vectorQuery = `
             CALL QUERY_VECTOR_INDEX('${EMBEDDING_TABLE_NAME}', '${EMBEDDING_INDEX_NAME}',
               CAST(${queryVecStr} AS FLOAT[${dims}]), ${fetchLimit})
             YIELD node AS emb, distance
@@ -1831,33 +1863,44 @@ export class LocalBackend {
             ORDER BY distance
           `;
 
-            const embResults = await executeQuery(repo.lbugPath, vectorQuery);
-            return embResults.map((row) => ({
-              nodeId: row.nodeId ?? row[0],
-              chunkIndex: row.chunkIndex ?? row[1] ?? 0,
-              startLine: row.startLine ?? row[2] ?? 0,
-              endLine: row.endLine ?? row[3] ?? 0,
-              distance: row.distance ?? row[4],
-            }));
-          });
-        } catch {
-          bestChunks = new Map();
+              const embResults = await executeQuery(repo.lbugPath, vectorQuery);
+              return embResults.map((row) => ({
+                nodeId: row.nodeId ?? row[0],
+                chunkIndex: row.chunkIndex ?? row[1] ?? 0,
+                startLine: row.startLine ?? row[2] ?? 0,
+                endLine: row.endLine ?? row[3] ?? 0,
+                distance: row.distance ?? row[4],
+              }));
+            });
+          } catch {
+            degraded = {
+              mode: 'exact-scan',
+              reason: `VECTOR index "${EMBEDDING_INDEX_NAME}" unavailable or query failed`,
+            };
+            bestChunks = new Map();
+          }
         }
-      } else if (!this.warnedVectorUnsupported) {
-        // Rare diagnostic: surface why we fell back to the exact scan path so
-        // operators can see at a glance that VECTOR is disabled by platform
-        // policy. Emitted once per `LocalBackend` instance lifetime to avoid
-        // noisy stderr on hot semantic-search paths (DoD §2.8).
-        this.warnedVectorUnsupported = true;
-        logger.warn(
-          'GitNexus [query:vector]: VECTOR extension not supported on this platform; using exact scan fallback',
-        );
+      } else {
+        if (!this.warnedVectorUnsupported) {
+          // Rare diagnostic: surface why we fell back to the exact scan path so
+          // operators can see at a glance that VECTOR is disabled by platform
+          // policy. Emitted once per `LocalBackend` instance lifetime to avoid
+          // noisy stderr on hot semantic-search paths (DoD §2.8).
+          this.warnedVectorUnsupported = true;
+          logger.warn(
+            'GitNexus [query:vector]: VECTOR extension not supported on this platform; using exact scan fallback',
+          );
+        }
+        degraded = {
+          mode: 'exact-scan',
+          reason: 'VECTOR extension not supported on this platform',
+        };
       }
 
       if (bestChunks.size === 0) {
         const embeddingCount = Number(tableCheck[0].cnt ?? tableCheck[0][0] ?? 0);
         const exactLimit = getExactScanLimit();
-        if (embeddingCount > exactLimit) return [];
+        if (embeddingCount > exactLimit) return { results: [], degraded };
 
         const rows = await executeQuery(
           repo.lbugPath,
@@ -1887,7 +1930,7 @@ export class LocalBackend {
         );
       }
 
-      if (bestChunks.size === 0) return [];
+      if (bestChunks.size === 0) return { results: [], degraded };
 
       const results: any[] = [];
 
@@ -1923,10 +1966,10 @@ export class LocalBackend {
         } catch {}
       }
 
-      return results;
+      return { results, degraded };
     } catch {
       // Expected when embeddings are disabled — silently fall back to BM25-only
-      return [];
+      return { results: [] };
     }
   }
 

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -72,6 +72,23 @@ export interface RepoMeta {
     processes?: number;
     embeddings?: number;
   };
+  capabilities?: {
+    graph?: {
+      provider?: string;
+      status?: string;
+    };
+    fts?: {
+      provider?: string;
+      status?: string;
+    };
+    vectorSearch?: {
+      provider?: string;
+      status?: string;
+      mode?: string;
+      exactScanLimit?: number;
+      reason?: string;
+    };
+  };
   /**
    * Bumped whenever incremental-indexing invariants change in an
    * incompatible way (delete-and-rewrite logic, subgraph extraction,

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -23,6 +23,7 @@ const { lbugMocks, platformMocks, rerankMocks } = vi.hoisted(() => ({
     executeParameterized: vi.fn().mockResolvedValue([]),
     closeLbug: vi.fn().mockResolvedValue(undefined),
     isLbugReady: vi.fn().mockReturnValue(true),
+    ensureVectorExtensionForRepo: vi.fn().mockResolvedValue(true),
   },
   platformMocks: {
     isVectorExtensionSupportedByPlatform: vi.fn().mockReturnValue(true),
@@ -107,6 +108,7 @@ import {
   executeParameterized,
   isLbugReady,
   closeLbug,
+  ensureVectorExtensionForRepo,
 } from '../../src/mcp/core/lbug-adapter.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -123,6 +125,7 @@ const MOCK_REPO_ENTRY = {
 beforeEach(() => {
   rerankMocks.resolveRerankConfig.mockReturnValue(null);
   rerankMocks.rerankDocuments.mockResolvedValue([]);
+  lbugMocks.ensureVectorExtensionForRepo.mockResolvedValue(true);
 });
 
 function setupSingleRepo() {
@@ -686,7 +689,26 @@ describe('LocalBackend.callTool', () => {
     await backend.callTool('query', { query: 'auth' });
 
     const queries = (executeQuery as any).mock.calls.map(([, cypher]: [string, string]) => cypher);
+    expect(ensureVectorExtensionForRepo).toHaveBeenCalledWith('/tmp/.gitnexus/test-project/lbug');
     expect(queries.some((cypher: string) => cypher.includes('QUERY_VECTOR_INDEX'))).toBe(true);
+  });
+
+  it('falls back explicitly when VECTOR is supported but not loadable on the read connection', async () => {
+    platformMocks.isVectorExtensionSupportedByPlatform.mockReturnValue(true);
+    lbugMocks.ensureVectorExtensionForRepo.mockResolvedValue(false);
+    (executeQuery as any).mockImplementation(async (_repoId: string, cypher: string) => {
+      if (cypher.includes('COUNT(*) AS cnt')) return [{ cnt: 1 }];
+      if (cypher.includes('MATCH (e:CodeEmbedding)')) return [];
+      return [];
+    });
+    (executeParameterized as any).mockResolvedValue([]);
+
+    const result = await backend.callTool('query', { query: 'auth' });
+
+    const queries = (executeQuery as any).mock.calls.map(([, cypher]: [string, string]) => cypher);
+    expect(ensureVectorExtensionForRepo).toHaveBeenCalledWith('/tmp/.gitnexus/test-project/lbug');
+    expect(queries.some((cypher: string) => cypher.includes('QUERY_VECTOR_INDEX'))).toBe(false);
+    expect(result.warning).toContain('VECTOR extension unavailable on the query path');
   });
 
   it('query tool returns error for empty query', async () => {

--- a/gitnexus/test/unit/doctor-format.test.ts
+++ b/gitnexus/test/unit/doctor-format.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { displayWidth, localEmbeddingDoctorStatus, padDisplayEnd } from '../../src/cli/doctor.js';
+import {
+  displayWidth,
+  localEmbeddingDoctorStatus,
+  padDisplayEnd,
+  repoVectorDoctorStatus,
+} from '../../src/cli/doctor.js';
 
 describe('doctor output formatting', () => {
   it('keeps ASCII padding equivalent to String.padEnd', () => {
@@ -53,5 +58,28 @@ describe('doctor embedding-runtime support status', () => {
     });
     expect(status).toBe('✓ http endpoint configured');
     expect(detail).toBeNull();
+  });
+});
+
+describe('doctor repo vector-index status', () => {
+  it('distinguishes platform VECTOR availability from a per-repo exact-scan fallback', () => {
+    const { status, detail } = repoVectorDoctorStatus({
+      stats: { embeddings: 9704 },
+      capabilities: {
+        vectorSearch: {
+          provider: 'exact-scan',
+          status: 'exact-scan-index-create-failed',
+          exactScanLimit: 20_000,
+          reason: 'CREATE_VECTOR_INDEX failed: FLOAT[2048] is unsupported',
+        },
+      },
+    } as any);
+
+    expect(status).toBe('exact-scan-index-create-failed');
+    expect(detail).toContain('CREATE_VECTOR_INDEX failed');
+  });
+
+  it('reports no current repo index when metadata is absent', () => {
+    expect(repoVectorDoctorStatus(null).status).toBe('not indexed in current repo');
   });
 });

--- a/gitnexus/test/unit/embedding-pipeline.test.ts
+++ b/gitnexus/test/unit/embedding-pipeline.test.ts
@@ -4,6 +4,7 @@ import {
   contentHashForNode,
   EMBEDDING_TEXT_VERSION,
   resolveEmbeddingInstallPolicy,
+  type VectorIndexState,
 } from '../../src/core/embeddings/embedding-pipeline.js';
 import { generateEmbeddingText } from '../../src/core/embeddings/text-generator.js';
 import type { EmbeddableNode, EmbeddingProgress } from '../../src/core/embeddings/types.js';
@@ -218,6 +219,8 @@ describe('runEmbeddingPipeline incremental filter', () => {
     // Mock loadVectorExtension (avoids needing the native lbug module)
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       loadVectorExtension: vi.fn().mockResolvedValue(true),
+      getVectorExtensionUnavailableReason: vi.fn().mockReturnValue(undefined),
+      createCodeEmbeddingVectorIndex: vi.fn().mockResolvedValue(undefined),
     }));
   };
 
@@ -347,6 +350,8 @@ describe('runEmbeddingPipeline incremental filter', () => {
     }));
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       loadVectorExtension: vi.fn().mockResolvedValue(true),
+      getVectorExtensionUnavailableReason: vi.fn().mockReturnValue(undefined),
+      createCodeEmbeddingVectorIndex: vi.fn().mockResolvedValue(undefined),
     }));
 
     const executeQuery = vi.fn().mockImplementation(async (cypher: string) => {
@@ -496,9 +501,8 @@ describe('runEmbeddingPipeline incremental filter', () => {
       existingEmbeddings,
     );
 
-    // The CREATE_VECTOR_INDEX query should have been called via executeQuery
-    const vectorIndexCalls = queryCalls.filter((c) => c.includes('CREATE_VECTOR_INDEX'));
-    expect(vectorIndexCalls.length).toBeGreaterThanOrEqual(1);
+    const { createCodeEmbeddingVectorIndex } = await import('../../src/core/lbug/lbug-adapter.js');
+    expect(createCodeEmbeddingVectorIndex).toHaveBeenCalled();
   });
 
   it('stores embeddings with exact-scan fallback when VECTOR is unavailable', async () => {
@@ -515,6 +519,10 @@ describe('runEmbeddingPipeline incremental filter', () => {
     }));
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       loadVectorExtension: vi.fn().mockResolvedValue(false),
+      getVectorExtensionUnavailableReason: vi
+        .fn()
+        .mockReturnValue('LOAD EXTENSION VECTOR failed: extension not installed'),
+      createCodeEmbeddingVectorIndex: vi.fn().mockResolvedValue(undefined),
     }));
 
     const node = makeNode();
@@ -527,8 +535,49 @@ describe('runEmbeddingPipeline incremental filter', () => {
 
     expect(result.vectorIndexReady).toBe(false);
     expect(result.semanticMode).toBe('exact-scan');
+    expect(result.vectorIndexState satisfies VectorIndexState).toBe('exact-scan-extension-missing');
+    expect(result.vectorIndexError).toMatch(/LOAD EXTENSION VECTOR failed/i);
     expect(stmtCalls.some((call) => call.cypher.includes('CREATE'))).toBe(true);
     expect(progressUpdates.at(-1)?.phase).toBe('ready');
+  });
+
+  it('records an actionable diagnostic when VECTOR index creation fails after extension load', async () => {
+    vi.doMock('../../src/core/embeddings/embedder.js', () => ({
+      initEmbedder: vi.fn().mockResolvedValue(undefined),
+      embedBatch: vi
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => new Float32Array(384))),
+        ),
+      embedText: vi.fn().mockResolvedValue(new Float32Array(384)),
+      embeddingToArray: vi.fn().mockImplementation((emb: Float32Array) => Array.from(emb)),
+      isEmbedderReady: vi.fn().mockReturnValue(true),
+    }));
+    vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
+      loadVectorExtension: vi.fn().mockResolvedValue(true),
+      getVectorExtensionUnavailableReason: vi.fn().mockReturnValue(undefined),
+      createCodeEmbeddingVectorIndex: vi
+        .fn()
+        .mockRejectedValue(new Error('CREATE_VECTOR_INDEX failed: FLOAT[2048] is unsupported')),
+    }));
+
+    const node = makeNode();
+    const executeQuery = vi.fn().mockImplementation(async (cypher: string) => {
+      queryCalls.push(cypher);
+      return mockExecuteQuery([node])(cypher);
+    });
+    const executeWithReusedStatement = mockExecuteWithReusedStatement();
+    const { runEmbeddingPipeline } =
+      await import('../../src/core/embeddings/embedding-pipeline.js');
+
+    const result = await runEmbeddingPipeline(executeQuery, executeWithReusedStatement, onProgress);
+
+    expect(result.vectorIndexReady).toBe(false);
+    expect(result.semanticMode).toBe('exact-scan');
+    expect(result.vectorIndexState satisfies VectorIndexState).toBe(
+      'exact-scan-index-create-failed',
+    );
+    expect(result.vectorIndexError).toMatch(/FLOAT\[2048\] is unsupported/);
   });
 
   it('does not inject preceding context when overlap is disabled', async () => {
@@ -546,6 +595,8 @@ describe('runEmbeddingPipeline incremental filter', () => {
     }));
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       loadVectorExtension: vi.fn().mockResolvedValue(true),
+      getVectorExtensionUnavailableReason: vi.fn().mockReturnValue(undefined),
+      createCodeEmbeddingVectorIndex: vi.fn().mockResolvedValue(undefined),
     }));
 
     const node = makeNode({
@@ -600,6 +651,8 @@ describe('runEmbeddingPipeline incremental filter', () => {
     }));
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       loadVectorExtension: vi.fn().mockResolvedValue(true),
+      getVectorExtensionUnavailableReason: vi.fn().mockReturnValue(undefined),
+      createCodeEmbeddingVectorIndex: vi.fn().mockResolvedValue(undefined),
     }));
 
     const node = makeNode({

--- a/gitnexus/test/unit/run-analyze.test.ts
+++ b/gitnexus/test/unit/run-analyze.test.ts
@@ -325,3 +325,55 @@ describe('deriveEmbeddingCap', () => {
     expect(deriveEmbeddingCap(15_000, 10_000).skipForCap).toBe(true);
   });
 });
+
+describe('premium exact-scan fallback guard', () => {
+  it('blocks Voyage premium repos when VECTOR index creation degraded and fallback is not allowed', async () => {
+    const { shouldBlockPremiumExactScanFallback } = await import('../../src/core/run-analyze.js');
+
+    expect(
+      shouldBlockPremiumExactScanFallback({
+        isVoyageHttpMode: true,
+        premiumRepoAllowed: true,
+        semanticMode: 'exact-scan',
+        allowExactScanFallback: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not block explicit fallback, non-Voyage, non-premium, or vector-index paths', async () => {
+    const { shouldBlockPremiumExactScanFallback } = await import('../../src/core/run-analyze.js');
+
+    expect(
+      shouldBlockPremiumExactScanFallback({
+        isVoyageHttpMode: true,
+        premiumRepoAllowed: true,
+        semanticMode: 'exact-scan',
+        allowExactScanFallback: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockPremiumExactScanFallback({
+        isVoyageHttpMode: false,
+        premiumRepoAllowed: true,
+        semanticMode: 'exact-scan',
+        allowExactScanFallback: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockPremiumExactScanFallback({
+        isVoyageHttpMode: true,
+        premiumRepoAllowed: false,
+        semanticMode: 'exact-scan',
+        allowExactScanFallback: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockPremiumExactScanFallback({
+        isVoyageHttpMode: true,
+        premiumRepoAllowed: true,
+        semanticMode: 'vector-index',
+        allowExactScanFallback: false,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- distinguish embeddings persisted, VECTOR extension availability, and per-repo VECTOR index state
- create CodeEmbedding VECTOR indexes through raw LadybugDB query execution instead of the prepared query helper
- add premium Voyage exact-scan guard requiring explicit fallback approval when VECTOR index creation degrades
- load VECTOR on MCP/read-pool query paths before QUERY_VECTOR_INDEX and surface degraded-mode warnings
- teach doctor to report current repo VECTOR metadata separately from platform capability

## Root Cause
Disposable DB validation showed `FLOAT[2048]` works and `LOAD EXTENSION VECTOR` works on this machine. The missing index was caused by `CREATE_VECTOR_INDEX` going through the prepared query helper, which fails with `We do not support prepare multiple statements.` Raw query execution creates `code_embedding_idx` successfully.

Evidence: `/Volumes/LEXAR/Codex/gitnexus-reconciliation-2026-06-10/vector-index-fix-20260616-200033/vector-probe-report.md`

## Validation
- `npm run format:check`
- `npx vitest run test/unit/embedding-pipeline.test.ts test/unit/run-analyze.test.ts test/unit/calltool-dispatch.test.ts test/unit/doctor-format.test.ts --maxWorkers=2`
- `npx vitest run test/integration/lbug-vector-extension.test.ts test/unit/platform-capabilities.test.ts --maxWorkers=2`
- `npm run build`
- disposable copy probe: 13,192 embeddings, sampled 2048d, `CREATE_VECTOR_INDEX` raw path created `CodeEmbedding:code_embedding_idx:HNSW`, `QUERY_VECTOR_INDEX` returned rows

## Safety
- no registry cleanup, no worktree deletion, no broad reindex, no production embedding rollout
- Voyage token-value scan found no `pa-...` values in repo/evidence/config/history
- current registry count observed: 5

## Follow-up After Merge
- repair/re-analyze `gitnexus` and `evaos-gui` premium indexes and confirm `code_embedding_idx` before resuming Batch 1 rollout
- separately handle stale app-parented MCP process pile
