### PR TITLE
test(incremental): prove FTS deletion recovery

### DIFF
--- a/gitnexus/test/fixtures/large-incremental-child.mjs
+++ b/gitnexus/test/fixtures/large-incremental-child.mjs
@@ -6,10 +6,14 @@ const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.resolve(fixtureDir, '../..');
 const runAnalyzeUrl = pathToFileURL(path.join(packageRoot, 'dist/core/run-analyze.js')).href;
 const repoManagerUrl = pathToFileURL(path.join(packageRoot, 'dist/storage/repo-manager.js')).href;
+const lbugAdapterUrl = pathToFileURL(path.join(packageRoot, 'dist/core/lbug/lbug-adapter.js')).href;
+const bm25IndexUrl = pathToFileURL(path.join(packageRoot, 'dist/core/search/bm25-index.js')).href;
 
 const [repoPath, ...args] = process.argv.slice(2);
 if (!repoPath) {
-  throw new Error('usage: large-incremental-child.mjs <repo> [--force] [--pause-on-escalation <file>]');
+  throw new Error(
+    'usage: large-incremental-child.mjs <repo> [--force] [--pause-on-escalation <file>] [--fts-query <text>]',
+  );
 }
 
 const force = args.includes('--force');
@@ -17,6 +21,11 @@ const pauseIndex = args.indexOf('--pause-on-escalation');
 const pauseReadyFile = pauseIndex >= 0 ? args[pauseIndex + 1] : undefined;
 if (pauseIndex >= 0 && !pauseReadyFile) {
   throw new Error('--pause-on-escalation requires a ready-file path');
+}
+const ftsQueryIndex = args.indexOf('--fts-query');
+const ftsQuery = ftsQueryIndex >= 0 ? args[ftsQueryIndex + 1] : undefined;
+if (ftsQueryIndex >= 0 && !ftsQuery) {
+  throw new Error('--fts-query requires query text');
 }
 
 const { runFullAnalysis } = await import(runAnalyzeUrl);
