### PR TITLE
docs(policy): adopt shared owned-repo policy pointers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,9 +41,32 @@
 - [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
 - [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*
 
+## PR lifecycle
+
+- [ ] Current-head review threads queried: `total=`, `currentActionable=`, `outdated=`
+- [ ] Top-level bot comments, skipped-review/rate-limit notices, and check annotations reviewed separately from review threads
+- [ ] CI/check state reviewed:
+- [ ] Review bot status reviewed:
+- [ ] All P0-P2 actionable review threads fixed, proven false-positive, or explicitly escalated
+- [ ] P3/advisory review threads have terminal disposition
+- [ ] Evidence path / next-agent notes:
+
 ## Risk & rollout
 
 <!-- Breaking changes, migrations, index refresh (`npx gitnexus analyze`), release notes -->
+
+- Release-note impact:
+  - [ ] Human-readable release-note entry included below
+  - [ ] No release-note impact; rationale:
+- Release-proof tier:
+  - [ ] Not release-affecting
+  - [ ] Dev proof
+  - [ ] Release proof
+- User/operator release note:
+  - Outcome summary:
+  - Highlights / changes / fixes:
+  - Breaking changes / migration notes:
+  - Verification and evidence:
 
 ## Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
-<!-- version: 1.7.0 -->
-<!-- Last updated: 2026-04-23 -->
+<!-- version: 1.8.1 -->
+<!-- Last updated: 2026-07-02 -->
 
-Last reviewed: 2026-04-23
+Last reviewed: 2026-07-02
 
 **Project:** GitNexus · **Environment:** dev · **Maintainer:** repository maintainers (see GitHub)
 
@@ -55,10 +55,34 @@ listed in [`pr-swarm-review/README.md`](pr-swarm-review/README.md); edit review 
 in the canonical files, never in the wrappers. The review is read-only — it never edits,
 commits, or posts.
 
+## Shared Owned-Repo Policy
+
+This fork follows the shared owned-repo operating policy maintained in
+`100yenadmin/codex-operating-kit`. Keep this section as a pointer plus
+GitNexus-specific conventions; do not copy the full shared runbooks here.
+
+- Track meaningful work in GitHub issues before implementation. Use tracker
+  issues or milestones when work spans multiple PRs, release gates, CI waits,
+  index refreshes, or handoff.
+- Link PRs to the implementation issue and any tracker/milestone. Update the
+  issue or tracker before pausing, handoff, merge, release, or index refresh.
+- Before claiming PR readiness, query current-head `reviewThreads` and report
+  `total`, `currentActionable`, and `outdated`. Treat top-level bot comments,
+  skipped-review/rate-limit notices, and check annotations as separate status
+  inputs, not resolvable review threads.
+- P0-P2 current actionable review threads block merge, release, and readiness
+  claims unless fixed, proven false-positive, or explicitly escalated. P3
+  advisory threads still need terminal disposition before closeout.
+- Release notes should be human-readable first: user/operator outcome, grouped
+  highlights/changes/fixes, then compact verification and evidence. Operator
+  packets, local commands, rollback notes, and index-refresh details may be
+  linked or summarized, but should not replace the visible release narrative.
+
 ## Changelog
 
 | Date | Version | Change |
 |------|---------|--------|
+| 2026-07-02 | 1.8.1 | Added shared owned-repo PR lifecycle and human-readable release-note policy pointer for repo-local agents. |
 | 2026-05-22 | 1.8.0 | Kotlin added to `MIGRATED_LANGUAGES` (registry-primary call resolution by default). Closes #1756 (companion-vs-instance dispatch) and #1757 (lambda scopes); refs #1746. RFC §6.4 corpus criterion waived (corpus-mode wiring is #927-scope); fixture criterion met. |
 | 2026-04-23 | 1.7.0 | TypeScript added to `MIGRATED_LANGUAGES` (registry-primary call resolution by default). |
 | 2026-04-20 | 1.6.0 | Added scope-resolution pipeline pointer (RFC #909 Ring 3); Python migrated to registry-primary. |


### PR DESCRIPTION
## Summary

Adds the shared owned-repo PR lifecycle and human-readable release-note pointer to GitNexus agent guidance, then extends the PR template with review-thread readback, bot/check state, release-note impact, proof tier, evidence, and next-agent notes.

## Motivation / context

Closes #31 and advances 100yenadmin/codex-operating-kit#5. This keeps GitNexus aligned with the shared owned-repo policy without changing runtime code, generated GitNexus blocks, release workflows, or historical releases.

## Areas touched

- [ ] `gitnexus/` (CLI / core / MCP server)
- [ ] `gitnexus-web/` (Vite / React UI)
- [x] `.github/` (workflows, actions)
- [ ] `eval/` or other tooling
- [x] Docs / agent config only (`AGENTS.md`, `CLAUDE.md`, `.cursor/`, `llms.txt`, etc.)

## Scope & constraints

**In scope**

- Add shared owned-repo PR lifecycle pointer to `AGENTS.md`.
- Update AGENTS metadata/header/changelog per repo convention.
- Extend the existing PR template with shared review-thread and release-note fields.

**Explicitly out of scope / not done here**

- No runtime code, indexer behavior, release workflow, generated `gitnexus:start` block, branch protection/ruleset, or historical release changes.
- No historical review-thread cleanup.

## Implementation notes

The new AGENTS policy section is outside the generated GitNexus block and after the existing PR Swarm Review section.

## Testing & verification

- [ ] `cd gitnexus && npm test`
- [ ] `cd gitnexus && npm run test:integration` *(if core/indexing/MCP paths changed)*
- [ ] `cd gitnexus && npx tsc --noEmit`
- [ ] `cd gitnexus-web && npm test` *(if web changed)*
- [ ] `cd gitnexus-web && npx tsc -b --noEmit` *(if web changed)*
- [ ] Manual / Playwright E2E *(note environment — see `gitnexus-web/e2e/`)*
- [x] `git diff --check`
- [x] Docs/template-only change; local npm/web/index validation not required

## PR lifecycle

- [ ] Current-head review threads queried: `total=pending-pr-open`, `currentActionable=pending-pr-open`, `outdated=pending-pr-open`
- [x] Top-level bot comments, skipped-review/rate-limit notices, and check annotations reviewed separately from review threads
- [ ] CI/check state reviewed: pending PR creation
- [ ] Review bot status reviewed: pending PR creation
- [ ] All P0-P2 actionable review threads fixed, proven false-positive, or explicitly escalated
- [ ] P3/advisory review threads have terminal disposition
- [x] Evidence path / next-agent notes: `/Volumes/LEXAR/Codex/owned-repo-policy/2026-07-02/`

## Risk & rollout

Not release-affecting. Existing release workflow and label/category release generation are unchanged.

- Release-note impact:
  - [ ] Human-readable release-note entry included below
  - [x] No release-note impact; rationale: docs/template-only governance rollout, not product/runtime behavior
- Release-proof tier:
  - [x] Not release-affecting
  - [ ] Dev proof
  - [ ] Release proof
- User/operator release note:
  - Outcome summary: no public release-note entry
  - Highlights / changes / fixes: not applicable
  - Breaking changes / migration notes: none
  - Verification and evidence: `git diff --check`

## Checklist

- [x] PR body meets repo minimum length (workflow may label short descriptions)
- [x] If `AGENTS.md` / overlays changed: headers, scope block, and changelog updated per project conventions
- [x] No secrets, tokens, or machine-specific paths committed
