### PR TITLE
fix(release): synchronize plugin manifest versions

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.9",
+      "version": "1.6.10-rc.19",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.9",
+      "version": "1.6.10-rc.19",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -584,6 +584,21 @@ jobs:
           npm version "${{ steps.rc-version.outputs.rc_version }}" \
             --no-git-tag-version --allow-same-version
 
+      - name: Synchronize rc plugin manifest versions
+        if: needs.route.outputs.mode == 'rc'
+        shell: bash
+        working-directory: gitnexus
+        run: node scripts/sync-plugin-versions.mjs
+
+      - name: Verify rc plugin manifest versions
+        if: needs.route.outputs.mode == 'rc'
+        shell: bash
+        working-directory: gitnexus
+        run: >-
+          npx vitest run --project default
+          test/unit/sync-plugin-versions.test.ts
+          test/unit/cli-commands.test.ts
+
       - name: Build gitnexus
         run: npm run build
         working-directory: gitnexus
@@ -668,7 +683,13 @@ jobs:
           # Detached release commit with the version bump — main stays
           # pristine, but the v-tag's tree matches the published package
           # exactly (release-integrity).
-          git add package.json package-lock.json 2>/dev/null || git add package.json
+          git add \
+            package.json \
+            package-lock.json \
+            ../gitnexus-claude-plugin/.claude-plugin/plugin.json \
+            ../.claude-plugin/marketplace.json \
+            ../gitnexus-claude-plugin/.codex-plugin/plugin.json \
+            ../.agents/plugins/marketplace.json
           git commit -m "release: ${VTAG}" --allow-empty
           RELEASE_SHA="$(git rev-parse HEAD)"
           echo "Detached release commit: $RELEASE_SHA"

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.9",
+  "version": "1.6.10-rc.19",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.9",
+  "version": "1.6.10-rc.19",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/scripts/sync-plugin-versions.mjs
+++ b/gitnexus/scripts/sync-plugin-versions.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const DEFAULT_REPO_ROOT = path.resolve(path.dirname(SCRIPT_PATH), '..', '..');
+const PLUGIN_MANIFESTS = [
+  'gitnexus-claude-plugin/.claude-plugin/plugin.json',
+  'gitnexus-claude-plugin/.codex-plugin/plugin.json',
+];
+const MARKETPLACE_MANIFESTS = [
+  '.claude-plugin/marketplace.json',
+  '.agents/plugins/marketplace.json',
+];
+
+function parseRepoRoot(argv) {
+  if (argv.length === 0) return DEFAULT_REPO_ROOT;
+  if (argv.length === 2 && argv[0] === '--repo-root' && argv[1]) {
+    return path.resolve(argv[1]);
+  }
+  throw new Error('usage: sync-plugin-versions.mjs [--repo-root <path>]');
+}
+
+async function readJson(filePath) {
+  const value = JSON.parse(await fs.readFile(filePath, 'utf8'));
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${filePath} must contain a JSON object`);
+  }
+  return value;
+}
+
+async function writeJsonAtomic(filePath, value) {
+  const temporaryPath = `${filePath}.tmp-${process.pid}`;
+  try {
+    await fs.writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    await fs.rename(temporaryPath, filePath);
+  } catch (error) {
+    await fs.rm(temporaryPath, { force: true });
+    throw error;
+  }
+}
+
+async function prepareUpdates(repoRoot) {
+  const packagePath = path.join(repoRoot, 'gitnexus', 'package.json');
+  const packageJson = await readJson(packagePath);
+  if (typeof packageJson.version !== 'string' || packageJson.version.trim() === '') {
+    throw new Error(`${packagePath} must contain a non-empty version`);
+  }
+
+  const updates = [];
+  for (const relativePath of PLUGIN_MANIFESTS) {
+    const filePath = path.join(repoRoot, relativePath);
+    const manifest = await readJson(filePath);
+    if (typeof manifest.version !== 'string') {
+      throw new Error(`${relativePath} must contain a string version`);
+    }
+    manifest.version = packageJson.version;
+    updates.push({ filePath, manifest });
+  }
+
+  for (const relativePath of MARKETPLACE_MANIFESTS) {
+    const filePath = path.join(repoRoot, relativePath);
+    const manifest = await readJson(filePath);
+    if (!Array.isArray(manifest.plugins)) {
+      throw new Error(`${relativePath} must contain a plugins array`);
+    }
+    const entries = manifest.plugins.filter(
+      (plugin) => plugin && typeof plugin === 'object' && plugin.name === 'gitnexus',
+    );
+    if (entries.length !== 1) {
+      throw new Error(`${relativePath} must contain exactly one gitnexus entry`);
+    }
+    if (typeof entries[0].version !== 'string') {
+      throw new Error(`${relativePath} gitnexus entry must contain a string version`);
+    }
+    entries[0].version = packageJson.version;
+    updates.push({ filePath, manifest });
+  }
+
+  return { updates, version: packageJson.version };
+}
+
+async function main() {
+  const repoRoot = parseRepoRoot(process.argv.slice(2));
+  const { updates, version } = await prepareUpdates(repoRoot);
+  for (const { filePath, manifest } of updates) {
+    await writeJsonAtomic(filePath, manifest);
+  }
+  process.stdout.write(`Synchronized plugin manifests to ${version}.\n`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`sync-plugin-versions: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/gitnexus/test/unit/sync-plugin-versions.test.ts
+++ b/gitnexus/test/unit/sync-plugin-versions.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'gitnexus', 'scripts', 'sync-plugin-versions.mjs');
+const temporaryRoots: string[] = [];
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+async function createFixture(options: { duplicateCodexEntry?: boolean } = {}): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-version-sync-'));
+  temporaryRoots.push(root);
+
+  await writeJson(path.join(root, 'gitnexus', 'package.json'), {
+    name: 'gitnexus',
+    version: '2.3.4-rc.5',
+  });
+  await writeJson(path.join(root, 'gitnexus-claude-plugin', '.claude-plugin', 'plugin.json'), {
+    name: 'gitnexus',
+    version: '1.0.0',
+    preserved: true,
+  });
+  await writeJson(path.join(root, 'gitnexus-claude-plugin', '.codex-plugin', 'plugin.json'), {
+    name: 'gitnexus',
+    version: '1.0.0',
+    preserved: true,
+  });
+  await writeJson(path.join(root, '.claude-plugin', 'marketplace.json'), {
+    plugins: [
+      { name: 'unrelated', version: '9.9.9' },
+      { name: 'gitnexus', version: '1.0.0', source: './gitnexus-claude-plugin' },
+    ],
+  });
+  await writeJson(path.join(root, '.agents', 'plugins', 'marketplace.json'), {
+    plugins: [
+      { name: 'gitnexus', version: '1.0.0', source: './gitnexus-claude-plugin' },
+      ...(options.duplicateCodexEntry ? [{ name: 'gitnexus', version: '0.9.0' }] : []),
+    ],
+  });
+
+  return root;
+}
+
+function runSync(repoRoot: string) {
+  return spawnSync(process.execPath, [SCRIPT_PATH, '--repo-root', repoRoot], {
+    encoding: 'utf8',
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true })));
+});
+
+describe('sync-plugin-versions', () => {
+  it('updates exactly one GitNexus entry on every plugin surface and preserves other fields', async () => {
+    const root = await createFixture();
+
+    const result = runSync(root);
+
+    expect(result.status, result.stderr).toBe(0);
+    for (const relativePath of [
+      'gitnexus-claude-plugin/.claude-plugin/plugin.json',
+      'gitnexus-claude-plugin/.codex-plugin/plugin.json',
+    ]) {
+      const manifest = JSON.parse(await fs.readFile(path.join(root, relativePath), 'utf8')) as {
+        version: string;
+        preserved: boolean;
+      };
+      expect(manifest).toMatchObject({ version: '2.3.4-rc.5', preserved: true });
+    }
+
+    for (const relativePath of [
+      '.claude-plugin/marketplace.json',
+      '.agents/plugins/marketplace.json',
+    ]) {
+      const marketplace = JSON.parse(await fs.readFile(path.join(root, relativePath), 'utf8')) as {
+        plugins: Array<{ name: string; version: string }>;
+      };
+      const entries = marketplace.plugins.filter((plugin) => plugin.name === 'gitnexus');
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.version).toBe('2.3.4-rc.5');
+    }
+  });
+
+  it('fails before writing any manifest when a marketplace has duplicate GitNexus entries', async () => {
+    const root = await createFixture({ duplicateCodexEntry: true });
+    const claudePluginPath = path.join(
+      root,
+      'gitnexus-claude-plugin',
+      '.claude-plugin',
+      'plugin.json',
+    );
+    const before = await fs.readFile(claudePluginPath, 'utf8');
+
+    const result = runSync(root);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('exactly one gitnexus entry');
+    expect(await fs.readFile(claudePluginPath, 'utf8')).toBe(before);
+  });
+
+  it('runs and verifies synchronization before the RC tag while staging every manifest', async () => {
+    const workflow = await fs.readFile(
+      path.join(REPO_ROOT, '.github', 'workflows', 'publish.yml'),
+      'utf8',
+    );
+    const syncPosition = workflow.indexOf('node scripts/sync-plugin-versions.mjs');
+    const tagPosition = workflow.indexOf('- name: Create and push rc tags');
+
+    expect(syncPosition).toBeGreaterThan(-1);
+    expect(workflow).toContain('test/unit/sync-plugin-versions.test.ts');
+    expect(syncPosition).toBeLessThan(tagPosition);
+    for (const stagedPath of [
+      '../gitnexus-claude-plugin/.claude-plugin/plugin.json',
+      '../.claude-plugin/marketplace.json',
+      '../gitnexus-claude-plugin/.codex-plugin/plugin.json',
+      '../.agents/plugins/marketplace.json',
+    ]) {
+      expect(workflow).toContain(stagedPath);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- synchronize Claude and Codex plugin manifests from the package version with structured JSON
- fail before writing when a marketplace has a missing or duplicate GitNexus entry
- verify the version contract before RC tag creation
- stage all four manifests in the detached RC release commit
- align the RC19 integration tree to 1.6.10-rc.19

## Evidence

- TDD red: synchronizer missing, 2/2 tests failed
- focused synchronizer and CLI contract: 18/18 passed
- TypeScript no-emit passed
- ESLint passed
- Prettier passed
- actionlint passed
- pre-commit lint, format, and typecheck passed
- GitNexus detect_changes was attempted with the explicit worktree and safely refused because the registered MCP repository is a different canonical clone; no index refresh was performed

## Scope

This repairs the internally observed RC19 floor failure without weakening tests. It does not publish, tag, mutate main, deploy, or touch a live index.

Closes #69. Upstream contribution context: abhigyanpatwari/GitNexus#2445.