@@ -27,11 +36,7 @@ let paused = false;
 
 const onLog = (message) => {
   logs.push(message);
-  if (
-    !paused &&
-    pauseReadyFile &&
-    message.includes('switching to a full DB write')
-  ) {
+  if (!paused && pauseReadyFile && message.includes('switching to a full DB write')) {
     paused = true;
     const metadataPath = path.join(storagePath, 'gitnexus.json');
     const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
@@ -48,23 +53,40 @@ const onLog = (message) => {
 };
 
 try {
-  await runFullAnalysis(
-    repoPath,
-    { skipAgentsMd: true, force },
-    { onProgress: () => {}, onLog },
-  );
+  await runFullAnalysis(repoPath, { skipAgentsMd: true, force }, { onProgress: () => {}, onLog });
 
   const meta = await loadMeta(storagePath);
   const lbugStat = fs.statSync(lbugPath);
   if (!meta) throw new Error('analysis returned without metadata');
   if (meta.incrementalInProgress) {
-    throw new Error(`analysis returned with dirty marker phase ${meta.incrementalInProgress.phase}`);
+    throw new Error(
+      `analysis returned with dirty marker phase ${meta.incrementalInProgress.phase}`,
+    );
   }
   if (!meta.stats || Number(meta.stats.files ?? 0) <= 0 || Number(meta.stats.nodes ?? 0) <= 0) {
     throw new Error('analysis returned without a valid nonempty graph');
   }
   if (!lbugStat.isFile() || lbugStat.size <= 0) {
     throw new Error('analysis returned without a valid LadybugDB file');
+  }
+
+  let ftsSearch;
+  if (ftsQuery) {
+    const adapter = await import(lbugAdapterUrl);
+    const { searchFTSFromLbug } = await import(bm25IndexUrl);
+    await adapter.initLbug(lbugPath);
+    try {
+      const response = await searchFTSFromLbug(ftsQuery, 20);
+      ftsSearch = { query: ftsQuery, ...response };
+      if (!response.ftsAvailable) {
+        throw new Error(`FTS indexes are unavailable after analysis for query ${ftsQuery}`);
+      }
+      if (response.results.length === 0) {
+        throw new Error(`FTS query returned no results after analysis for ${ftsQuery}`);
+      }
+    } finally {
+      await adapter.closeLbug();
+    }
   }
 
   const lbugName = path.basename(lbugPath);
@@ -79,10 +101,11 @@ try {
       logs,
       sidecars,
       lastCommit: meta.lastCommit,
+      ftsSearch,
     })}\n`,
   );
 } catch (error) {
-  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
   process.stderr.write(`${message}\n`);
   process.exitCode = 1;
 }

--- a/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
+++ b/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
@@ -21,6 +21,11 @@ type HarnessResult = {
   logs: string[];
   sidecars: string[];
   lastCommit: string;
+  ftsSearch?: {
+    query: string;
+    ftsAvailable: boolean;
+    results: Array<{ filePath: string; score: number; rank: number }>;
+  };
 };
 
 const childEnv = (gitnexusHome: string): NodeJS.ProcessEnv => ({
@@ -28,7 +33,10 @@ const childEnv = (gitnexusHome: string): NodeJS.ProcessEnv => ({
   CI: '1',
   NODE_ENV: 'test',
   GITNEXUS_HOME: gitnexusHome,
-  GITNEXUS_LBUG_EXTENSION_INSTALL: 'never',
+  // The R09 contract requires FTS but must never install during the child
+  // process. CI and local setup preinstall the extension; load-only fails
+  // closed when that prerequisite is absent.
+  GITNEXUS_LBUG_EXTENSION_INSTALL: 'load-only',
   GITNEXUS_WORKER_POOL_SIZE: '2',
   GITNEXUS_PARSE_CHUNK_CONCURRENCY: '1',
 });
@@ -151,6 +159,30 @@ describe('large incremental analysis subprocess contract', () => {
       expect(initial.stats.files).toBe(61);
       expect(initial.stats.nodes).toBeGreaterThan(61);
 
+      // Exercise active FTS deletion below the escalation threshold before
+      // the wide importer-closure scenario. A rename is represented as an
+      // old-path delete plus a new-path insert, so LadybugDB must remove the
+      // indexed File/Function rows without entering its historical FTS delete
+      // crash or silently leaving stale derived state.
+      const src = path.join(fixture.repoPath, 'src');
+      fs.renameSync(path.join(src, 'spoke-059.ts'), path.join(src, 'r09-small-renamed.ts'));
+      fs.writeFileSync(
+        path.join(src, 'r09-small-renamed.ts'),
+        "import { hubValue } from './hub';\nexport function r09SmallFtsNeedle(): number { return hubValue(59); }\n",
+      );
+      commitAll(fixture.repoPath, 'exercise active FTS row deletion');
+
+      const smallIncremental = runChild(fixture.repoPath, fixture.gitnexusHome, [
+        '--fts-query',
+        'r09SmallFtsNeedle',
+      ]);
+      expect(smallIncremental.logs.join('\n')).not.toContain('switching to a full DB write');
+      expect(smallIncremental.stats.files).toBe(61);
+      expect(smallIncremental.ftsSearch?.ftsAvailable).toBe(true);
+      expect(smallIncremental.ftsSearch?.results.map((result) => result.filePath)).toContain(
+        'src/r09-small-renamed.ts',
+      );
+
       const seedFiles = [
         'src/hub.ts',
         'src/spoke-000.ts',
@@ -165,13 +197,12 @@ describe('large incremental analysis subprocess contract', () => {
       const { storagePath } = getStoragePaths(fixture.repoPath);
       await stampEmbeddingCount(storagePath, seededIds.length);
 
-      const src = path.join(fixture.repoPath, 'src');
       fs.appendFileSync(path.join(src, 'hub.ts'), '\n// importer-closure edit\n');
       fs.renameSync(path.join(src, 'spoke-002.ts'), path.join(src, 'renamed-spoke.ts'));
       fs.rmSync(path.join(src, 'spoke-001.ts'));
       fs.writeFileSync(
         path.join(src, 'added.ts'),
-        "import { hubValue } from './hub';\nexport const added = hubValue(99);\n",
+        "import { hubValue } from './hub';\nexport function r09FtsNeedle(): number { return hubValue(99); }\n",
       );
       commitAll(fixture.repoPath, 'exercise incremental write set');
 
@@ -200,7 +231,10 @@ describe('large incremental analysis subprocess contract', () => {
       const dirtyMeta = await loadMeta(storagePath);
       expect(dirtyMeta?.incrementalInProgress).toBeDefined();
 
-      const recovered = runChild(fixture.repoPath, fixture.gitnexusHome);
+      const recovered = runChild(fixture.repoPath, fixture.gitnexusHome, [
+        '--fts-query',
+        'r09FtsNeedle',
+      ]);
       expect(recovered.logs.join('\n')).toContain(
         'Previous analyze run did not complete cleanly (incrementalInProgress flag set)',
       );
@@ -211,6 +245,10 @@ describe('large incremental analysis subprocess contract', () => {
       expect(recovered.capabilities).toHaveProperty('fts');
       expect(recovered.capabilities).toHaveProperty('vectorSearch');
       expect(Array.isArray(recovered.sidecars)).toBe(true);
+      expect(recovered.ftsSearch?.ftsAvailable).toBe(true);
+      expect(recovered.ftsSearch?.results.map((result) => result.filePath)).toContain(
+        'src/added.ts',
+      );
 
       const survivingEmbeddingIds = await readEmbeddingNodeIds(fixture.repoPath);
       expect(survivingEmbeddingIds.length).toBeGreaterThanOrEqual(4);
@@ -219,8 +257,13 @@ describe('large incremental analysis subprocess contract', () => {
       expect(survivingEmbeddingIds).not.toContain(seeded.get('src/spoke-002.ts')?.[0]);
       expect(await readEmbeddingDimensions(fixture.repoPath)).toEqual([384]);
 
-      const forced = runChild(fixture.repoPath, fixture.gitnexusHome, ['--force']);
+      const forced = runChild(fixture.repoPath, fixture.gitnexusHome, [
+        '--force',
+        '--fts-query',
+        'r09FtsNeedle',
+      ]);
       expect(forced.stats).toEqual(recovered.stats);
+      expect(forced.ftsSearch).toEqual(recovered.ftsSearch);
       expect(await readEmbeddingNodeIds(fixture.repoPath)).toEqual(survivingEmbeddingIds);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });


### PR DESCRIPTION
## Summary

- require the large incremental child to load a preinstalled FTS extension without network installation
- exercise a below-threshold rename/edit while FTS indexes are active
- require query hits after the small incremental, dirty recovery, and force comparison
- retain the existing finalization path without adding the historical drop-before-delete workaround

## Evidence

- red: policy never prevented preinstalled FTS loading and the new gate failed closed
- green post-recovery queryability: 1/1 passed in 194.41 seconds
- tightened active-FTS deletion and full recovery contract: 1/1 passed in 284.92 seconds
- TypeScript no-emit passed
- Prettier passed
- GitNexus detect_changes was attempted with the explicit worktree and safely refused because the registered MCP repository is a different canonical clone; no index refresh was performed

## Scope

Test harness only. No production FTS behavior, embeddings, live indexes, tags, packages, releases, or runtime deployments are changed.

Tracks #48. Dispositions #38 after current-head CI is green.