### PR TITLE
fix(eval-server): require auth for remote binds

### DIFF
--- a/gitnexus/src/cli/eval-server.ts
+++ b/gitnexus/src/cli/eval-server.ts
@@ -16,7 +16,7 @@
  * Usage:
  *   gitnexus eval-server                        # default port 4848, binds 127.0.0.1
  *   gitnexus eval-server --port 4848            # explicit port
- *   gitnexus eval-server --host 0.0.0.0         # reachable from other VMs / containers
+ *   GITNEXUS_AUTH_TOKEN=... gitnexus eval-server --host 0.0.0.0
  *   gitnexus eval-server --idle-timeout 300     # auto-shutdown after 300s idle
  *
  * READY signal format: GITNEXUS_EVAL_SERVER_READY:<host>:<port>
@@ -60,6 +60,40 @@ export function validateHost(raw: string): string | null {
   if (raw === 'localhost') return raw;
   if (isIPv4(raw) || isIPv6(raw)) return raw;
   return null;
+}
+
+/** Resolve the eval-server bearer token without retaining surrounding shell whitespace. */
+export function resolveEvalServerAuthToken(env: NodeJS.ProcessEnv): string | undefined {
+  return env.GITNEXUS_AUTH_TOKEN?.trim() || undefined;
+}
+
+/** True only for bind hosts that are local to this machine. */
+export function isEvalServerLoopbackHost(host: string): boolean {
+  return host === 'localhost' || host === '::1' || (isIPv4(host) && host.startsWith('127.'));
+}
+
+/** Refuse exposure of the eval-server query surface without authentication. */
+export function assertSecureEvalServerBinding(host: string, authToken: string | undefined): void {
+  if (!authToken && !isEvalServerLoopbackHost(host)) {
+    throw new Error(
+      `Refusing to start eval-server on non-loopback host ${host} without authentication. ` +
+        'Set GITNEXUS_AUTH_TOKEN or bind to 127.0.0.1, localhost, or ::1.',
+    );
+  }
+}
+
+/** Validate the exact Bearer header while keeping token comparison constant-time. */
+export function isEvalServerBearerAuthorized(
+  authorization: string | string[] | undefined,
+  authToken: string | undefined,
+): boolean {
+  if (!authToken) return true;
+
+  const expected = Buffer.from(`Bearer ${authToken}`, 'utf8');
+  const supplied = typeof authorization === 'string' ? Buffer.from(authorization, 'utf8') : null;
+  const sameLength = supplied?.length === expected.length;
+  const candidate = sameLength && supplied ? supplied : Buffer.alloc(expected.length);
+  return crypto.timingSafeEqual(candidate, expected) && sameLength;
 }
 
 // ─── Text Formatters ──────────────────────────────────────────────────
@@ -657,11 +691,21 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
         `  Must be an IP address or "localhost".\n\n` +
         `  Examples:\n` +
         `    gitnexus eval-server --host 127.0.0.1    (loopback only, default)\n` +
-        `    gitnexus eval-server --host 0.0.0.0      (all network interfaces)\n` +
-        `    gitnexus eval-server --host 192.168.1.5  (specific interface)\n` +
+        `    GITNEXUS_AUTH_TOKEN=... gitnexus eval-server --host 0.0.0.0\n` +
+        `    GITNEXUS_AUTH_TOKEN=... gitnexus eval-server --host 192.168.1.5\n` +
         `    gitnexus eval-server --host localhost     (OS-resolved loopback)\n`,
       { flag: '--host', value: rawHost },
     );
+    process.exit(1);
+  }
+
+  const authToken = resolveEvalServerAuthToken(process.env);
+  try {
+    assertSecureEvalServerBinding(host, authToken);
+  } catch (error) {
+    cliError(error instanceof Error ? error.message : 'Refusing insecure eval-server binding.', {
+      host,
+    });
     process.exit(1);
   }
 
@@ -705,6 +749,14 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
   const shutdownToken = crypto.randomBytes(24).toString('hex');
 
   const server = http.createServer(async (req, res) => {
+    if (!isEvalServerBearerAuthorized(req.headers.authorization, authToken)) {
+      res.setHeader('Content-Type', 'application/json');
+      res.setHeader('WWW-Authenticate', 'Bearer');
+      res.writeHead(401);
+      res.end(JSON.stringify({ error: 'Unauthorized' }));
+      return;
+    }
+
     resetIdleTimer();
 
     try {
@@ -807,7 +859,7 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
               `  Run \`ip addr\` (Linux) or \`ipconfig\` (Windows) to list available addresses.\n\n`) +
           `  Common fixes:\n` +
           `    gitnexus eval-server --host 127.0.0.1  (loopback, this machine only)\n` +
-          `    gitnexus eval-server --host 0.0.0.0    (all interfaces, reachable from other VMs)\n`,
+          `    GITNEXUS_AUTH_TOKEN=... gitnexus eval-server --host 0.0.0.0\n`,
         { code: err.code, port, host },
       );
     } else if (err.code === 'EACCES') {
@@ -856,6 +908,9 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
       `  GET  /health        — health check`,
       `  POST /shutdown      — graceful shutdown`,
     ];
