### PR TITLE
fix: embed file nodes for static repos

### DIFF
--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -196,7 +196,52 @@ const queryEmbeddableNodes = async (
     }
   }
 
-  return allNodes;
+  return allNodes.length > 0 ? allNodes : queryFallbackFileNodes(executeQuery);
+};
+
+/**
+ * Static/documentation repos can have no code-symbol labels at all while still
+ * carrying useful File nodes with persisted content. Use those only as a
+ * zero-code-symbol fallback so normal code repos do not duplicate every file
+ * into the semantic index.
+ */
+const queryFallbackFileNodes = async (
+  executeQuery: (cypher: string) => Promise<any[]>,
+): Promise<EmbeddableNode[]> => {
+  try {
+    const rows = await executeQuery(`
+      MATCH (n:File)
+      RETURN n.id AS id, n.name AS name, 'File' AS label,
+             n.filePath AS filePath, n.content AS content
+    `);
+
+    return rows
+      .map((row) => {
+        const content = row.content ?? row[4] ?? '';
+        const lineCount = content ? content.split('\n').length : 0;
+        return {
+          id: row.id ?? row[0],
+          name: row.name ?? row[1],
+          label: row.label ?? row[2] ?? 'File',
+          filePath: row.filePath ?? row[3],
+          content,
+          startLine: 1,
+          endLine: Math.max(1, lineCount),
+        };
+      })
+      .filter(
+        (node) =>
+          node.id &&
+          node.filePath &&
+          node.content.trim() &&
+          node.content !== '[Binary file - content not stored]',
+      );
+  } catch (error) {
+    if (isDev) {
+      logger.warn({ error }, 'Fallback File-node embedding query failed:');
+    }
+    return [];
+  }
 };
 
 /**

--- a/gitnexus/test/unit/embedding-pipeline.test.ts
+++ b/gitnexus/test/unit/embedding-pipeline.test.ts
@@ -266,6 +266,49 @@ describe('runEmbeddingPipeline incremental filter', () => {
     progressUpdates.push({ ...p });
   };
 
+  it('falls back to text-bearing File nodes when a repo has no code symbols', async () => {
+    const embedBatchSpy = vi
+      .fn()
+      .mockImplementation((texts: string[]) =>
+        Promise.resolve(texts.map(() => new Float32Array(384))),
+      );
+    vi.doMock('../../src/core/embeddings/embedder.js', () => ({
+      initEmbedder: vi.fn().mockResolvedValue(undefined),
+      embedBatch: embedBatchSpy,
+      embedText: vi.fn().mockResolvedValue(new Float32Array(384)),
+      embeddingToArray: vi.fn().mockImplementation((emb: Float32Array) => Array.from(emb)),
+      isEmbedderReady: vi.fn().mockReturnValue(true),
+    }));
+    vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
+      loadVectorExtension: vi.fn().mockResolvedValue(true),
+      getVectorExtensionUnavailableReason: vi.fn().mockReturnValue(undefined),
+      createCodeEmbeddingVectorIndex: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const fileNode = makeNode({
+      id: 'File:README.md',
+      name: 'README.md',
+      label: 'File',
+      filePath: 'README.md',
+      content: '# Bailey Bear Hub\n\nLanding page routing and recovery notes.',
+      startLine: 1,
+      endLine: 3,
+    });
+    const executeQuery = mockExecuteQuery([fileNode]);
+    const executeWithReusedStatement = mockExecuteWithReusedStatement();
+
+    const { runEmbeddingPipeline } =
+      await import('../../src/core/embeddings/embedding-pipeline.js');
+
+    const result = await runEmbeddingPipeline(executeQuery, executeWithReusedStatement, onProgress);
+
+    expect(queryCalls.some((cypher) => cypher.includes('MATCH (n:File)'))).toBe(true);
+    expect(embedBatchSpy).toHaveBeenCalled();
+    expect(stmtCalls.some((call) => call.params.some((p) => p.nodeId === fileNode.id))).toBe(true);
+    expect(result.nodesProcessed).toBe(1);
+    expect(progressUpdates.at(-1)?.phase).toBe('ready');
+  });
+
   it('skips unchanged nodes when hash matches', async () => {
     mockEmbedderSetup();
 


### PR DESCRIPTION
## Summary
- add a zero-code-symbol fallback that embeds text-bearing `File` nodes for static/docs-only repos
- keep normal code repos unchanged by only using `File` nodes when no code-symbol embeddables are found
- add regression coverage for static repo fallback behavior

## Local Repair Proof
- Fixed local `100yenadmin/bailey-bear-hub-site` indexing after the patch.
- Registry/meta now report `embeddings: 18`.
- `gitnexus cypher -r bailey-bear-hub-site 'MATCH (e:CodeEmbedding) RETURN count(e) AS embeddings'` returns 18.
- `gitnexus query -r bailey-bear-hub-site 'Bailey Bear hub landing page routing' --max-tokens 800` returns File definitions with vector timing.

## Validation
- `npm exec vitest -- run test/unit/embedding-pipeline.test.ts --maxWorkers=1`
- `npm run build`
- pre-commit format/typecheck hook passed

Fixes #34.
