### PR TITLE
fix: treat existing VECTOR index as ready

### DIFF
--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -54,6 +54,10 @@ const vectorUnavailableMessage =
   '(GITNEXUS_LBUG_EXTENSION_INSTALL=auto), or pre-install it for offline use. ' +
   'Set GITNEXUS_LBUG_EXTENSION_INSTALL=never to skip installs and silence this.';
 
+const isVectorIndexAlreadyExistsError = (message: string): boolean =>
+  message.toLowerCase().includes('already exists') &&
+  message.toLowerCase().includes(EMBEDDING_INDEX_NAME.toLowerCase());
+
 /**
  * Resolve the extension-install policy for the embedding WRITE path (analyze).
  *
@@ -258,6 +262,9 @@ const createVectorIndex = async (): Promise<VectorIndexDiagnostic> => {
     return { ready: true, state: 'vector-index' };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (isVectorIndexAlreadyExistsError(message)) {
+      return { ready: true, state: 'vector-index' };
+    }
     if (isDev) {
       logger.warn({ error }, 'Vector index creation warning:');
     }

--- a/gitnexus/test/unit/embedding-pipeline.test.ts
+++ b/gitnexus/test/unit/embedding-pipeline.test.ts
@@ -580,6 +580,44 @@ describe('runEmbeddingPipeline incremental filter', () => {
     expect(result.vectorIndexError).toMatch(/FLOAT\[2048\] is unsupported/);
   });
 
+  it('treats an existing VECTOR index as ready when refreshing embeddings', async () => {
+    vi.doMock('../../src/core/embeddings/embedder.js', () => ({
+      initEmbedder: vi.fn().mockResolvedValue(undefined),
+      embedBatch: vi
+        .fn()
+        .mockImplementation((texts: string[]) =>
+          Promise.resolve(texts.map(() => new Float32Array(384))),
+        ),
+      embedText: vi.fn().mockResolvedValue(new Float32Array(384)),
+      embeddingToArray: vi.fn().mockImplementation((emb: Float32Array) => Array.from(emb)),
+      isEmbedderReady: vi.fn().mockReturnValue(true),
+    }));
+    vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
+      loadVectorExtension: vi.fn().mockResolvedValue(true),
+      getVectorExtensionUnavailableReason: vi.fn().mockReturnValue(undefined),
+      createCodeEmbeddingVectorIndex: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            'Binder exception: Index code_embedding_idx already exists in table CodeEmbedding.',
+          ),
+        ),
+    }));
+
+    const node = makeNode();
+    const executeQuery = mockExecuteQuery([node]);
+    const executeWithReusedStatement = mockExecuteWithReusedStatement();
+    const { runEmbeddingPipeline } =
+      await import('../../src/core/embeddings/embedding-pipeline.js');
+
+    const result = await runEmbeddingPipeline(executeQuery, executeWithReusedStatement, onProgress);
+
+    expect(result.vectorIndexReady).toBe(true);
+    expect(result.semanticMode).toBe('vector-index');
+    expect(result.vectorIndexState satisfies VectorIndexState).toBe('vector-index');
+    expect(result.vectorIndexError).toBeUndefined();
+  });
+
   it('does not inject preceding context when overlap is disabled', async () => {
     const embedBatchSpy = vi
       .fn()


### PR DESCRIPTION
## Summary
- Treat LadybugDB `code_embedding_idx already exists` as a successful VECTOR-ready state during embedding refresh
- Add a regression test for refreshing embeddings when the HNSW index already exists

## Verification
- Red test failed before fix: `npx vitest run test/unit/embedding-pipeline.test.ts --maxWorkers=2`
- Green: `npx vitest run test/unit/embedding-pipeline.test.ts --maxWorkers=2`
- Green: `npx vitest run test/unit/embedding-pipeline.test.ts test/unit/run-analyze.test.ts --maxWorkers=2`
- Green: `npm run build`
- Green: live `gitnexus` approved index refresh with Voyage 2048 after patch

## Notes
No broad embedding rollout, registry cleanup, worktree deletion, npm publish, or Docker publish in this PR.