+    if (authToken) {
+      bannerLines.push('  Bearer authentication enabled');
+    }
     if (idleTimeoutSec > 0) {
       bannerLines.push(`  Auto-shutdown after ${idleTimeoutSec}s idle`);
     }
@@ -863,6 +918,7 @@ export async function evalServerCommand(options?: EvalServerOptions): Promise<vo
       port: boundPort,
       host,
       idleTimeoutSec: idleTimeoutSec > 0 ? idleTimeoutSec : undefined,
+      authEnabled: Boolean(authToken),
       endpoints: [
         'POST /tool/query',
         'POST /tool/context',

--- a/gitnexus/src/cli/i18n/en.ts
+++ b/gitnexus/src/cli/i18n/en.ts
@@ -277,7 +277,7 @@ export const en = {
   'help.option.cypher.limit': 'Max result rows to return',
   'help.option.check.cycles': 'Detect circular imports and fail when any are found',
   'help.option.evalServer.host':
-    'Bind address (default: 127.0.0.1, use 0.0.0.0 to expose to all interfaces)',
+    'Bind address (default: 127.0.0.1; non-loopback requires GITNEXUS_AUTH_TOKEN)',
   'help.option.evalServer.idleTimeout': 'Auto-shutdown after N seconds idle (0 = disabled)',
   'help.option.embeddings.install.cuda':
     "Also download the CUDA GPU binaries (runs onnxruntime-node's NuGet postinstall; set GLOBAL_AGENT_HTTPS_PROXY behind a proxy)",

--- a/gitnexus/src/cli/i18n/zh-CN.ts
+++ b/gitnexus/src/cli/i18n/zh-CN.ts
@@ -257,7 +257,7 @@ export const zhCN = {
   'help.option.detectChanges.limit': '最多返回的已变更符号数',
   'help.option.cypher.limit': '最多返回的结果行数',
   'help.option.check.cycles': '检测循环导入，并在发现循环时失败',
-  'help.option.evalServer.host': '绑定地址（默认：127.0.0.1；用 0.0.0.0 暴露到所有网卡）',
+  'help.option.evalServer.host': '绑定地址（默认：127.0.0.1；非回环绑定需要 GITNEXUS_AUTH_TOKEN）',
   'help.option.evalServer.idleTimeout': '空闲 N 秒后自动关闭（0 = 禁用）',
   'help.option.embeddings.install.cuda':
     '同时下载 CUDA GPU 二进制文件（运行 onnxruntime-node 的 NuGet postinstall；代理后请设置 GLOBAL_AGENT_HTTPS_PROXY）',

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -441,7 +441,7 @@ program
   .option('-p, --port <port>', 'Port number', '4848')
   .option(
     '--host <host>',
-    'Bind address (default: 127.0.0.1, use 0.0.0.0 to expose to all interfaces)',
+    'Bind address (default: 127.0.0.1; non-loopback requires GITNEXUS_AUTH_TOKEN)',
   )
   .option('--idle-timeout <seconds>', 'Auto-shutdown after N seconds idle (0 = disabled)', '0')
   .action(createLbugLazyAction(() => import('./eval-server.js'), 'evalServerCommand'));

--- a/gitnexus/test/integration/cli-e2e.test.ts
+++ b/gitnexus/test/integration/cli-e2e.test.ts
@@ -210,8 +210,10 @@ function runEvalServerHostFlagTest(
   spawnArgs: string[],
   opts: {
     timeoutMsg: string;
+    extraEnv?: Record<string, string>;
     onStdout: (params: {
       stdoutBuffer: string;
+      stderrBuffer: string;
       isSettled: () => boolean;
       settle: (fn: () => void) => void;
       resolve: () => void;
@@ -223,7 +225,7 @@ function runEvalServerHostFlagTest(
     const child = spawn(process.execPath, [...CLI_SPAWN_PREFIX, 'eval-server', ...spawnArgs], {
       cwd: MINI_REPO,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: cliEnv(),
+      env: cliEnv(opts.extraEnv),
     });
 
     let stdoutBuffer = '';
@@ -255,6 +257,7 @@ function runEvalServerHostFlagTest(
       try {
         await opts.onStdout({
           stdoutBuffer,
+          stderrBuffer,
           isSettled: () => settled,
           settle,
           resolve,
@@ -1416,10 +1419,25 @@ describe('CLI end-to-end', () => {
   // Original flag registration test by Val Vladescu (PR #1602).
 
   describe('eval-server --host flag', { retry: 2 }, () => {
+    it('refuses an unauthenticated non-loopback bind before emitting READY', () => {
+      const result = runCliWithEnv(
+        ['eval-server', '--port', '0', '--host', '0.0.0.0', '--idle-timeout', '3'],
+        MINI_REPO,
+        { GITNEXUS_AUTH_TOKEN: '' },
+        30000,
+      );
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      expect(result.status).toBe(1);
+      expect(output).toMatch(/non-loopback.*GITNEXUS_AUTH_TOKEN/is);
+      expect(output).not.toContain('GITNEXUS_EVAL_SERVER_READY:');
+    }, 35000);
+
     it('emits READY signal containing the bound host 127.0.0.1', () => {
       return runEvalServerHostFlagTest(
         ['--port', '0', '--host', '127.0.0.1', '--idle-timeout', '3'],
         {
+          extraEnv: { GITNEXUS_AUTH_TOKEN: '' },
           timeoutMsg: 'eval-server did not emit READY signal within 30s',
           onStdout({ stdoutBuffer, settle, resolve, reject }) {
             if (!stdoutBuffer.includes('GITNEXUS_EVAL_SERVER_READY:')) return;
@@ -1439,12 +1457,26 @@ describe('CLI end-to-end', () => {
       );
     }, 35000);
 
-    it('binds to 0.0.0.0 and serves /health on 127.0.0.1 (cross-container use case)', () => {
+    it('binds to ::1 without a token when IPv6 loopback is available', () => {
+      return runEvalServerHostFlagTest(['--port', '0', '--host', '::1', '--idle-timeout', '3'], {
+        extraEnv: { GITNEXUS_AUTH_TOKEN: '' },
+        timeoutMsg: 'eval-server --host ::1 did not emit READY signal within 30s',
+        onStdout({ stdoutBuffer, settle, resolve }) {
+          if (stdoutBuffer.includes('GITNEXUS_EVAL_SERVER_READY:[::1]:')) {
+            settle(resolve);
+          }
+        },
+      });
+    }, 35000);
+
+    it('requires the configured bearer token on a 0.0.0.0 bind', () => {
+      const authToken = 'integration-secret-token';
       return runEvalServerHostFlagTest(
         ['--port', '0', '--host', '0.0.0.0', '--idle-timeout', '3'],
         {
+          extraEnv: { GITNEXUS_AUTH_TOKEN: authToken },
           timeoutMsg: 'eval-server --host 0.0.0.0 did not emit READY signal within 30s',
-          async onStdout({ stdoutBuffer, isSettled, settle, resolve, reject }) {
+          async onStdout({ stdoutBuffer, stderrBuffer, isSettled, settle, resolve, reject }) {
             const readyLine = stdoutBuffer
               .split('\n')
               .find((l) => l.startsWith('GITNEXUS_EVAL_SERVER_READY:0.0.0.0:'));
@@ -1459,19 +1491,42 @@ describe('CLI end-to-end', () => {
               return;
             }
 
-            // A server bound to 0.0.0.0 must be reachable on 127.0.0.1 from the same host
             try {
-              const res = await fetch(`http://127.0.0.1:${boundPort}/health`);
-              if (res.status === 200) {
+              const url = `http://127.0.0.1:${boundPort}/health`;
+              const missing = await fetch(url);
+              const wrong = await fetch(url, {
+                headers: { Authorization: 'Bearer wrong-token' },
+              });
+              const correct = await fetch(url, {
+                headers: { Authorization: `Bearer ${authToken}` },
+              });
+              const responseText = `${await missing.text()}${await wrong.text()}${await correct.text()}`;
+
+              if (
+                missing.status === 401 &&
+                wrong.status === 401 &&
+                correct.status === 200 &&
+                missing.headers.get('www-authenticate') === 'Bearer' &&
+                wrong.headers.get('www-authenticate') === 'Bearer' &&
+                !responseText.includes(authToken) &&
+                !stdoutBuffer.includes(authToken) &&
+                !stderrBuffer.includes(authToken)
+              ) {
                 settle(resolve);
               } else {
-                settle(() => reject(new Error(`/health returned ${res.status}, expected 200`)));
+                settle(() =>
+                  reject(
+                    new Error(
+                      `/health auth statuses were ${missing.status}/${wrong.status}/${correct.status}; expected 401/401/200`,
+                    ),
+                  ),
+                );
               }
             } catch (err) {
               settle(() =>
                 reject(
                   new Error(
-                    `eval-server bound to 0.0.0.0 but /health unreachable on 127.0.0.1:${boundPort}: ${err}`,
+                    `authenticated eval-server health probe failed on 127.0.0.1:${boundPort}: ${err}`,
                   ),
                 ),
               );
@@ -1485,6 +1540,7 @@ describe('CLI end-to-end', () => {
       return runEvalServerHostFlagTest(
         ['--port', '0', '--host', 'localhost', '--idle-timeout', '3'],
         {
+          extraEnv: { GITNEXUS_AUTH_TOKEN: '' },
           timeoutMsg: 'eval-server --host localhost did not emit READY signal within 30s',
           async onStdout({ stdoutBuffer, isSettled, settle, resolve, reject }) {
             const readyLine = stdoutBuffer

--- a/gitnexus/test/unit/eval-server-auth.test.ts
+++ b/gitnexus/test/unit/eval-server-auth.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertSecureEvalServerBinding,
+  isEvalServerBearerAuthorized,
+  isEvalServerLoopbackHost,
+  resolveEvalServerAuthToken,
+} from '../../src/cli/eval-server.js';
+
+describe('eval-server bearer authentication', () => {
+  it('resolves a trimmed token and treats blank values as absent', () => {
+    expect(resolveEvalServerAuthToken({ GITNEXUS_AUTH_TOKEN: '  secret-value  ' })).toBe(
+      'secret-value',
+    );
+    expect(resolveEvalServerAuthToken({ GITNEXUS_AUTH_TOKEN: '' })).toBeUndefined();
+    expect(resolveEvalServerAuthToken({ GITNEXUS_AUTH_TOKEN: '   ' })).toBeUndefined();
+  });
+
+  it.each(['127.0.0.1', '127.0.0.2', 'localhost', '::1'])('classifies %s as loopback', (host) => {
+    expect(isEvalServerLoopbackHost(host)).toBe(true);
+  });
+
+  it.each(['0.0.0.0', '::', '192.168.1.50', '2001:db8::1', 'localhost.evil.test'])(
+    'classifies %s as non-loopback',
+    (host) => {
+      expect(isEvalServerLoopbackHost(host)).toBe(false);
+    },
+  );
+
+  it('allows loopback without a token and requires one for non-loopback binds', () => {
+    expect(() => assertSecureEvalServerBinding('127.0.0.1', undefined)).not.toThrow();
+    expect(() => assertSecureEvalServerBinding('::1', undefined)).not.toThrow();
+    expect(() => assertSecureEvalServerBinding('0.0.0.0', 'secret-value')).not.toThrow();
+    expect(() => assertSecureEvalServerBinding('192.168.1.50', undefined)).toThrow(
+      /non-loopback.*GITNEXUS_AUTH_TOKEN/i,
+    );
+  });
+
+  it('accepts only the exact Bearer header when a token is configured', () => {
+    const token = 'secret-value';
+    expect(isEvalServerBearerAuthorized(undefined, undefined)).toBe(true);
+    expect(isEvalServerBearerAuthorized(`Bearer ${token}`, token)).toBe(true);
+    expect(isEvalServerBearerAuthorized(undefined, token)).toBe(false);
+    expect(isEvalServerBearerAuthorized(`Bearer wrong`, token)).toBe(false);
+    expect(isEvalServerBearerAuthorized(token, token)).toBe(false);
+    expect(isEvalServerBearerAuthorized(`bearer ${token}`, token)).toBe(false);
+    expect(isEvalServerBearerAuthorized([`Bearer ${token}`], token)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Capability

Implements R13 by securing the standalone `gitnexus eval-server` HTTP surface.

- Retains `GITNEXUS_AUTH_TOKEN`.
- Allows tokenless startup only on IPv4/IPv6 loopback.
- Refuses non-loopback startup without a token before database initialization or socket binding.
- Applies exact Bearer authentication to health, tool, and shutdown routes.
- Uses constant-time comparison and generic 401 responses with `WWW-Authenticate: Bearer`.
- Keeps token material out of logs, diagnostics, banners, and response bodies.
- Updates localized CLI help and runtime examples to match the enforced policy.

This replaces, rather than cherry-picks, legacy fork commit `8a38fe83`; the old patch did not fail closed on remote binds and had no tests.

## Evidence

- Red phase retained: 12 of 13 new contract tests failed before implementation.
- Focused unit/help tests: 75 passed.
- Real subprocess bind/auth tests: 5 passed.
- TypeScript: passed.
- Targeted ESLint: zero errors; existing warnings only.
- Full package build: passed.
- Prettier and diff checks: passed.
- Detailed evidence: `/Volumes/LEXAR/Codex/session-notes/2026-07-13/gitnexus-fork-upstream-reconciliation/r13-secure-eval-server.md`.

## Stack And Gate

- Base: `reconcile/r12-mcp-output-budgets`.
- Head: `694526a591f899ad5c457f12450f4cb706a4ab8c`.
- This PR must wait for R12, then be retargeted to the integration branch and revalidated at current head.
- Publication, runtime rollout, live-index mutation, and default-branch promotion are outside this PR.

Closes #52 after merge.
Parent epic: #39.
