### PR TITLE
test(ladybug): compare 0.18.1 on the RC19 matrix

### DIFF
--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
-        "@ladybugdb/core": "^0.18.0",
+        "@ladybugdb/core": "0.18.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@scarf/scarf": "^1.4.0",
         "busboy": "^1.6.0",
@@ -1261,9 +1261,9 @@
       }
     },
     "node_modules/@ladybugdb/core": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core/-/core-0.18.0.tgz",
-      "integrity": "sha512-3X1NCsZZn2oPF/KtvrbQtRu9NvRw9z6BvNSW3lO9xe/I89HSnAsXXFaMDIirLnm3hgGb8ocnVhuMAyfS4DXnhA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core/-/core-0.18.1.tgz",
+      "integrity": "sha512-0c1kXDpdv7z/GB0oyFYnLEjLsXFwPHz1YD4wxtrk9hav8zJX5T1PHQMr+XRfdDI1NQjx4iNdbPQGGT7Bx/X2aw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1272,17 +1272,17 @@
         "node-addon-api": "^6.0.0"
       },
       "optionalDependencies": {
-        "@ladybugdb/core-darwin-arm64": "0.18.0",
-        "@ladybugdb/core-darwin-x64": "0.18.0",
-        "@ladybugdb/core-linux-arm64": "0.18.0",
-        "@ladybugdb/core-linux-x64": "0.18.0",
-        "@ladybugdb/core-win32-x64": "0.18.0"
+        "@ladybugdb/core-darwin-arm64": "0.18.1",
+        "@ladybugdb/core-darwin-x64": "0.18.1",
+        "@ladybugdb/core-linux-arm64": "0.18.1",
+        "@ladybugdb/core-linux-x64": "0.18.1",
+        "@ladybugdb/core-win32-x64": "0.18.1"
       }
     },
     "node_modules/@ladybugdb/core-darwin-arm64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-arm64/-/core-darwin-arm64-0.18.0.tgz",
-      "integrity": "sha512-HlJswkjSdPyXDp+krZBnU5jHQYK/1G4jTBj9Y5cUkm7ze+qR7mj9bkstUldEC3t2N7W6Os7wzTIUUORpHDRGvA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-arm64/-/core-darwin-arm64-0.18.1.tgz",
+      "integrity": "sha512-M5YZuAONRAv3awkr+cfaibn9Da+3pgDzRiek/JabWQuz48xgzW3Vh9yQH4s8Dq/bfQo6YTsaLIBRcUCCUzCtcg==",
       "cpu": [
         "arm64"
       ],
@@ -1293,9 +1293,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-darwin-x64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-x64/-/core-darwin-x64-0.18.0.tgz",
-      "integrity": "sha512-NUqnxnnGPs3XR86/4fLWsn+Cz9/sykVIaNOw3BsYccpiGWKvnGnDcpKID1HVHRcSa84N+CrXPkuzUvkRD36s3Q==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-x64/-/core-darwin-x64-0.18.1.tgz",
+      "integrity": "sha512-kq+pyTskfCx++Mrbk7QssE/f/CpSuU50T8lhRtv4PaOKhC2Jf8/wAUOA17UxI594wAru3ERpqVBFUBWGcPk2ag==",
       "cpu": [
         "x64"
       ],
@@ -1306,9 +1306,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-linux-arm64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-arm64/-/core-linux-arm64-0.18.0.tgz",
-      "integrity": "sha512-/wHoqsPOna+lZZbeAOFRiTHHpaiuA+07H5FUQqZI/qrEfjjN38xznmnLVCE5YZcFCzNxAS4aK40rXaUFZLj+Ow==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-arm64/-/core-linux-arm64-0.18.1.tgz",
+      "integrity": "sha512-fu7ke1haa5rPINcQn0+kxQijZ0A8ZDWP9e+X8xcDH94RagDbPWwG8yFC890cGSdc/j7mTV+xkA/y/kVHpmVI6w==",
       "cpu": [
         "arm64"
       ],
@@ -1319,9 +1319,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-linux-x64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-x64/-/core-linux-x64-0.18.0.tgz",
-      "integrity": "sha512-ge9pGnU94jVBOYxAuUq3d9BYSS3ProtwIKse9ZKXxeL9Hh8Qmwcz9Ey++BJMm+lSN8dE0lUBQTGXCTd1jrMnpA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-x64/-/core-linux-x64-0.18.1.tgz",
+      "integrity": "sha512-qp5HilHzDGuArfOyD+VyA7lVJ7IwQDKd81NZKKTmUwIAOJtdwqniYx6JZICPnlr36zFJBx/lGYoSsEzbC+TVdw==",
       "cpu": [
         "x64"
       ],
@@ -1332,9 +1332,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-win32-x64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-win32-x64/-/core-win32-x64-0.18.0.tgz",
-      "integrity": "sha512-RLW9m9BJ4LdFjKsTOZdg43FjmdboZ1gvhmnP494JPfVsmNt+7lMJOmhtvuePj3uAhOEd9qOpGN8hqGiPDywbOA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-win32-x64/-/core-win32-x64-0.18.1.tgz",
+      "integrity": "sha512-vHcXr7Df2X1dbb5ORK+SBmNstd/3tApGFImbAnaWiTuLDFlAdfY8lbiSBSp3OgFjc0BB7F3GYUUdvgDRJjK3zA==",
       "cpu": [
         "x64"
       ],

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -55,7 +55,7 @@
     "prepack": "node scripts/assert-publish-grammar-coverage.cjs && node scripts/build.js"
   },
   "dependencies": {
-    "@ladybugdb/core": "^0.18.0",
+    "@ladybugdb/core": "0.18.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@scarf/scarf": "^1.4.0",
     "busboy": "^1.6.0",


### PR DESCRIPTION
Tracks #43 (R04). This evidence-only draft PR compares LadybugDB `0.18.1` with the pristine RC19 `0.18.0` floor running in #64.

The diff is intentionally limited to `gitnexus/package.json` and `gitnexus/package-lock.json`, changing `@ladybugdb/core` from RC19's `^0.18.0` lock resolution to an exact `0.18.1` pin. It is not intended to merge.

Acceptance evidence sought here:
- native package installation and loading on Ubuntu, Windows, and macOS runners
- checkpoint/delete behavior exercised by the existing GitNexus integration matrix
- non-zero failure behavior remains separately proven by forced native-load tests
- results are compared with #64 before any Ladybug disposition decision

Related upstream artifacts: GitNexus #2441, LadybugDB/ladybug#681, and LadybugDB/ladybug#682. No publication, runtime rollout, or live-index mutation is included.