### PR TITLE
test(incremental): prove node deletion failures surface

### DIFF
--- a/gitnexus/test/integration/lbug-delete-nodes-for-files.test.ts
+++ b/gitnexus/test/integration/lbug-delete-nodes-for-files.test.ts
@@ -237,3 +237,29 @@ withTestLbugDB('delete-nodes-missing-embedding-table', () => {
     }, 120_000);
   });
 });
+
+/**
+ * Error propagation contract for #37: zero matched rows are a valid no-op,
+ * but a native/schema failure while deleting a required node table must
+ * reject the whole writeback. A dedicated database keeps the intentional
+ * schema damage isolated from the successful-delete coverage above.
+ */
+withTestLbugDB('delete-nodes-required-table-failure', () => {
+  describe('deleteNodesForFiles native deletion failures (#37)', () => {
+    it('surfaces a required node-table failure instead of reporting success', async () => {
+      const { deleteNodesForFiles, executeQuery } =
+        await import('../../src/core/lbug/lbug-adapter.js');
+
+      await executeQuery(
+        `CREATE (:Function {id: 'Function:src/a.ts:fnA:1', name: 'fnA', filePath: 'src/a.ts', startLine: 1, endLine: 3, isExported: true, content: '', description: ''})`,
+      );
+
+      // File is not part of the embedding join. Removing the property used
+      // by its delete predicate therefore reaches the actual node-table
+      // loop before LadybugDB raises the binder failure.
+      await executeQuery('ALTER TABLE File DROP filePath');
+
+      await expect(deleteNodesForFiles(['src/a.ts'])).rejects.toThrow(/File|filePath|property/i);
+    }, 120_000);
+  });
+});


### PR DESCRIPTION
## Summary

- add a real LadybugDB regression contract for unexpected node-table deletion failures
- preserve the documented zero-match and missing-embedding-table behavior
- pair the contract with the retained R07 subprocess and escalation evidence

## Evidence

- lbug-delete-nodes-for-files: 4/4 passed
- incremental-escalation-gate: 6/6 passed
- incremental-orchestration: 12/12 passed
- Prettier check passed
- GitNexus detect_changes was attempted with the explicit worktree and safely refused because the registered MCP repository is a different canonical clone; no index refresh was performed

## Scope

This PR changes one integration test file. It does not alter production deletion behavior, force rebuilds, mutate a live index, or modify the preserved worktree.

Tracks #47. Dispositions #37 after current-head CI is green.