### PR TITLE
fix(cli): fail cypher errors loudly

### DIFF
--- a/gitnexus/src/cli/tool.ts
+++ b/gitnexus/src/cli/tool.ts
@@ -301,6 +301,15 @@ export async function cypherCommand(
     }
   }
   output(result);
+  if (
+    result &&
+    typeof result === 'object' &&
+    'error' in result &&
+    typeof result.error === 'string' &&
+    result.error.trim().length > 0
+  ) {
+    process.exitCode = 1;
+  }
 }
 
 export async function detectChangesCommand(options?: {

--- a/gitnexus/test/unit/tool-direct-cli.test.ts
+++ b/gitnexus/test/unit/tool-direct-cli.test.ts
@@ -81,6 +81,29 @@ describe('direct CLI tool commands', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('fails closed when cypher returns a backend error payload', async () => {
+    callToolMock.mockResolvedValue({ error: 'Binder exception: missing relationship property' });
+    const { cypherCommand } = await import('../../src/cli/tool.js');
+
+    await cypherCommand('MATCH ()-[r:CodeRelation]->() RETURN r.missing');
+
+    expect(writeSyncMock).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining('Binder exception: missing relationship property'),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('keeps a successful cypher result at exit zero', async () => {
+    callToolMock.mockResolvedValue({ markdown: '| count |\n| --- |\n| 1 |', row_count: 1 });
+    const { cypherCommand } = await import('../../src/cli/tool.js');
+
+    await cypherCommand('MATCH (n) RETURN count(n) AS count');
+
+    expect(writeSyncMock).toHaveBeenCalledWith(1, expect.stringContaining('"row_count": 1'));
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it('dispatches detect_changes with CLI-shaped arguments', async () => {
     callToolMock.mockResolvedValue({
       summary: {


### PR DESCRIPTION
Closes #86.

## What changed

- preserves the existing structured Cypher error payload;
- sets `process.exitCode = 1` when the backend returns a non-empty `error` string;
- retains exit-zero behavior for successful tabular results;
- adds focused red-to-green unit coverage.

## Proof

- `vitest run test/unit/tool-direct-cli.test.ts`: 12 passed;
- Prettier check on both changed files: passed;
- `git diff --check`: passed;
- GitNexus impact: LOW, zero indexed callers;
- filesystem diff: exactly two files.

## Scope

No database, schema, index, publication, runtime, or release mutation.