### PR TITLE
test(reconciliation): add disposable OpenClaw scale canary

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -204,6 +204,10 @@ jobs:
     env:
       GITNEXUS_REQUIRE_FTS: '1'
       GITNEXUS_E2E_CLI: dist
+      # Ubuntu coverage proves all four durable recovery boundaries. The OS
+      # matrix keeps the most destructive native filesystem boundary inside
+      # its 15-minute per-shard watchdog.
+      GITNEXUS_RECOVERY_BOUNDARIES: during-delete
     steps:
       # persist-credentials: false — runs tests only, never pushes (zizmor
       # credential-persistence / artipacked audit).

--- a/gitnexus/scripts/reconciliation/canary-environment.mjs
+++ b/gitnexus/scripts/reconciliation/canary-environment.mjs
@@ -1,0 +1,33 @@
+const PORTABLE_KEYS = [
+  'PATH',
+  'SHELL',
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TZ',
+];
+
+const WINDOWS_KEYS = ['SystemRoot', 'WINDIR', 'COMSPEC', 'PATHEXT'];
+
+export const createSanitizedEnvironment = (source, { home, platform = process.platform } = {}) => {
+  if (!home) throw new Error('sanitized environment requires an isolated home');
+
+  const result = {};
+  const allowedKeys = platform === 'win32' ? [...PORTABLE_KEYS, ...WINDOWS_KEYS] : PORTABLE_KEYS;
+  for (const key of allowedKeys) {
+    if (typeof source[key] === 'string') result[key] = source[key];
+  }
+
+  return {
+    ...result,
+    HOME: home,
+    USERPROFILE: home,
+    CI: '1',
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_CONFIG_GLOBAL: platform === 'win32' ? 'NUL' : '/dev/null',
+  };
+};

--- a/gitnexus/scripts/reconciliation/canary-safety.mjs
+++ b/gitnexus/scripts/reconciliation/canary-safety.mjs
@@ -1,0 +1,253 @@
+import { spawn, spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SIGNAL_EXIT_CODES = { SIGINT: 130, SIGTERM: 143 };
+
+const codePointCompare = (left, right) => (left < right ? -1 : left > right ? 1 : 0);
+
+const assertDirectory = (directory) => {
+  const stat = fs.lstatSync(directory);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`refusing symbolic link in canary evidence path: ${directory}`);
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`expected canary evidence directory: ${directory}`);
+  }
+};
+
+const assertTreeHasNoSymlinks = (directory) => {
+  assertDirectory(directory);
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`refusing symbolic link in canary evidence path: ${entryPath}`);
+    }
+    if (entry.isDirectory()) assertTreeHasNoSymlinks(entryPath);
+  }
+};
+
+export const prepareEvidenceLayout = ({ evidence, commandDir, snapshotDir, home }) => {
+  fs.mkdirSync(evidence, { recursive: true });
+  assertDirectory(evidence);
+  for (const directory of [commandDir, snapshotDir, home]) {
+    fs.mkdirSync(directory, { recursive: true });
+    assertDirectory(directory);
+  }
+  assertTreeHasNoSymlinks(commandDir);
+  assertTreeHasNoSymlinks(snapshotDir);
+  assertTreeHasNoSymlinks(home);
+};
+
+export const writeJsonAtomic = (filePath, value) => {
+  assertDirectory(path.dirname(filePath));
+  const temporaryPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    fs.renameSync(temporaryPath, filePath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+};
+
+const artifactStem = (name, attempt) => (attempt === 1 ? name : `${name}-attempt-${attempt}`);
+
+export const openArtifactLogs = (directory, name) => {
+  assertDirectory(directory);
+  for (let attempt = 1; attempt < 10_000; attempt += 1) {
+    const stem = artifactStem(name, attempt);
+    const stdoutPath = path.join(directory, `${stem}.stdout.log`);
+    const stderrPath = path.join(directory, `${stem}.stderr.log`);
+    let stdout;
+    try {
+      stdout = fs.openSync(stdoutPath, 'wx', 0o600);
+      const stderr = fs.openSync(stderrPath, 'wx', 0o600);
+      return { stdoutPath, stderrPath, stdout, stderr };
+    } catch (error) {
+      if (stdout !== undefined) {
+        fs.closeSync(stdout);
+        fs.rmSync(stdoutPath, { force: true });
+      }
+      if (error?.code !== 'EEXIST') throw error;
+    }
+  }
+  throw new Error(`could not allocate unique command artifacts for ${name}`);
+};
+
+export const writeJsonArtifact = (directory, name, value) => {
+  assertDirectory(directory);
+  for (let attempt = 1; attempt < 10_000; attempt += 1) {
+    const filePath = path.join(directory, `${artifactStem(name, attempt)}.json`);
+    try {
+      fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600,
+      });
+      return filePath;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+    }
+  }
+  throw new Error(`could not allocate unique JSON artifact for ${name}`);
+};
+
+const isContained = (root, candidate) => {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+};
+
+const assertNoSymlinkComponents = (root, candidate) => {
+  const relative = path.relative(root, candidate);
+  let cursor = root;
+  for (const component of relative.split(path.sep).filter(Boolean)) {
+    cursor = path.join(cursor, component);
+    if (fs.lstatSync(cursor).isSymbolicLink()) {
+      throw new Error(`refusing symbolic link in canary worktree path: ${cursor}`);
+    }
+  }
+};
+
+export const createSafeContainedDirectory = (root, relativePath) => {
+  const resolvedRoot = path.resolve(root);
+  const candidate = path.resolve(resolvedRoot, relativePath);
+  if (!isContained(resolvedRoot, candidate) || candidate === resolvedRoot) {
+    throw new Error(`refusing directory outside canary worktree: ${relativePath}`);
+  }
+  if (fs.existsSync(candidate)) {
+    throw new Error(`refusing existing canary fixture directory: ${candidate}`);
+  }
+  let cursor = resolvedRoot;
+  for (const component of path.relative(resolvedRoot, candidate).split(path.sep)) {
+    cursor = path.join(cursor, component);
+    if (fs.existsSync(cursor)) {
+      const stat = fs.lstatSync(cursor);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`refusing symbolic link in canary worktree path: ${cursor}`);
+      }
+      if (!stat.isDirectory()) {
+        throw new Error(`refusing non-directory in canary worktree path: ${cursor}`);
+      }
+    } else {
+      fs.mkdirSync(cursor, { mode: 0o700 });
+    }
+  }
+  const realRoot = fs.realpathSync(resolvedRoot);
+  const realCandidate = fs.realpathSync(candidate);
+  if (!isContained(realRoot, realCandidate)) {
+    throw new Error(`refusing directory outside real canary worktree: ${relativePath}`);
+  }
+  return candidate;
+};
+
+export const selectSafeTrackedFiles = (worktree, files, count) => {
+  const realWorktree = fs.realpathSync(worktree);
+  const candidates = files.map((file) => {
+    if (!file || path.isAbsolute(file)) {
+      throw new Error(`refusing unsafe tracked path: ${JSON.stringify(file)}`);
+    }
+    const candidate = path.resolve(worktree, file);
+    if (!isContained(path.resolve(worktree), candidate)) {
+      throw new Error(`refusing tracked path outside canary worktree: ${file}`);
+    }
+    assertNoSymlinkComponents(path.resolve(worktree), candidate);
+    const stat = fs.lstatSync(candidate);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`refusing tracked symbolic link in canary mutation set: ${file}`);
+    }
+    if (!stat.isFile()) {
+      throw new Error(`refusing non-file in canary mutation set: ${file}`);
+    }
+    const realCandidate = fs.realpathSync(candidate);
+    if (!isContained(realWorktree, realCandidate)) {
+      throw new Error(`refusing tracked path outside real canary worktree: ${file}`);
+    }
+    return { file, bytes: stat.size };
+  });
+  return candidates
+    .sort((left, right) => left.bytes - right.bytes || codePointCompare(left.file, right.file))
+    .slice(0, count);
+};
+
+export class ChildSupervisor {
+  constructor({ platform = process.platform, killTimeoutMs = 5_000 } = {}) {
+    this.platform = platform;
+    this.killTimeoutMs = killTimeoutMs;
+    this.children = new Set();
+    this.receivedSignal = undefined;
+    this.signalHandlers = new Map();
+  }
+
+  spawn(command, args, options = {}) {
+    if (this.receivedSignal) {
+      throw new Error(`refusing child spawn after ${this.receivedSignal}`);
+    }
+    const child = spawn(command, args, {
+      ...options,
+      detached: this.platform !== 'win32',
+    });
+    this.children.add(child);
+    child.once('close', () => this.children.delete(child));
+    return child;
+  }
+
+  terminate(child, signal = 'SIGTERM') {
+    if (!child?.pid || child.exitCode !== null || child.signalCode !== null) return;
+    if (this.platform === 'win32') {
+      const result = spawnSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      if (result.error || result.status !== 0) child.kill(signal);
+      return;
+    }
+    try {
+      process.kill(-child.pid, signal);
+    } catch (error) {
+      if (error?.code !== 'ESRCH') child.kill(signal);
+    }
+  }
+
+  terminateAll(signal = 'SIGTERM') {
+    const children = [...this.children];
+    for (const child of children) this.terminate(child, signal);
+    if (children.length > 0) {
+      const timer = setTimeout(() => {
+        for (const child of this.children) this.terminate(child, 'SIGKILL');
+      }, this.killTimeoutMs);
+      timer.unref();
+    }
+  }
+
+  installSignalHandlers(targetProcess = process, onSignal = () => {}) {
+    for (const signal of ['SIGINT', 'SIGTERM']) {
+      const handler = () => {
+        if (this.receivedSignal) return;
+        this.receivedSignal = signal;
+        targetProcess.exitCode = SIGNAL_EXIT_CODES[signal];
+        this.terminateAll(signal);
+        onSignal(signal);
+      };
+      this.signalHandlers.set(signal, handler);
+      targetProcess.on(signal, handler);
+    }
+  }
+
+  disposeSignalHandlers(targetProcess = process) {
+    for (const [signal, handler] of this.signalHandlers) {
+      targetProcess.off(signal, handler);
+    }
+    this.signalHandlers.clear();
+  }
+}

--- a/gitnexus/scripts/reconciliation/canary-safety.mjs
+++ b/gitnexus/scripts/reconciliation/canary-safety.mjs
@@ -35,9 +35,7 @@ export const prepareEvidenceLayout = ({ evidence, commandDir, snapshotDir, home 
     fs.mkdirSync(directory, { recursive: true });
     assertDirectory(directory);
   }
-  assertTreeHasNoSymlinks(commandDir);
-  assertTreeHasNoSymlinks(snapshotDir);
-  assertTreeHasNoSymlinks(home);
+  assertTreeHasNoSymlinks(evidence);
 };
 
 export const writeJsonAtomic = (filePath, value) => {
@@ -181,9 +179,23 @@ export const selectSafeTrackedFiles = (worktree, files, count) => {
 };
 
 export class ChildSupervisor {
-  constructor({ platform = process.platform, killTimeoutMs = 5_000 } = {}) {
+  constructor({
+    platform = process.platform,
+    killTimeoutMs = 5_000,
+    terminationEnv,
+    spawnSyncImpl = spawnSync,
+  } = {}) {
     this.platform = platform;
     this.killTimeoutMs = killTimeoutMs;
+    this.terminationEnv = terminationEnv ?? {
+      SystemRoot: process.env.SystemRoot,
+      WINDIR: process.env.WINDIR,
+      COMSPEC: process.env.COMSPEC,
+      PATHEXT: process.env.PATHEXT,
+      TEMP: process.env.TEMP,
+      TMP: process.env.TMP,
+    };
+    this.spawnSyncImpl = spawnSyncImpl;
     this.children = new Set();
     this.receivedSignal = undefined;
     this.signalHandlers = new Map();
@@ -204,18 +216,49 @@ export class ChildSupervisor {
 
   terminate(child, signal = 'SIGTERM') {
     if (!child?.pid || child.exitCode !== null || child.signalCode !== null) return;
+    this.terminateProcessGroup(child.pid, signal, child);
+  }
+
+  terminateProcessGroup(pid, signal, directChild) {
     if (this.platform === 'win32') {
-      const result = spawnSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
-        stdio: 'ignore',
-        windowsHide: true,
-      });
-      if (result.error || result.status !== 0) child.kill(signal);
+      const systemRoot = this.terminationEnv.SystemRoot ?? this.terminationEnv.WINDIR;
+      let result;
+      if (systemRoot) {
+        try {
+          result = this.spawnSyncImpl(
+            path.win32.join(systemRoot, 'System32', 'taskkill.exe'),
+            ['/pid', String(pid), '/t', '/f'],
+            {
+              env: this.terminationEnv,
+              stdio: 'ignore',
+              windowsHide: true,
+            },
+          );
+        } catch (error) {
+          result = { error };
+        }
+      }
+      if (
+        (!result || result.error || result.status !== 0) &&
+        directChild &&
+        directChild.exitCode === null &&
+        directChild.signalCode === null
+      ) {
+        directChild.kill(signal);
+      }
       return;
     }
     try {
-      process.kill(-child.pid, signal);
+      process.kill(-pid, signal);
     } catch (error) {
-      if (error?.code !== 'ESRCH') child.kill(signal);
+      if (
+        error?.code !== 'ESRCH' &&
+        directChild &&
+        directChild.exitCode === null &&
+        directChild.signalCode === null
+      ) {
+        directChild.kill(signal);
+      }
     }
   }
 
@@ -223,10 +266,11 @@ export class ChildSupervisor {
     const children = [...this.children];
     for (const child of children) this.terminate(child, signal);
     if (children.length > 0) {
-      const timer = setTimeout(() => {
-        for (const child of this.children) this.terminate(child, 'SIGKILL');
+      setTimeout(() => {
+        for (const child of children) {
+          if (child.pid) this.terminateProcessGroup(child.pid, 'SIGKILL');
+        }
       }, this.killTimeoutMs);
-      timer.unref();
     }
   }
 

--- a/gitnexus/scripts/reconciliation/large-repository-canary.mjs
+++ b/gitnexus/scripts/reconciliation/large-repository-canary.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { spawn } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import http from 'node:http';
@@ -8,6 +7,15 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { createSanitizedEnvironment } from './canary-environment.mjs';
+import {
+  ChildSupervisor,
+  createSafeContainedDirectory,
+  openArtifactLogs,
+  prepareEvidenceLayout,
+  selectSafeTrackedFiles,
+  writeJsonArtifact,
+  writeJsonAtomic,
+} from './canary-safety.mjs';
 
 const REQUIRED_ARGS = [
   'source',
@@ -77,9 +85,7 @@ for (const requiredPath of [source, cli, incrementalChild, extensionSource]) {
   if (!fs.existsSync(requiredPath))
     throw new Error(`required path does not exist: ${requiredPath}`);
 }
-fs.mkdirSync(commandDir, { recursive: true });
-fs.mkdirSync(snapshotDir, { recursive: true });
-fs.mkdirSync(home, { recursive: true });
+prepareEvidenceLayout({ evidence, commandDir, snapshotDir, home });
 if (resumeFrom && fs.existsSync(failurePath)) {
   let archiveIndex = 1;
   let archivedFailurePath;
@@ -94,9 +100,7 @@ if (resumeFrom && fs.existsSync(failurePath)) {
 }
 fs.cpSync(extensionSource, path.join(home, '.lbdb', 'extension'), { recursive: true });
 
-const writeJson = (filePath, value) => {
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
-};
+const writeJson = writeJsonAtomic;
 
 const extensionFiles = [];
 const collectExtensionFiles = (dir) => {
@@ -121,26 +125,31 @@ const commandLedger =
     ? JSON.parse(fs.readFileSync(commandLedgerPath, 'utf8'))
     : [];
 const embeddingStats = { requests: 0, items: 0 };
+const childSupervisor = new ChildSupervisor();
 
 const run = async (name, command, commandArgs, options = {}) => {
-  const stdoutPath = path.join(commandDir, `${name}.stdout.log`);
-  const stderrPath = path.join(commandDir, `${name}.stderr.log`);
-  const stdout = fs.openSync(stdoutPath, 'w');
-  const stderr = fs.openSync(stderrPath, 'w');
+  const { stdoutPath, stderrPath, stdout, stderr } = openArtifactLogs(commandDir, name);
   const startedAt = new Date().toISOString();
   const startedMs = Date.now();
   process.stdout.write(`[${runId}] ${name}\n`);
-  const child = spawn(command, commandArgs, {
+  const child = childSupervisor.spawn(command, commandArgs, {
     cwd: options.cwd ?? worktree,
     env: options.env ?? baseEnv,
     stdio: ['ignore', stdout, stderr],
   });
-  const result = await new Promise((resolve, reject) => {
-    child.once('error', reject);
-    child.once('close', (code, signal) => resolve({ code, signal }));
-  });
-  fs.closeSync(stdout);
-  fs.closeSync(stderr);
+  let childError;
+  let result = { code: null, signal: null };
+  try {
+    result = await new Promise((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', (code, signal) => resolve({ code, signal }));
+    });
+  } catch (error) {
+    childError = error;
+  } finally {
+    fs.closeSync(stdout);
+    fs.closeSync(stderr);
+  }
   const entry = {
     name,
     command,
@@ -151,11 +160,13 @@ const run = async (name, command, commandArgs, options = {}) => {
     durationMs: Date.now() - startedMs,
     code: result.code,
     signal: result.signal,
+    error: childError instanceof Error ? childError.message : undefined,
     stdout: path.basename(stdoutPath),
     stderr: path.basename(stderrPath),
   };
   commandLedger.push(entry);
   writeJson(path.join(evidence, 'command-ledger.json'), commandLedger);
+  if (childError) throw childError;
   if (!options.allowFailure && (result.code !== 0 || result.signal !== null)) {
     throw new Error(`${name} failed with code=${result.code} signal=${result.signal}`);
   }
@@ -164,7 +175,7 @@ const run = async (name, command, commandArgs, options = {}) => {
 
 const runText = async (name, command, commandArgs, options = {}) => {
   const chunks = [];
-  const child = spawn(command, commandArgs, {
+  const child = childSupervisor.spawn(command, commandArgs, {
     cwd: options.cwd ?? worktree,
     env: options.env ?? baseEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -230,6 +241,7 @@ await new Promise((resolve, reject) => {
 });
 const address = embeddingServer.address();
 if (!address || typeof address === 'string') throw new Error('embedding server has no TCP address');
+childSupervisor.installSignalHandlers(process, () => embeddingServer.close());
 
 const canaryEnv = {
   ...baseEnv,
@@ -413,16 +425,22 @@ const snapshot = async (name, { fingerprint = false } = {}) => {
     index: { path: storagePath, sizeKb: indexKb, files },
     disk: disk.split(/\r?\n/).slice(-1)[0],
   };
-  writeJson(path.join(snapshotDir, `${name}.json`), result);
+  const snapshotPath = writeJsonArtifact(snapshotDir, name, result);
+  result.artifact = path.basename(snapshotPath);
   return result;
 };
 
 const waitForPauseAndTerminate = async (child, readyFile, timeoutMs) => {
   const deadline = Date.now() + timeoutMs;
+  let childError;
+  child.once('error', (error) => {
+    childError = error;
+  });
   while (Date.now() < deadline) {
+    if (childError) throw childError;
     if (fs.existsSync(readyFile)) {
       const dirty = JSON.parse(fs.readFileSync(readyFile, 'utf8'));
-      child.kill('SIGTERM');
+      childSupervisor.terminate(child, 'SIGTERM');
       const result = await new Promise((resolve) => {
         child.once('close', (code, signal) => resolve({ code, signal }));
       });
@@ -433,21 +451,18 @@ const waitForPauseAndTerminate = async (child, readyFile, timeoutMs) => {
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
-  child.kill('SIGKILL');
+  childSupervisor.terminate(child, 'SIGKILL');
   await new Promise((resolve) => child.once('close', resolve));
   throw new Error('timed out waiting for the escalation pause point');
 };
 
-const interruptAtEscalation = async () => {
-  const name = 'wide-interrupted';
-  const readyFile = path.join(evidence, 'pause-ready.json');
+const interruptAtRecoveryBoundary = async (boundary) => {
+  const name = `wide-interrupted-${boundary}`;
+  const readyFile = path.join(evidence, `pause-ready-${boundary}.json`);
   if (fs.existsSync(readyFile)) {
     throw new Error(`refusing stale escalation ready file: ${readyFile}`);
   }
-  const stdoutPath = path.join(commandDir, `${name}.stdout.log`);
-  const stderrPath = path.join(commandDir, `${name}.stderr.log`);
-  const stdout = fs.openSync(stdoutPath, 'w');
-  const stderr = fs.openSync(stderrPath, 'w');
+  const { stdoutPath, stderrPath, stdout, stderr } = openArtifactLogs(commandDir, name);
   const startedAt = new Date().toISOString();
   const startedMs = Date.now();
   process.stdout.write(`[${runId}] ${name}\n`);
@@ -455,10 +470,12 @@ const interruptAtEscalation = async () => {
     incrementalChild,
     worktree,
     '--embeddings',
-    '--pause-on-escalation',
+    '--pause-at',
+    boundary,
+    '--pause-ready',
     readyFile,
   ];
-  const child = spawn(process.execPath, childArgs, {
+  const child = childSupervisor.spawn(process.execPath, childArgs, {
     cwd: packageRoot,
     env: canaryEnv,
     stdio: ['ignore', stdout, stderr],
@@ -488,7 +505,9 @@ const interruptAtEscalation = async () => {
   commandLedger.push(entry);
   writeJson(path.join(evidence, 'command-ledger.json'), commandLedger);
   if (result.code === 0 || result.signal !== 'SIGTERM') {
-    throw new Error(`interrupted child did not fail by SIGTERM: ${JSON.stringify(result)}`);
+    throw new Error(
+      `child interrupted at ${boundary} did not fail by SIGTERM: ${JSON.stringify(result)}`,
+    );
   }
   return entry;
 };
@@ -606,11 +625,11 @@ try {
     const repeated = await snapshot('forced-repeat', { fingerprint: true });
     assertSnapshot(repeated, wideHead);
     const comparison = compareSnapshots(preflight, repeated);
-    writeJson(path.join(evidence, 'forced-repeat-comparison.json'), comparison);
+    writeJsonArtifact(evidence, 'forced-repeat-comparison', comparison);
     if (!comparison.equal) {
       throw new Error('consecutive forced rebuilds produced different graph fingerprints');
     }
-    writeJson(path.join(evidence, 'forced-repeat-summary.json'), {
+    writeJsonArtifact(evidence, 'forced-repeat-summary', {
       runId,
       result: 'passed',
       sourceSha,
@@ -683,8 +702,7 @@ try {
         },
       );
 
-      const fixtureRoot = path.join(worktree, 'src/r19-canary');
-      fs.mkdirSync(fixtureRoot, { recursive: true });
+      const fixtureRoot = createSafeContainedDirectory(worktree, 'src/r19-canary');
       fs.writeFileSync(
         path.join(fixtureRoot, 'hub.ts'),
         'export function r19CanaryHub(value: number): number {\n  return value + 19;\n}\n',
@@ -756,12 +774,10 @@ try {
         },
       );
 
-      const tracked = (await runText('tracked-typescript', 'git', ['ls-files', '*.ts']))
-        .split(/\r?\n/)
-        .filter((file) => file && !file.startsWith('src/r19-canary/'))
-        .map((file) => ({ file, bytes: fs.statSync(path.join(worktree, file)).size }))
-        .sort((left, right) => left.bytes - right.bytes || left.file.localeCompare(right.file))
-        .slice(0, 51);
+      const trackedFiles = (await runText('tracked-typescript', 'git', ['ls-files', '-z', '*.ts']))
+        .split('\0')
+        .filter((file) => file && !file.startsWith('src/r19-canary/'));
+      const tracked = selectSafeTrackedFiles(worktree, trackedFiles, 51);
       if (tracked.length !== 51)
         throw new Error(`expected 51 TypeScript files, found ${tracked.length}`);
       tracked.forEach(({ file }, index) => {
@@ -772,8 +788,11 @@ try {
       wideHead = await runText('wide-head', 'git', ['rev-parse', 'HEAD']);
     }
 
-    const interrupted = await interruptAtEscalation();
-    if (interrupted.dirty?.dirty?.phase !== 'effective-write-set') {
+    const interrupted = await interruptAtRecoveryBoundary('during-delete');
+    if (interrupted.dirty?.boundary !== 'during-delete') {
+      throw new Error(`unexpected recovery boundary: ${JSON.stringify(interrupted.dirty)}`);
+    }
+    if (interrupted.dirty?.dirty?.phase !== 'escalated-full-write') {
       throw new Error(`unexpected dirty phase: ${JSON.stringify(interrupted.dirty)}`);
     }
     if (Number(interrupted.dirty?.dirty?.effectiveWriteCount ?? 0) < 50) {
@@ -802,7 +821,7 @@ try {
     const forced = await snapshot('forced', { fingerprint: true });
     assertSnapshot(forced, wideHead);
     const recoveredForcedComparison = compareSnapshots(recovered, forced);
-    writeJson(path.join(evidence, 'recovered-forced-comparison.json'), recoveredForcedComparison);
+    writeJsonArtifact(evidence, 'recovered-forced-comparison', recoveredForcedComparison);
     if (!recoveredForcedComparison.equal) {
       throw new Error('recovered and forced graphs produced different fingerprints');
     }
@@ -849,7 +868,8 @@ try {
   process.stderr.write(
     `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
   );
-  process.exitCode = 1;
+  if (!process.exitCode) process.exitCode = 1;
 } finally {
+  childSupervisor.disposeSignalHandlers();
   await new Promise((resolve) => embeddingServer.close(resolve));
 }

--- a/gitnexus/scripts/reconciliation/large-repository-canary.mjs
+++ b/gitnexus/scripts/reconciliation/large-repository-canary.mjs
@@ -1,0 +1,854 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const REQUIRED_ARGS = [
+  'source',
+  'source-sha',
+  'public-origin',
+  'worktree',
+  'evidence',
+  'gitnexus-cli',
+  'incremental-child',
+  'extension-source',
+  'run-id',
+];
+
+const parseArgs = (argv) => {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]?.replace(/^--/, '');
+    const value = argv[index + 1];
+    if (!key || !value || !argv[index].startsWith('--')) {
+      throw new Error(`invalid argument sequence near ${argv[index] ?? '<end>'}`);
+    }
+    result[key] = value;
+  }
+  for (const key of REQUIRED_ARGS) {
+    if (!result[key]) throw new Error(`missing required --${key}`);
+  }
+  return result;
+};
+
+const args = parseArgs(process.argv.slice(2));
+const source = path.resolve(args.source);
+const sourceSha = args['source-sha'];
+const publicOrigin = args['public-origin'];
+const worktree = path.resolve(args.worktree);
+const evidence = path.resolve(args.evidence);
+const cli = path.resolve(args['gitnexus-cli']);
+const incrementalChild = path.resolve(args['incremental-child']);
+const extensionSource = path.resolve(args['extension-source']);
+const runId = args['run-id'];
+const dimensions = Number(args['embedding-dims'] ?? '8');
+const model = args['embedding-model'] ?? 'gitnexus-canary-deterministic-v1';
+const resumeFrom = args['resume-from'];
+const escalationTimeoutMs = Number(args['escalation-timeout-ms'] ?? '21600000');
+const packageRoot = path.resolve(path.dirname(cli), '../..');
+const home = path.join(evidence, 'home');
+const commandDir = path.join(evidence, 'commands');
+const snapshotDir = path.join(evidence, 'snapshots');
+const failurePath = path.join(evidence, 'failure.json');
+
+if (!Number.isInteger(dimensions) || dimensions <= 0) {
+  throw new Error('--embedding-dims must be a positive integer');
+}
+if (resumeFrom && !['wide', 'forced'].includes(resumeFrom)) {
+  throw new Error('--resume-from currently supports only "wide" or "forced"');
+}
+if (!Number.isInteger(escalationTimeoutMs) || escalationTimeoutMs <= 0) {
+  throw new Error('--escalation-timeout-ms must be a positive integer');
+}
+if (!resumeFrom && fs.existsSync(worktree)) {
+  throw new Error(`refusing existing canary worktree: ${worktree}`);
+}
+if (resumeFrom && !fs.existsSync(worktree)) {
+  throw new Error(`cannot resume missing canary worktree: ${worktree}`);
+}
+for (const requiredPath of [source, cli, incrementalChild, extensionSource]) {
+  if (!fs.existsSync(requiredPath))
+    throw new Error(`required path does not exist: ${requiredPath}`);
+}
+fs.mkdirSync(commandDir, { recursive: true });
+fs.mkdirSync(snapshotDir, { recursive: true });
+fs.mkdirSync(home, { recursive: true });
+if (resumeFrom && fs.existsSync(failurePath)) {
+  let archiveIndex = 1;
+  let archivedFailurePath;
+  do {
+    archivedFailurePath = path.join(evidence, `failure-before-resume-${archiveIndex}.json`);
+    archiveIndex += 1;
+  } while (fs.existsSync(archivedFailurePath));
+  if (!archivedFailurePath) {
+    throw new Error('failed to allocate archived failure path');
+  }
+  fs.renameSync(failurePath, archivedFailurePath);
+}
+fs.cpSync(extensionSource, path.join(home, '.lbdb', 'extension'), { recursive: true });
+
+const writeJson = (filePath, value) => {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+};
+
+const extensionFiles = [];
+const collectExtensionFiles = (dir) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) collectExtensionFiles(fullPath);
+    if (entry.isFile()) {
+      extensionFiles.push({
+        path: path.relative(extensionSource, fullPath),
+        bytes: fs.statSync(fullPath).size,
+        sha256: crypto.createHash('sha256').update(fs.readFileSync(fullPath)).digest('hex'),
+      });
+    }
+  }
+};
+collectExtensionFiles(extensionSource);
+writeJson(path.join(evidence, 'extension-manifest.json'), extensionFiles);
+
+const commandLedgerPath = path.join(evidence, 'command-ledger.json');
+const commandLedger =
+  resumeFrom && fs.existsSync(commandLedgerPath)
+    ? JSON.parse(fs.readFileSync(commandLedgerPath, 'utf8'))
+    : [];
+const embeddingStats = { requests: 0, items: 0 };
+
+const run = async (name, command, commandArgs, options = {}) => {
+  const stdoutPath = path.join(commandDir, `${name}.stdout.log`);
+  const stderrPath = path.join(commandDir, `${name}.stderr.log`);
+  const stdout = fs.openSync(stdoutPath, 'w');
+  const stderr = fs.openSync(stderrPath, 'w');
+  const startedAt = new Date().toISOString();
+  const startedMs = Date.now();
+  process.stdout.write(`[${runId}] ${name}\n`);
+  const child = spawn(command, commandArgs, {
+    cwd: options.cwd ?? worktree,
+    env: options.env ?? process.env,
+    stdio: ['ignore', stdout, stderr],
+  });
+  const result = await new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, signal) => resolve({ code, signal }));
+  });
+  fs.closeSync(stdout);
+  fs.closeSync(stderr);
+  const entry = {
+    name,
+    command,
+    args: commandArgs,
+    cwd: options.cwd ?? worktree,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    durationMs: Date.now() - startedMs,
+    code: result.code,
+    signal: result.signal,
+    stdout: path.basename(stdoutPath),
+    stderr: path.basename(stderrPath),
+  };
+  commandLedger.push(entry);
+  writeJson(path.join(evidence, 'command-ledger.json'), commandLedger);
+  if (!options.allowFailure && (result.code !== 0 || result.signal !== null)) {
+    throw new Error(`${name} failed with code=${result.code} signal=${result.signal}`);
+  }
+  return entry;
+};
+
+const runText = async (name, command, commandArgs, options = {}) => {
+  const chunks = [];
+  const child = spawn(command, commandArgs, {
+    cwd: options.cwd ?? worktree,
+    env: options.env ?? process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', (chunk) => chunks.push(chunk));
+  const errors = [];
+  child.stderr.on('data', (chunk) => errors.push(chunk));
+  const result = await new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, signal) => resolve({ code, signal }));
+  });
+  if (result.code !== 0 || result.signal !== null) {
+    throw new Error(`${name} failed: ${Buffer.concat(errors).toString('utf8').trim()}`);
+  }
+  return Buffer.concat(chunks).toString('utf8').trim();
+};
+
+const deterministicVector = (text) => {
+  const digest = crypto.createHash('sha256').update(text).digest();
+  const vector = Array.from({ length: dimensions }, (_, index) => digest[index] / 127.5 - 1);
+  const magnitude = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0)) || 1;
+  return vector.map((value) => value / magnitude);
+};
+
+const embeddingServer = http.createServer((request, response) => {
+  if (request.method !== 'POST' || request.url !== '/v1/embeddings') {
+    response.writeHead(404).end();
+    return;
+  }
+  const chunks = [];
+  request.on('data', (chunk) => chunks.push(chunk));
+  request.on('end', () => {
+    try {
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      const inputs = Array.isArray(body.input) ? body.input : [body.input];
+      if (!inputs.every((input) => typeof input === 'string')) {
+        throw new Error('input must be a string or string array');
+      }
+      embeddingStats.requests += 1;
+      embeddingStats.items += inputs.length;
+      const payload = {
+        object: 'list',
+        model,
+        data: inputs.map((input, index) => ({
+          object: 'embedding',
+          index,
+          embedding: deterministicVector(input),
+        })),
+        usage: { prompt_tokens: 0, total_tokens: 0 },
+      };
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify(payload));
+    } catch (error) {
+      response.writeHead(400, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: { message: error.message } }));
+    }
+  });
+});
+
+await new Promise((resolve, reject) => {
+  embeddingServer.once('error', reject);
+  embeddingServer.listen(0, '127.0.0.1', resolve);
+});
+const address = embeddingServer.address();
+if (!address || typeof address === 'string') throw new Error('embedding server has no TCP address');
+
+const canaryEnv = {
+  ...process.env,
+  HOME: home,
+  USERPROFILE: home,
+  GITNEXUS_HOME: path.join(home, '.gitnexus'),
+  CI: '1',
+  NODE_OPTIONS: '--max-old-space-size=6144',
+  GITNEXUS_WORKER_POOL_SIZE: '2',
+  GITNEXUS_PARSE_CHUNK_CONCURRENCY: '1',
+  GITNEXUS_LBUG_EXTENSION_INSTALL: 'load-only',
+  GITNEXUS_EMBEDDING_URL: `http://127.0.0.1:${address.port}/v1`,
+  GITNEXUS_EMBEDDING_MODEL: model,
+  GITNEXUS_EMBEDDING_DIMS: String(dimensions),
+  GITNEXUS_EMBEDDING_BATCH_SIZE: '256',
+  GITNEXUS_EMBEDDING_SUB_BATCH_SIZE: '256',
+  GITNEXUS_EMBEDDING_MAX_ATTEMPTS: '3',
+  GITNEXUS_EMBEDDING_RETRY_CAP_MS: '1000',
+  GITNEXUS_EMBEDDING_MIN_INTERVAL_MS: '0',
+};
+
+const commitAll = async (message) => {
+  await run(`git-add-${commandLedger.length}`, 'git', ['add', '-A']);
+  await run(`git-commit-${commandLedger.length}`, 'git', [
+    '-c',
+    'user.name=GitNexus Canary',
+    '-c',
+    'user.email=canary@example.invalid',
+    '-c',
+    'commit.gpgsign=false',
+    'commit',
+    '-q',
+    '-m',
+    message,
+  ]);
+};
+
+const snapshot = async (name, { fingerprint = false } = {}) => {
+  const repoManager = await import(
+    pathToFileURL(path.join(packageRoot, 'dist/storage/repo-manager.js')).href
+  );
+  const adapter = await import(
+    pathToFileURL(path.join(packageRoot, 'dist/core/lbug/lbug-adapter.js')).href
+  );
+  const schema = await import(
+    pathToFileURL(path.join(packageRoot, 'dist/core/lbug/schema.js')).href
+  );
+  const { storagePath, lbugPath } = repoManager.getStoragePaths(worktree);
+  const meta = await repoManager.loadMeta(storagePath);
+  const status = await runText(`status-${name}`, 'git', ['status', '--porcelain=v1']);
+  const head = await runText(`head-${name}`, 'git', ['rev-parse', 'HEAD']);
+  const disk = await runText(`disk-${name}`, 'df', ['-k', path.dirname(worktree)]);
+  const indexKb = Number(
+    await runText(`du-${name}`, 'du', ['-sk', storagePath]).then((text) => text.split(/\s+/)[0]),
+  );
+  const files = fs.existsSync(storagePath)
+    ? fs
+        .readdirSync(storagePath)
+        .sort()
+        .map((file) => {
+          const stat = fs.statSync(path.join(storagePath, file));
+          return { file, bytes: stat.size, directory: stat.isDirectory() };
+        })
+    : [];
+  let database = null;
+  if (fs.existsSync(lbugPath)) {
+    await adapter.initLbug(lbugPath);
+    try {
+      const nodes = await adapter.executeQuery('MATCH (n) RETURN count(n) AS count');
+      const edges = await adapter.executeQuery('MATCH ()-[r]->() RETURN count(r) AS count');
+      const embeddings = await adapter.executeQuery(
+        'MATCH (e:CodeEmbedding) RETURN count(e) AS count',
+      );
+      const embeddingDimensions = await adapter.executeQuery(
+        'MATCH (e:CodeEmbedding) RETURN DISTINCT size(e.embedding) AS dimensions ORDER BY dimensions',
+      );
+      let graphFingerprint = null;
+      if (fingerprint) {
+        const nodeTables = {};
+        for (const table of schema.NODE_TABLES) {
+          const countRows = await adapter.executeQuery(
+            `MATCH (n:\`${table}\`) RETURN count(n) AS count`,
+          );
+          const digest = crypto.createHash('sha256');
+          const streamed = await adapter.streamQuery(
+            `MATCH (n:\`${table}\`) RETURN n.id AS id ORDER BY id`,
+            (row) => digest.update(`${JSON.stringify(String(row.id ?? ''))}\n`),
+          );
+          const count = Number(countRows[0]?.count ?? 0);
+          if (streamed !== count) {
+            throw new Error(
+              `${name}: ${table} fingerprint streamed ${streamed} rows, expected ${count}`,
+            );
+          }
+          nodeTables[table] = { count, idSha256: digest.digest('hex') };
+        }
+        const relationshipTypes = await adapter.executeQuery(
+          `MATCH ()-[r:${schema.REL_TABLE_NAME}]->() ` +
+            'RETURN r.type AS type, count(r) AS count ORDER BY type',
+        );
+        const relationshipPairs = await adapter.executeQuery(
+          `MATCH (source)-[r:${schema.REL_TABLE_NAME}]->(target) ` +
+            'RETURN labels(source) AS sourceLabel, r.type AS type, ' +
+            'labels(target) AS targetLabel, count(r) AS count ' +
+            'ORDER BY type, sourceLabel, targetLabel',
+        );
+        const relationshipIdentityDigests = new Map();
+        const relationshipIdentityCounts = new Map();
+        await adapter.streamQuery(
+          `MATCH (source)-[r:${schema.REL_TABLE_NAME}]->(target) ` +
+            'RETURN labels(source) AS sourceLabel, source.id AS sourceId, ' +
+            'r.type AS type, labels(target) AS targetLabel, target.id AS targetId, ' +
+            'r.confidence AS confidence, r.reason AS reason, r.step AS step ' +
+            'ORDER BY type, sourceLabel, sourceId, targetLabel, targetId, ' +
+            'confidence, reason, step',
+          (row) => {
+            const type = String(row.type);
+            let digest = relationshipIdentityDigests.get(type);
+            if (!digest) {
+              digest = crypto.createHash('sha256');
+              relationshipIdentityDigests.set(type, digest);
+            }
+            digest.update(
+              `${JSON.stringify([
+                String(row.sourceLabel),
+                String(row.sourceId),
+                String(row.targetLabel),
+                String(row.targetId),
+                Number(row.confidence),
+                String(row.reason ?? ''),
+                Number(row.step),
+              ])}\n`,
+            );
+            relationshipIdentityCounts.set(type, (relationshipIdentityCounts.get(type) ?? 0) + 1);
+          },
+        );
+        const relationshipIdentities = Array.from(relationshipIdentityDigests.entries())
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([type, digest]) => ({
+            type,
+            count: relationshipIdentityCounts.get(type) ?? 0,
+            sha256: digest.digest('hex'),
+          }));
+        graphFingerprint = {
+          nodeTables,
+          relationshipTypes: relationshipTypes.map((row) => ({
+            type: String(row.type),
+            count: Number(row.count),
+          })),
+          relationshipPairs: relationshipPairs.map((row) => ({
+            sourceLabel: String(row.sourceLabel),
+            type: String(row.type),
+            targetLabel: String(row.targetLabel),
+            count: Number(row.count),
+          })),
+          relationshipIdentities,
+        };
+      }
+      database = {
+        nodes: Number(nodes[0]?.count ?? 0),
+        edges: Number(edges[0]?.count ?? 0),
+        embeddings: Number(embeddings[0]?.count ?? 0),
+        embeddingDimensions: embeddingDimensions.map((row) => Number(row.dimensions)),
+        graphFingerprint,
+      };
+    } finally {
+      await adapter.closeLbug();
+    }
+  }
+  const result = {
+    name,
+    at: new Date().toISOString(),
+    runId,
+    sourceSha,
+    head,
+    gitStatus: {
+      clean: status.length === 0,
+      entryCount: status.length === 0 ? 0 : status.split(/\r?\n/).length,
+    },
+    embedding: { model, dimensions, server: { ...embeddingStats } },
+    metadata: meta ?? null,
+    database,
+    index: { path: storagePath, sizeKb: indexKb, files },
+    disk: disk.split(/\r?\n/).slice(-1)[0],
+  };
+  writeJson(path.join(snapshotDir, `${name}.json`), result);
+  return result;
+};
+
+const waitForPauseAndTerminate = async (child, readyFile, timeoutMs) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(readyFile)) {
+      const dirty = JSON.parse(fs.readFileSync(readyFile, 'utf8'));
+      child.kill('SIGTERM');
+      const result = await new Promise((resolve) => {
+        child.once('close', (code, signal) => resolve({ code, signal }));
+      });
+      return { dirty, ...result };
+    }
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error('incremental child exited before the escalation pause point');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  child.kill('SIGKILL');
+  await new Promise((resolve) => child.once('close', resolve));
+  throw new Error('timed out waiting for the escalation pause point');
+};
+
+const interruptAtEscalation = async () => {
+  const name = 'wide-interrupted';
+  const readyFile = path.join(evidence, 'pause-ready.json');
+  if (fs.existsSync(readyFile)) {
+    throw new Error(`refusing stale escalation ready file: ${readyFile}`);
+  }
+  const stdoutPath = path.join(commandDir, `${name}.stdout.log`);
+  const stderrPath = path.join(commandDir, `${name}.stderr.log`);
+  const stdout = fs.openSync(stdoutPath, 'w');
+  const stderr = fs.openSync(stderrPath, 'w');
+  const startedAt = new Date().toISOString();
+  const startedMs = Date.now();
+  process.stdout.write(`[${runId}] ${name}\n`);
+  const childArgs = [
+    incrementalChild,
+    worktree,
+    '--embeddings',
+    '--pause-on-escalation',
+    readyFile,
+  ];
+  const child = spawn(process.execPath, childArgs, {
+    cwd: packageRoot,
+    env: canaryEnv,
+    stdio: ['ignore', stdout, stderr],
+  });
+  let result;
+  try {
+    result = await waitForPauseAndTerminate(child, readyFile, escalationTimeoutMs);
+  } finally {
+    fs.closeSync(stdout);
+    fs.closeSync(stderr);
+  }
+  const entry = {
+    name,
+    command: process.execPath,
+    args: childArgs,
+    cwd: packageRoot,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    durationMs: Date.now() - startedMs,
+    timeoutMs: escalationTimeoutMs,
+    code: result.code,
+    signal: result.signal,
+    dirty: result.dirty,
+    stdout: path.basename(stdoutPath),
+    stderr: path.basename(stderrPath),
+  };
+  commandLedger.push(entry);
+  writeJson(path.join(evidence, 'command-ledger.json'), commandLedger);
+  if (result.code === 0 || result.signal !== 'SIGTERM') {
+    throw new Error(`interrupted child did not fail by SIGTERM: ${JSON.stringify(result)}`);
+  }
+  return entry;
+};
+
+const assertSnapshot = (value, expectedHead) => {
+  if (value.head !== expectedHead) throw new Error(`${value.name}: metadata head mismatch`);
+  if (value.metadata?.lastCommit !== expectedHead) {
+    throw new Error(`${value.name}: persisted commit does not match repository head`);
+  }
+  if (!value.gitStatus.clean) throw new Error(`${value.name}: repository worktree is not clean`);
+  if (value.metadata?.incrementalInProgress) {
+    throw new Error(`${value.name}: dirty marker remained after successful analysis`);
+  }
+  if (!value.database || value.database.nodes <= 0 || value.database.edges <= 0) {
+    throw new Error(`${value.name}: graph is empty`);
+  }
+  if (value.database.embeddings <= 0) throw new Error(`${value.name}: embeddings are empty`);
+  if (JSON.stringify(value.database.embeddingDimensions) !== JSON.stringify([dimensions])) {
+    throw new Error(`${value.name}: unexpected embedding dimensions`);
+  }
+  if (Number(value.metadata?.stats?.embeddings ?? -1) !== value.database.embeddings) {
+    throw new Error(`${value.name}: metadata/database embedding counts differ`);
+  }
+  if (value.metadata?.capabilities?.fts?.status !== 'available') {
+    throw new Error(`${value.name}: FTS capability is not available`);
+  }
+  if (value.metadata?.capabilities?.vectorSearch?.status !== 'vector-index') {
+    throw new Error(`${value.name}: VECTOR capability is not vector-index`);
+  }
+};
+
+const compareSnapshots = (left, right) => {
+  const metadata = {};
+  for (const key of ['files', 'nodes', 'edges', 'communities', 'processes', 'embeddings']) {
+    const leftValue = Number(left.metadata?.stats?.[key] ?? -1);
+    const rightValue = Number(right.metadata?.stats?.[key] ?? -1);
+    if (leftValue !== rightValue) metadata[key] = { left: leftValue, right: rightValue };
+  }
+  const leftFingerprint = left.database?.graphFingerprint;
+  const rightFingerprint = right.database?.graphFingerprint;
+  if (!leftFingerprint || !rightFingerprint) {
+    return { equal: false, metadata, fingerprint: { missing: true } };
+  }
+  const nodeTables = {};
+  for (const table of Object.keys(leftFingerprint.nodeTables)) {
+    const leftTable = leftFingerprint.nodeTables[table];
+    const rightTable = rightFingerprint.nodeTables[table];
+    if (leftTable?.count !== rightTable?.count || leftTable?.idSha256 !== rightTable?.idSha256) {
+      nodeTables[table] = { left: leftTable ?? null, right: rightTable ?? null };
+    }
+  }
+  const relationshipTypesEqual =
+    JSON.stringify(leftFingerprint.relationshipTypes) ===
+    JSON.stringify(rightFingerprint.relationshipTypes);
+  const relationshipPairsEqual =
+    JSON.stringify(leftFingerprint.relationshipPairs) ===
+    JSON.stringify(rightFingerprint.relationshipPairs);
+  const relationshipIdentitiesEqual =
+    JSON.stringify(leftFingerprint.relationshipIdentities) ===
+    JSON.stringify(rightFingerprint.relationshipIdentities);
+  return {
+    equal:
+      Object.keys(metadata).length === 0 &&
+      Object.keys(nodeTables).length === 0 &&
+      relationshipTypesEqual &&
+      relationshipPairsEqual &&
+      relationshipIdentitiesEqual,
+    metadata,
+    fingerprint: {
+      nodeTables,
+      relationshipTypes: relationshipTypesEqual
+        ? null
+        : {
+            left: leftFingerprint.relationshipTypes,
+            right: rightFingerprint.relationshipTypes,
+          },
+      relationshipPairs: relationshipPairsEqual
+        ? null
+        : {
+            left: leftFingerprint.relationshipPairs,
+            right: rightFingerprint.relationshipPairs,
+          },
+      relationshipIdentities: relationshipIdentitiesEqual
+        ? null
+        : {
+            left: leftFingerprint.relationshipIdentities,
+            right: rightFingerprint.relationshipIdentities,
+          },
+    },
+  };
+};
+
+try {
+  if (resumeFrom === 'forced') {
+    const forcedPath = path.join(snapshotDir, 'forced.json');
+    if (!fs.existsSync(forcedPath)) {
+      throw new Error('forced resume requires the original forced snapshot');
+    }
+    const originalForced = JSON.parse(fs.readFileSync(forcedPath, 'utf8'));
+    if (originalForced.runId !== runId || originalForced.sourceSha !== sourceSha) {
+      throw new Error('forced resume snapshot does not match this run or source SHA');
+    }
+    const wideHead = await runText('forced-repeat-head', 'git', ['rev-parse', 'HEAD']);
+    const preflight = await snapshot('forced-repeat-preflight', { fingerprint: true });
+    assertSnapshot(preflight, wideHead);
+    if (preflight.metadata?.lastCommit !== originalForced.metadata?.lastCommit) {
+      throw new Error('forced repeat preflight does not match the original forced commit');
+    }
+    await run(
+      'forced-repeat-rebuild',
+      process.execPath,
+      [incrementalChild, worktree, '--force', '--embeddings', '--fts-query', 'r19CanaryNeedleV2'],
+      { cwd: packageRoot, env: canaryEnv },
+    );
+    const repeated = await snapshot('forced-repeat', { fingerprint: true });
+    assertSnapshot(repeated, wideHead);
+    const comparison = compareSnapshots(preflight, repeated);
+    writeJson(path.join(evidence, 'forced-repeat-comparison.json'), comparison);
+    if (!comparison.equal) {
+      throw new Error('consecutive forced rebuilds produced different graph fingerprints');
+    }
+    writeJson(path.join(evidence, 'forced-repeat-summary.json'), {
+      runId,
+      result: 'passed',
+      sourceSha,
+      finalHead: wideHead,
+      preflight: preflight.metadata.stats,
+      repeated: repeated.metadata.stats,
+      comparison,
+    });
+    process.stdout.write(`[${runId}] forced repeat passed\n`);
+  } else {
+    let initial;
+    let controlled;
+    let wideHead;
+    if (resumeFrom === 'wide') {
+      const initialPath = path.join(snapshotDir, 'initial.json');
+      const controlledPath = path.join(snapshotDir, 'controlled-change.json');
+      if (!fs.existsSync(initialPath) || !fs.existsSync(controlledPath)) {
+        throw new Error('wide resume requires initial and controlled-change snapshots');
+      }
+      initial = JSON.parse(fs.readFileSync(initialPath, 'utf8'));
+      controlled = JSON.parse(fs.readFileSync(controlledPath, 'utf8'));
+      if (initial.runId !== runId || controlled.runId !== runId) {
+        throw new Error('wide resume snapshots do not belong to this run');
+      }
+      if (initial.sourceSha !== sourceSha || controlled.sourceSha !== sourceSha) {
+        throw new Error('wide resume snapshots do not match the requested source SHA');
+      }
+      if (!fs.existsSync(path.join(evidence, 'wide-write-set.json'))) {
+        throw new Error('wide resume requires the recorded write set');
+      }
+      wideHead = await runText('wide-resume-head', 'git', ['rev-parse', 'HEAD']);
+      const preflight = await snapshot('wide-resume-preflight');
+      if (!preflight.gitStatus.clean) throw new Error('wide resume worktree is not clean');
+      if (preflight.metadata?.incrementalInProgress) {
+        throw new Error('wide resume refuses an existing dirty marker');
+      }
+      if (preflight.metadata?.lastCommit !== controlled.head || wideHead === controlled.head) {
+        throw new Error('wide resume does not match the controlled-to-wide boundary');
+      }
+    } else {
+      await run('clone', 'git', ['clone', '--shared', '--no-checkout', source, worktree], {
+        cwd: path.dirname(worktree),
+        env: process.env,
+      });
+      await run('checkout-source-sha', 'git', ['checkout', '--detach', sourceSha]);
+      await run('set-public-origin', 'git', ['remote', 'set-url', 'origin', publicOrigin]);
+      const checkedOut = await runText('verify-source-sha', 'git', ['rev-parse', 'HEAD']);
+      if (checkedOut !== sourceSha) throw new Error(`source SHA mismatch: ${checkedOut}`);
+      const initialStatus = await runText('verify-initial-clean', 'git', [
+        'status',
+        '--porcelain=v1',
+      ]);
+      if (initialStatus) throw new Error('fresh canary clone is not clean');
+
+      await run(
+        'initial-analyze',
+        process.execPath,
+        [cli, 'analyze', worktree, '--embeddings', '0', '--workers', '2', '--index-only'],
+        { cwd: packageRoot, env: canaryEnv },
+      );
+      initial = await snapshot('initial');
+      assertSnapshot(initial, sourceSha);
+      await run(
+        'initial-query',
+        process.execPath,
+        [cli, 'query', 'gateway authentication', '-r', worktree],
+        {
+          cwd: packageRoot,
+          env: canaryEnv,
+        },
+      );
+
+      const fixtureRoot = path.join(worktree, 'src/r19-canary');
+      fs.mkdirSync(fixtureRoot, { recursive: true });
+      fs.writeFileSync(
+        path.join(fixtureRoot, 'hub.ts'),
+        'export function r19CanaryHub(value: number): number {\n  return value + 19;\n}\n',
+      );
+      fs.writeFileSync(
+        path.join(fixtureRoot, 'spoke-a.ts'),
+        "import { r19CanaryHub } from './hub.js';\nexport const r19CanaryNeedle = r19CanaryHub(1);\n",
+      );
+      fs.writeFileSync(
+        path.join(fixtureRoot, 'spoke-b.ts'),
+        "import { r19CanaryHub } from './hub.js';\nexport const r19CanarySecondary = r19CanaryHub(2);\n",
+      );
+      await commitAll('r19 controlled add');
+      await run(
+        'controlled-add-analyze',
+        process.execPath,
+        [incrementalChild, worktree, '--embeddings', '--fts-query', 'r19CanaryNeedle'],
+        { cwd: packageRoot, env: canaryEnv },
+      );
+      const afterAddHead = await runText('after-add-head', 'git', ['rev-parse', 'HEAD']);
+      const afterAdd = await snapshot('controlled-add');
+      assertSnapshot(afterAdd, afterAddHead);
+
+      fs.appendFileSync(path.join(fixtureRoot, 'hub.ts'), '\n// r19 controlled edit\n');
+      fs.renameSync(
+        path.join(fixtureRoot, 'spoke-a.ts'),
+        path.join(fixtureRoot, 'spoke-renamed.ts'),
+      );
+      fs.rmSync(path.join(fixtureRoot, 'spoke-b.ts'));
+      fs.writeFileSync(
+        path.join(fixtureRoot, 'spoke-c.ts'),
+        "import { r19CanaryHub } from './hub.js';\nexport const r19CanaryNeedleV2 = r19CanaryHub(3);\n",
+      );
+      await commitAll('r19 controlled edit rename delete add');
+      await run(
+        'controlled-change-analyze',
+        process.execPath,
+        [incrementalChild, worktree, '--embeddings', '--fts-query', 'r19CanaryNeedleV2'],
+        { cwd: packageRoot, env: canaryEnv },
+      );
+      const controlledHead = await runText('controlled-head', 'git', ['rev-parse', 'HEAD']);
+      controlled = await snapshot('controlled-change');
+      assertSnapshot(controlled, controlledHead);
+      await run(
+        'controlled-query',
+        process.execPath,
+        [cli, 'query', 'r19CanaryNeedleV2', '-r', worktree],
+        {
+          cwd: packageRoot,
+          env: canaryEnv,
+        },
+      );
+      await run(
+        'controlled-context',
+        process.execPath,
+        [cli, 'context', 'r19CanaryHub', '-r', worktree],
+        {
+          cwd: packageRoot,
+          env: canaryEnv,
+        },
+      );
+      await run(
+        'controlled-impact',
+        process.execPath,
+        [cli, 'impact', 'r19CanaryHub', '-r', worktree],
+        {
+          cwd: packageRoot,
+          env: canaryEnv,
+        },
+      );
+
+      const tracked = (await runText('tracked-typescript', 'git', ['ls-files', '*.ts']))
+        .split(/\r?\n/)
+        .filter((file) => file && !file.startsWith('src/r19-canary/'))
+        .map((file) => ({ file, bytes: fs.statSync(path.join(worktree, file)).size }))
+        .sort((left, right) => left.bytes - right.bytes || left.file.localeCompare(right.file))
+        .slice(0, 51);
+      if (tracked.length !== 51)
+        throw new Error(`expected 51 TypeScript files, found ${tracked.length}`);
+      tracked.forEach(({ file }, index) => {
+        fs.appendFileSync(path.join(worktree, file), `\n// gitnexus-r19-wide-${index}\n`);
+      });
+      writeJson(path.join(evidence, 'wide-write-set.json'), tracked);
+      await commitAll('r19 force incremental scale escalation');
+      wideHead = await runText('wide-head', 'git', ['rev-parse', 'HEAD']);
+    }
+
+    const interrupted = await interruptAtEscalation();
+    if (interrupted.dirty?.dirty?.phase !== 'effective-write-set') {
+      throw new Error(`unexpected dirty phase: ${JSON.stringify(interrupted.dirty)}`);
+    }
+    if (Number(interrupted.dirty?.dirty?.effectiveWriteCount ?? 0) < 50) {
+      throw new Error('incremental escalation write set was smaller than 50 files');
+    }
+    const dirtySnapshot = await snapshot('interrupted-dirty');
+    if (!dirtySnapshot.metadata?.incrementalInProgress) {
+      throw new Error('interrupted analysis left no dirty marker');
+    }
+
+    await run(
+      'resume-after-interruption',
+      process.execPath,
+      [incrementalChild, worktree, '--embeddings', '--fts-query', 'r19CanaryNeedleV2'],
+      { cwd: packageRoot, env: canaryEnv },
+    );
+    const recovered = await snapshot('recovered', { fingerprint: true });
+    assertSnapshot(recovered, wideHead);
+
+    await run(
+      'forced-rebuild',
+      process.execPath,
+      [incrementalChild, worktree, '--force', '--embeddings', '--fts-query', 'r19CanaryNeedleV2'],
+      { cwd: packageRoot, env: canaryEnv },
+    );
+    const forced = await snapshot('forced', { fingerprint: true });
+    assertSnapshot(forced, wideHead);
+    const recoveredForcedComparison = compareSnapshots(recovered, forced);
+    writeJson(path.join(evidence, 'recovered-forced-comparison.json'), recoveredForcedComparison);
+    if (!recoveredForcedComparison.equal) {
+      throw new Error('recovered and forced graphs produced different fingerprints');
+    }
+    await run('final-status', process.execPath, [cli, 'status'], { cwd: worktree, env: canaryEnv });
+    await run('final-doctor', process.execPath, [cli, 'doctor', worktree], {
+      cwd: packageRoot,
+      env: canaryEnv,
+    });
+    await run(
+      'final-query',
+      process.execPath,
+      [cli, 'query', 'r19CanaryNeedleV2', '-r', worktree],
+      {
+        cwd: packageRoot,
+        env: canaryEnv,
+      },
+    );
+
+    const summary = {
+      runId,
+      result: 'passed',
+      sourceSha,
+      finalHead: wideHead,
+      publicOrigin,
+      embedding: { model, dimensions, ...embeddingStats },
+      initial: initial.metadata.stats,
+      controlled: controlled.metadata.stats,
+      recovered: recovered.metadata.stats,
+      forced: forced.metadata.stats,
+      interrupted: interrupted.dirty,
+      worktree,
+      evidence,
+    };
+    writeJson(path.join(evidence, 'summary.json'), summary);
+    process.stdout.write(`[${runId}] passed\n`);
+  }
+} catch (error) {
+  writeJson(failurePath, {
+    runId,
+    at: new Date().toISOString(),
+    error: error instanceof Error ? (error.stack ?? error.message) : String(error),
+    embedding: { model, dimensions, ...embeddingStats },
+  });
+  process.stderr.write(
+    `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+  );
+  process.exitCode = 1;
+} finally {
+  await new Promise((resolve) => embeddingServer.close(resolve));
+}

--- a/gitnexus/scripts/reconciliation/large-repository-canary.mjs
+++ b/gitnexus/scripts/reconciliation/large-repository-canary.mjs
@@ -7,6 +7,8 @@ import http from 'node:http';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { createSanitizedEnvironment } from './canary-environment.mjs';
+
 const REQUIRED_ARGS = [
   'source',
   'source-sha',
@@ -54,6 +56,7 @@ const home = path.join(evidence, 'home');
 const commandDir = path.join(evidence, 'commands');
 const snapshotDir = path.join(evidence, 'snapshots');
 const failurePath = path.join(evidence, 'failure.json');
+const baseEnv = createSanitizedEnvironment(process.env, { home });
 
 if (!Number.isInteger(dimensions) || dimensions <= 0) {
   throw new Error('--embedding-dims must be a positive integer');
@@ -129,7 +132,7 @@ const run = async (name, command, commandArgs, options = {}) => {
   process.stdout.write(`[${runId}] ${name}\n`);
   const child = spawn(command, commandArgs, {
     cwd: options.cwd ?? worktree,
-    env: options.env ?? process.env,
+    env: options.env ?? baseEnv,
     stdio: ['ignore', stdout, stderr],
   });
   const result = await new Promise((resolve, reject) => {
@@ -163,7 +166,7 @@ const runText = async (name, command, commandArgs, options = {}) => {
   const chunks = [];
   const child = spawn(command, commandArgs, {
     cwd: options.cwd ?? worktree,
-    env: options.env ?? process.env,
+    env: options.env ?? baseEnv,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   child.stdout.on('data', (chunk) => chunks.push(chunk));
@@ -229,9 +232,7 @@ const address = embeddingServer.address();
 if (!address || typeof address === 'string') throw new Error('embedding server has no TCP address');
 
 const canaryEnv = {
-  ...process.env,
-  HOME: home,
-  USERPROFILE: home,
+  ...baseEnv,
   GITNEXUS_HOME: path.join(home, '.gitnexus'),
   CI: '1',
   NODE_OPTIONS: '--max-old-space-size=6144',
@@ -652,7 +653,7 @@ try {
     } else {
       await run('clone', 'git', ['clone', '--shared', '--no-checkout', source, worktree], {
         cwd: path.dirname(worktree),
-        env: process.env,
+        env: baseEnv,
       });
       await run('checkout-source-sha', 'git', ['checkout', '--detach', sourceSha]);
       await run('set-public-origin', 'git', ['remote', 'set-url', 'origin', publicOrigin]);

--- a/gitnexus/scripts/reconciliation/large-repository-canary.mjs
+++ b/gitnexus/scripts/reconciliation/large-repository-canary.mjs
@@ -125,7 +125,7 @@ const commandLedger =
     ? JSON.parse(fs.readFileSync(commandLedgerPath, 'utf8'))
     : [];
 const embeddingStats = { requests: 0, items: 0 };
-const childSupervisor = new ChildSupervisor();
+const childSupervisor = new ChildSupervisor({ terminationEnv: baseEnv });
 
 const run = async (name, command, commandArgs, options = {}) => {
   const { stdoutPath, stderrPath, stdout, stderr } = openArtifactLogs(commandDir, name);

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -934,11 +934,16 @@ const copyCsvWithRetry = async (
  * keeps the IGNORE_ERRORS=true retry; a hard failure throws (no node rows ⇒ the
  * relationship COPY would dangle on missing endpoints).
  */
+export interface LbugLoadHooks {
+  onNodeCopyCommitted?: (table: NodeTableName, index: number, total: number) => void;
+}
+
 const copyNodeCSVs = async (
   targetConn: lbug.Connection,
   nodeFileEntries: [NodeTableName, { csvPath: string; rows: number }][],
   log: (message: string) => void,
   totalSteps: number,
+  hooks?: LbugLoadHooks,
 ): Promise<void> => {
   let stepsDone = 0;
   for (const [table, { csvPath, rows }] of nodeFileEntries) {
@@ -950,6 +955,7 @@ const copyNodeCSVs = async (
       const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
       throw new Error(`COPY failed for ${table}: ${retryMsg.slice(0, 200)}`);
     });
+    hooks?.onNodeCopyCommitted?.(table, stepsDone - 1, totalSteps);
   }
 };
 
@@ -979,6 +985,7 @@ export const loadGraphToLbug = async (
    * emits none — the manifest is the sole source and there is no double-COPY.
    */
   pdgEmitManifest?: PdgEmitManifest,
+  hooks?: LbugLoadHooks,
 ) => {
   if (!conn) {
     throw new Error('LadybugDB not initialized. Call initLbug first.');
@@ -1050,7 +1057,7 @@ export const loadGraphToLbug = async (
     // denominator is the node-table count — not +1 reserving a rel step.
     // .catch captures the failure so an overlapped (mid-emit) rejection cannot
     // surface as an unhandled rejection; it is rethrown at the FK barrier below.
-    nodeCopyPromise = copyNodeCSVs(writeConn, entries, log, entries.length).catch((e) => {
+    nodeCopyPromise = copyNodeCSVs(writeConn, entries, log, entries.length, hooks).catch((e) => {
       nodeCopyError = e;
     });
   };
@@ -2085,14 +2092,25 @@ export class LbugWipeError extends Error {
  * DB the run is about to recreate, so neither needs (or may share) the
  * loud-failure contract here.
  */
-export const wipeLbugDbFiles = async (lbugPath: string): Promise<void> => {
+export interface LbugWipeOptions {
+  onRemoved?: (removedPath: string, index: number, total: number) => void;
+}
+
+export const wipeLbugDbFiles = async (
+  lbugPath: string,
+  options: LbugWipeOptions = {},
+): Promise<void> => {
   const lockPath = `${lbugPath}.lock`;
   const family = [lbugPath, `${lbugPath}.wal`, `${lbugPath}.shadow`, lockPath];
   let survivors: string[] = [];
 
   for (let attempt = 1; attempt <= HANDLE_RELEASE_PROBE_ATTEMPTS; attempt++) {
     survivors = [];
-    for (const f of family) {
+    for (const [index, f] of family.entries()) {
+      const existedBefore = await fs.access(f).then(
+        () => true,
+        () => false,
+      );
       try {
         await fs.rm(f, { recursive: true, force: true });
       } catch {
@@ -2104,7 +2122,11 @@ export const wipeLbugDbFiles = async (lbugPath: string): Promise<void> => {
         () => false, // still present
         (err: unknown) => (err as NodeJS.ErrnoException | null)?.code === 'ENOENT',
       );
-      if (!gone) survivors.push(f);
+      if (!gone) {
+        survivors.push(f);
+      } else if (existedBefore) {
+        options.onRemoved?.(f, index, family.length);
+      }
     }
     if (survivors.length === 0) return;
     if (attempt < HANDLE_RELEASE_PROBE_ATTEMPTS) {

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -126,6 +126,11 @@ import { STALE_HASH_SENTINEL } from './lbug/schema.js';
 export interface AnalyzeCallbacks {
   onProgress: (phase: string, percent: number, message: string) => void;
   onLog?: (message: string) => void;
+  /** Test/recovery observability at durable incremental-write boundaries. */
+  onRecoveryBoundary?: (
+    boundary: 'before-delete' | 'during-delete' | 'during-insert' | 'before-finalize',
+    details: Readonly<Record<string, unknown>>,
+  ) => void;
 }
 
 export interface AnalyzeOptions {
@@ -1623,6 +1628,11 @@ export async function runFullAnalysis(
           effectiveWriteCount: effectiveWriteSet.size,
           deleteCount: filesToDelete.length,
         });
+        callbacks.onRecoveryBoundary?.('before-delete', {
+          phase: 'escalated-full-write',
+          effectiveWriteCount: effectiveWriteSet.size,
+          deleteCount: filesToDelete.length,
+        });
         // Strategy switch: stop the checkpoint driver around the close so its
         // in-flight CHECKPOINT can't race the reopen, drop the DB files
         // (sidecars included), and bulk-load the full graph into a fresh DB —
@@ -1633,14 +1643,52 @@ export async function runFullAnalysis(
         // to replace wholesale.
         await walCheckpointDriver.stop();
         await closeLbug();
-        await wipeLbugDbFiles(lbugPath);
+        let deletionBoundaryReported = false;
+        await wipeLbugDbFiles(lbugPath, {
+          onRemoved: (removedPath, index, total) => {
+            if (deletionBoundaryReported) return;
+            deletionBoundaryReported = true;
+            callbacks.onRecoveryBoundary?.('during-delete', {
+              phase: 'escalated-full-write',
+              removedPath,
+              index,
+              total,
+            });
+          },
+        });
+        await saveIncrementalDirtyState('escalated-load-graph', {
+          toWriteCount: 0,
+          importerExpansion,
+          shadowSeedCount: shadowSeed.length,
+          effectiveWriteCount: effectiveWriteSet.size,
+          deleteCount: filesToDelete.length,
+        });
         await initLbug(lbugPath);
         walCheckpointDriver = startWalCheckpointDriver();
-        await loadGraphToLbug(pipelineResult.graph, pipelineResult.repoPath, storagePath, (msg) => {
-          lbugMsgCount++;
-          const pct = Math.min(84, 65 + Math.round((lbugMsgCount / (lbugMsgCount + 10)) * 19));
-          progress('lbug', pct, msg);
-        });
+        let insertionBoundaryReported = false;
+        await loadGraphToLbug(
+          pipelineResult.graph,
+          pipelineResult.repoPath,
+          storagePath,
+          (msg) => {
+            lbugMsgCount++;
+            const pct = Math.min(84, 65 + Math.round((lbugMsgCount / (lbugMsgCount + 10)) * 19));
+            progress('lbug', pct, msg);
+          },
+          undefined,
+          {
+            onNodeCopyCommitted: (table, index, total) => {
+              if (insertionBoundaryReported) return;
+              insertionBoundaryReported = true;
+              callbacks.onRecoveryBoundary?.('during-insert', {
+                phase: 'escalated-load-graph',
+                table,
+                index,
+                total,
+              });
+            },
+          },
+        );
       } else {
         // The surgical plan is now final. Only at this point may
         // --incremental-only write its crash marker, immediately before the
@@ -2215,6 +2263,12 @@ export async function runFullAnalysis(
       // off==off and incremental eligibility is restored.
       pdg: resolvePdgConfig(options),
     };
+    if (isIncremental && hashDiff) {
+      callbacks.onRecoveryBoundary?.('before-finalize', {
+        phase: escalatedFullWrite ? 'escalated-load-graph' : 'load-graph',
+        targetCommit: currentCommit,
+      });
+    }
     await saveMeta(metaDir, meta);
 
     // Persist the incremental parse cache for the next run. Wraps in

--- a/gitnexus/test/fixtures/deterministic-embedding-server.mjs
+++ b/gitnexus/test/fixtures/deterministic-embedding-server.mjs
@@ -1,0 +1,66 @@
+import crypto from 'node:crypto';
+import http from 'node:http';
+
+const dimensions = 384;
+const model = 'gitnexus-test-deterministic-v1';
+
+const deterministicVector = (text) => {
+  const digest = crypto.createHash('sha256').update(text).digest();
+  const vector = Array.from(
+    { length: dimensions },
+    (_, index) => digest[index % digest.length] / 127.5 - 1,
+  );
+  const magnitude = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0)) || 1;
+  return vector.map((value) => value / magnitude);
+};
+
+const server = http.createServer((request, response) => {
+  if (request.method !== 'POST' || request.url !== '/v1/embeddings') {
+    response.writeHead(404).end();
+    return;
+  }
+
+  const chunks = [];
+  request.on('data', (chunk) => chunks.push(chunk));
+  request.on('end', () => {
+    try {
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      const inputs = Array.isArray(body.input) ? body.input : [body.input];
+      if (!inputs.every((input) => typeof input === 'string')) {
+        throw new Error('input must be a string or string array');
+      }
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          object: 'list',
+          model,
+          data: inputs.map((input, index) => ({
+            object: 'embedding',
+            index,
+            embedding: deterministicVector(input),
+          })),
+          usage: { prompt_tokens: 0, total_tokens: 0 },
+        }),
+      );
+    } catch (error) {
+      response.writeHead(400, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          error: { message: error instanceof Error ? error.message : String(error) },
+        }),
+      );
+    }
+  });
+});
+
+await new Promise((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(0, '127.0.0.1', resolve);
+});
+const address = server.address();
+if (!address || typeof address === 'string') throw new Error('embedding server has no TCP address');
+process.stdout.write(`EMBEDDING_SERVER=http://127.0.0.1:${address.port}/v1\n`);
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/gitnexus/test/fixtures/large-incremental-child.mjs
+++ b/gitnexus/test/fixtures/large-incremental-child.mjs
@@ -12,16 +12,18 @@ const bm25IndexUrl = pathToFileURL(path.join(packageRoot, 'dist/core/search/bm25
 const [repoPath, ...args] = process.argv.slice(2);
 if (!repoPath) {
   throw new Error(
-    'usage: large-incremental-child.mjs <repo> [--force] [--embeddings] [--pause-on-escalation <file>] [--fts-query <text>]',
+    'usage: large-incremental-child.mjs <repo> [--force] [--embeddings] [--pause-at <boundary> --pause-ready <file>] [--fts-query <text>]',
   );
 }
 
 const force = args.includes('--force');
 const embeddings = args.includes('--embeddings');
-const pauseIndex = args.indexOf('--pause-on-escalation');
-const pauseReadyFile = pauseIndex >= 0 ? args[pauseIndex + 1] : undefined;
-if (pauseIndex >= 0 && !pauseReadyFile) {
-  throw new Error('--pause-on-escalation requires a ready-file path');
+const pauseAtIndex = args.indexOf('--pause-at');
+const pauseAt = pauseAtIndex >= 0 ? args[pauseAtIndex + 1] : undefined;
+const pauseReadyIndex = args.indexOf('--pause-ready');
+const pauseReadyFile = pauseReadyIndex >= 0 ? args[pauseReadyIndex + 1] : undefined;
+if ((pauseAt && !pauseReadyFile) || (!pauseAt && pauseReadyFile)) {
+  throw new Error('--pause-at and --pause-ready must be provided together');
 }
 const ftsQueryIndex = args.indexOf('--fts-query');
 const ftsQuery = ftsQueryIndex >= 0 ? args[ftsQueryIndex + 1] : undefined;
@@ -37,20 +39,22 @@ let paused = false;
 
 const onLog = (message) => {
   logs.push(message);
-  if (!paused && pauseReadyFile && message.includes('switching to a full DB write')) {
-    paused = true;
-    const metadataPath = path.join(storagePath, 'gitnexus.json');
-    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
-    fs.writeFileSync(
-      pauseReadyFile,
-      JSON.stringify({ message, dirty: metadata.incrementalInProgress }),
-      'utf8',
-    );
+};
 
-    const latch = new Int32Array(new SharedArrayBuffer(4));
-    Atomics.wait(latch, 0, 0, 120_000);
-    throw new Error('pause-on-escalation timed out before the parent terminated this process');
-  }
+const onRecoveryBoundary = (boundary, details) => {
+  if (paused || !pauseReadyFile || boundary !== pauseAt) return;
+  paused = true;
+  const metadataPath = path.join(storagePath, 'gitnexus.json');
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+  fs.writeFileSync(
+    pauseReadyFile,
+    JSON.stringify({ boundary, details, dirty: metadata.incrementalInProgress }),
+    { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+  );
+
+  const latch = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(latch, 0, 0, 120_000);
+  throw new Error(`pause-at ${boundary} timed out before the parent terminated this process`);
 };
 
 try {
@@ -63,7 +67,7 @@ try {
       embeddings,
       embeddingsNodeLimit: embeddings ? 0 : undefined,
     },
-    { onProgress: () => {}, onLog },
+    { onProgress: () => {}, onLog, onRecoveryBoundary },
   );
 
   const meta = await loadMeta(storagePath);

--- a/gitnexus/test/fixtures/large-incremental-child.mjs
+++ b/gitnexus/test/fixtures/large-incremental-child.mjs
@@ -12,11 +12,12 @@ const bm25IndexUrl = pathToFileURL(path.join(packageRoot, 'dist/core/search/bm25
 const [repoPath, ...args] = process.argv.slice(2);
 if (!repoPath) {
   throw new Error(
-    'usage: large-incremental-child.mjs <repo> [--force] [--pause-on-escalation <file>] [--fts-query <text>]',
+    'usage: large-incremental-child.mjs <repo> [--force] [--embeddings] [--pause-on-escalation <file>] [--fts-query <text>]',
   );
 }
 
 const force = args.includes('--force');
+const embeddings = args.includes('--embeddings');
 const pauseIndex = args.indexOf('--pause-on-escalation');
 const pauseReadyFile = pauseIndex >= 0 ? args[pauseIndex + 1] : undefined;
 if (pauseIndex >= 0 && !pauseReadyFile) {
@@ -53,7 +54,17 @@ const onLog = (message) => {
 };
 
 try {
-  await runFullAnalysis(repoPath, { skipAgentsMd: true, force }, { onProgress: () => {}, onLog });
+  await runFullAnalysis(
+    repoPath,
+    {
+      skipAgentsMd: true,
+      skipSkills: true,
+      force,
+      embeddings,
+      embeddingsNodeLimit: embeddings ? 0 : undefined,
+    },
+    { onProgress: () => {}, onLog },
+  );
 
   const meta = await loadMeta(storagePath);
   const lbugStat = fs.statSync(lbugPath);

--- a/gitnexus/test/fixtures/large-incremental-child.mjs
+++ b/gitnexus/test/fixtures/large-incremental-child.mjs
@@ -12,12 +12,13 @@ const bm25IndexUrl = pathToFileURL(path.join(packageRoot, 'dist/core/search/bm25
 const [repoPath, ...args] = process.argv.slice(2);
 if (!repoPath) {
   throw new Error(
-    'usage: large-incremental-child.mjs <repo> [--force] [--embeddings] [--pause-at <boundary> --pause-ready <file>] [--fts-query <text>]',
+    'usage: large-incremental-child.mjs <repo> [--force] [--embeddings] [--drop-embeddings] [--pause-at <boundary> --pause-ready <file>] [--fts-query <text>]',
   );
 }
 
 const force = args.includes('--force');
 const embeddings = args.includes('--embeddings');
+const dropEmbeddings = args.includes('--drop-embeddings');
 const pauseAtIndex = args.indexOf('--pause-at');
 const pauseAt = pauseAtIndex >= 0 ? args[pauseAtIndex + 1] : undefined;
 const pauseReadyIndex = args.indexOf('--pause-ready');
@@ -65,6 +66,7 @@ try {
       skipSkills: true,
       force,
       embeddings,
+      dropEmbeddings,
       embeddingsNodeLimit: embeddings ? 0 : undefined,
     },
     { onProgress: () => {}, onLog, onRecoveryBoundary },

--- a/gitnexus/test/helpers/embedding-seed.ts
+++ b/gitnexus/test/helpers/embedding-seed.ts
@@ -13,7 +13,8 @@
  * close. Zero vectors need no VECTOR extension: the CodeEmbedding TABLE is
  * plain schema; only the HNSW index is extension-gated.
  */
-import { expect } from 'vitest';
+import { createHash } from 'node:crypto';
+
 import {
   getStoragePaths,
   loadMeta,
@@ -105,11 +106,57 @@ export async function readEmbeddingNodeIds(repoPath: string): Promise<string[]> 
   }
 }
 
+export interface EmbeddingRowFingerprint {
+  nodeId: string;
+  chunkIndex: number;
+  startLine: number;
+  endLine: number;
+  contentHash: string;
+  dimensions: number;
+  vectorSha256: string;
+}
+
+/** Read a compact, deterministic fingerprint of every persisted embedding row. */
+export async function readEmbeddingRowFingerprints(
+  repoPath: string,
+): Promise<EmbeddingRowFingerprint[]> {
+  const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+  const { lbugPath } = getStoragePaths(repoPath);
+  await adapter.initLbug(lbugPath);
+  try {
+    const rows = (await adapter.executeQuery(
+      `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN e.nodeId AS nodeId, e.chunkIndex AS chunkIndex, e.startLine AS startLine, e.endLine AS endLine, e.contentHash AS contentHash, e.embedding AS embedding`,
+    )) as Array<Record<string, unknown>>;
+    return rows
+      .map((row) => {
+        const rawVector = row.embedding ?? row[5];
+        const vector = Array.isArray(rawVector)
+          ? rawVector.map(Number)
+          : Array.from(rawVector as Iterable<unknown>).map(Number);
+        return {
+          nodeId: String(row.nodeId ?? row[0] ?? ''),
+          chunkIndex: Number(row.chunkIndex ?? row[1] ?? 0),
+          startLine: Number(row.startLine ?? row[2] ?? 0),
+          endLine: Number(row.endLine ?? row[3] ?? 0),
+          contentHash: String(row.contentHash ?? row[4] ?? ''),
+          dimensions: vector.length,
+          vectorSha256: createHash('sha256').update(JSON.stringify(vector)).digest('hex'),
+        };
+      })
+      .sort(
+        (left, right) =>
+          left.nodeId.localeCompare(right.nodeId) || left.chunkIndex - right.chunkIndex,
+      );
+  } finally {
+    await adapter.closeLbug();
+  }
+}
+
 /** Tamper meta.stats.embeddings so deriveEmbeddingMode sees an embedded repo
  *  (loadMeta → spread → saveMeta, same pattern as the dirty-flag tests). */
 export async function stampEmbeddingCount(storagePath: string, embeddings: number): Promise<void> {
   const meta = await loadMeta(storagePath);
-  expect(meta).not.toBeNull();
-  const tampered: RepoMeta = { ...meta!, stats: { ...meta!.stats, embeddings } };
+  if (!meta) throw new Error(`missing repository metadata at ${storagePath}`);
+  const tampered: RepoMeta = { ...meta, stats: { ...meta.stats, embeddings } };
   await saveMeta(storagePath, tampered);
 }

--- a/gitnexus/test/helpers/large-incremental-contract.ts
+++ b/gitnexus/test/helpers/large-incremental-contract.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const PORTABLE_ENV_KEYS = [
   'PATH',
@@ -26,6 +28,91 @@ export type RecoveryBoundary = (typeof RECOVERY_BOUNDARY_CASES)[number][0];
 export const ALL_RECOVERY_BOUNDARIES: readonly RecoveryBoundary[] = RECOVERY_BOUNDARY_CASES.map(
   ([boundary]) => boundary,
 );
+
+export function setupDisposableRoot<T>(prefix: string, setup: (root: string) => T): T {
+  const root = fs.mkdtempSync(prefix);
+  try {
+    return setup(root);
+  } catch (error) {
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    throw error;
+  }
+}
+
+type RegularTreeEntry = { relativePath: string; directory: boolean; mode: number };
+
+const collectRegularTree = (sourceRoot: string): RegularTreeEntry[] => {
+  const rootStat = fs.lstatSync(sourceRoot);
+  if (rootStat.isSymbolicLink()) {
+    throw new Error(`regular file tree source is a symbolic link: ${sourceRoot}`);
+  }
+  if (!rootStat.isDirectory()) {
+    throw new Error(`regular file tree source is not a directory: ${sourceRoot}`);
+  }
+
+  const entries: RegularTreeEntry[] = [];
+  const visit = (directory: string, relativeDirectory: string): void => {
+    for (const name of fs.readdirSync(directory).sort()) {
+      const sourcePath = path.join(directory, name);
+      const relativePath = path.join(relativeDirectory, name);
+      const stat = fs.lstatSync(sourcePath);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`regular file tree contains a symbolic link: ${sourcePath}`);
+      }
+      if (stat.isDirectory()) {
+        entries.push({ relativePath, directory: true, mode: stat.mode });
+        visit(sourcePath, relativePath);
+      } else if (stat.isFile()) {
+        entries.push({ relativePath, directory: false, mode: stat.mode });
+      } else {
+        throw new Error(`regular file tree contains a non-regular entry: ${sourcePath}`);
+      }
+    }
+  };
+  visit(sourceRoot, '');
+  return entries;
+};
+
+const assertContainedRealPath = (root: string, candidate: string): void => {
+  const realRoot = fs.realpathSync.native(root);
+  const realCandidate = fs.realpathSync.native(candidate);
+  if (realCandidate !== realRoot && !realCandidate.startsWith(`${realRoot}${path.sep}`)) {
+    throw new Error(`staged path escaped its destination root: ${candidate}`);
+  }
+};
+
+export function stageRegularFileTree(sourceRoot: string, destinationRoot: string): void {
+  if (fs.existsSync(destinationRoot)) {
+    throw new Error(`regular file tree destination already exists: ${destinationRoot}`);
+  }
+  const entries = collectRegularTree(sourceRoot);
+  try {
+    fs.mkdirSync(destinationRoot, { recursive: true, mode: 0o700 });
+    assertContainedRealPath(destinationRoot, destinationRoot);
+    for (const entry of entries) {
+      const sourcePath = path.join(sourceRoot, entry.relativePath);
+      const destinationPath = path.join(destinationRoot, entry.relativePath);
+      if (entry.directory) {
+        fs.mkdirSync(destinationPath, { mode: entry.mode & 0o777 });
+      } else {
+        const sourceStat = fs.lstatSync(sourcePath);
+        if (!sourceStat.isFile() || sourceStat.isSymbolicLink()) {
+          throw new Error(`regular file changed type during staging: ${sourcePath}`);
+        }
+        fs.mkdirSync(path.dirname(destinationPath), { recursive: true, mode: 0o700 });
+        fs.copyFileSync(sourcePath, destinationPath, fs.constants.COPYFILE_EXCL);
+        fs.chmodSync(destinationPath, entry.mode & 0o777);
+        if (!fs.lstatSync(destinationPath).isFile()) {
+          throw new Error(`staged extension is not a regular file: ${destinationPath}`);
+        }
+      }
+      assertContainedRealPath(destinationRoot, destinationPath);
+    }
+  } catch (error) {
+    fs.rmSync(destinationRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    throw error;
+  }
+}
 
 export function createHermeticProcessEnv(
   source: NodeJS.ProcessEnv,

--- a/gitnexus/test/helpers/large-incremental-contract.ts
+++ b/gitnexus/test/helpers/large-incremental-contract.ts
@@ -1,0 +1,208 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+
+const PORTABLE_ENV_KEYS = [
+  'PATH',
+  'SHELL',
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TZ',
+] as const;
+
+const WINDOWS_ENV_KEYS = ['SystemRoot', 'WINDIR', 'COMSPEC', 'PATHEXT'] as const;
+
+export const RECOVERY_BOUNDARY_CASES = [
+  ['before-delete', 'escalated-full-write'],
+  ['during-delete', 'escalated-full-write'],
+  ['during-insert', 'escalated-load-graph'],
+  ['before-finalize', 'escalated-load-graph'],
+] as const;
+
+export type RecoveryBoundary = (typeof RECOVERY_BOUNDARY_CASES)[number][0];
+
+export const ALL_RECOVERY_BOUNDARIES: readonly RecoveryBoundary[] = RECOVERY_BOUNDARY_CASES.map(
+  ([boundary]) => boundary,
+);
+
+export function createHermeticProcessEnv(
+  source: NodeJS.ProcessEnv,
+  home: string,
+  overrides: NodeJS.ProcessEnv = {},
+  platform: NodeJS.Platform = process.platform,
+): NodeJS.ProcessEnv {
+  if (!home) throw new Error('hermetic process environment requires an isolated home');
+  const allowedKeys =
+    platform === 'win32'
+      ? ([...PORTABLE_ENV_KEYS, ...WINDOWS_ENV_KEYS] as const)
+      : PORTABLE_ENV_KEYS;
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of allowedKeys) {
+    if (typeof source[key] === 'string') env[key] = source[key];
+  }
+  return {
+    ...env,
+    HOME: home,
+    USERPROFILE: home,
+    CI: '1',
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_CONFIG_GLOBAL: platform === 'win32' ? 'NUL' : '/dev/null',
+    ...overrides,
+  };
+}
+
+export function selectRecoveryBoundaries(raw: string | undefined): RecoveryBoundary[] {
+  if (raw === undefined) return [...ALL_RECOVERY_BOUNDARIES];
+  const requested = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (requested.length === 0) {
+    throw new Error('GITNEXUS_RECOVERY_BOUNDARIES must name at least one boundary');
+  }
+  const known = new Set<string>(ALL_RECOVERY_BOUNDARIES);
+  const unknown = requested.filter((value) => !known.has(value));
+  if (unknown.length > 0) {
+    throw new Error(
+      `GITNEXUS_RECOVERY_BOUNDARIES contains unknown value(s): ${unknown.join(', ')}`,
+    );
+  }
+  return [...new Set(requested)] as RecoveryBoundary[];
+}
+
+export type ChildExit = { code: number | null; signal: NodeJS.Signals | null };
+
+const currentExit = (child: ChildProcess): ChildExit | undefined => {
+  if (child.exitCode === null && child.signalCode === null) return undefined;
+  return { code: child.exitCode, signal: child.signalCode as NodeJS.Signals | null };
+};
+
+export async function terminateChild(
+  child: ChildProcess,
+  graceMs = 30_000,
+  killWaitMs = 5_000,
+): Promise<ChildExit> {
+  const exited = currentExit(child);
+  if (exited) return exited;
+
+  return new Promise<ChildExit>((resolve, reject) => {
+    let killTimer: NodeJS.Timeout | undefined;
+    let settled = false;
+
+    const cleanup = (): void => {
+      if (graceTimer) clearTimeout(graceTimer);
+      if (killTimer) clearTimeout(killTimer);
+      child.off('exit', onExit);
+    };
+    const finish = (result: ChildExit): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      finish({ code, signal });
+    };
+    const graceTimer = setTimeout(() => {
+      if (settled) return;
+      child.kill('SIGKILL');
+      killTimer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new Error('child did not terminate after SIGKILL'));
+      }, killWaitMs);
+    }, graceMs);
+
+    child.once('exit', onExit);
+    const racedExit = currentExit(child);
+    if (racedExit) {
+      finish(racedExit);
+      return;
+    }
+
+    child.kill('SIGTERM');
+  });
+}
+
+export interface ReadyProcessOptions {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  readyPrefix: string;
+  timeoutMs?: number;
+  terminateGraceMs?: number;
+  cwd?: string;
+}
+
+export async function startReadyProcess(
+  options: ReadyProcessOptions,
+): Promise<{ child: ChildProcess; value: string }> {
+  const child = spawn(options.command, options.args, {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  try {
+    const value = await new Promise<string>((resolve, reject) => {
+      let stdout = '';
+      let settled = false;
+      const timeoutMs = options.timeoutMs ?? 30_000;
+      const timer = setTimeout(
+        () => rejectOnce(new Error(`child did not become ready within ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        child.stdout?.off('data', onStdout);
+        child.stderr?.off('data', onStderr);
+        child.off('error', onError);
+        child.off('exit', onExit);
+      };
+      const rejectOnce = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+      const onStdout = (chunk: Buffer | string): void => {
+        stdout += chunk.toString();
+        const line = stdout
+          .split(/\r?\n/u)
+          .find((candidate) => candidate.startsWith(options.readyPrefix));
+        if (!line || settled) return;
+        settled = true;
+        cleanup();
+        resolve(line.slice(options.readyPrefix.length));
+      };
+      const onStderr = (chunk: Buffer | string): void => {
+        stderr = `${stderr}${chunk.toString()}`.slice(-8_192);
+      };
+      const onError = (error: Error): void => rejectOnce(error);
+      const onExit = (code: number | null, signal: NodeJS.Signals | null): void =>
+        rejectOnce(
+          new Error(
+            `child exited before ready: code=${code} signal=${signal}${stderr ? ` ${stderr}` : ''}`,
+          ),
+        );
+
+      child.stdout?.on('data', onStdout);
+      child.stderr?.on('data', onStderr);
+      child.once('error', onError);
+      child.once('exit', onExit);
+    });
+    return { child, value };
+  } catch (error) {
+    try {
+      await terminateChild(child, options.terminateGraceMs ?? 1_000);
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], 'child startup and cleanup both failed');
+    }
+    throw error;
+  }
+}

--- a/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
+++ b/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
@@ -7,9 +7,17 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   readEmbeddingNodeIds,
+  readEmbeddingRowFingerprints,
   seedEmbeddingsForFiles,
   stampEmbeddingCount,
 } from '../helpers/embedding-seed.js';
+import {
+  createHermeticProcessEnv,
+  RECOVERY_BOUNDARY_CASES,
+  selectRecoveryBoundaries,
+  startReadyProcess,
+  terminateChild,
+} from '../helpers/large-incremental-contract.js';
 import { getStoragePaths, loadMeta } from '../../src/storage/repo-manager.js';
 
 const testDir = path.dirname(fileURLToPath(import.meta.url));
@@ -33,12 +41,7 @@ type HarnessResult = {
 };
 
 const childEnv = (gitnexusHome: string, embeddingUrl: string): NodeJS.ProcessEnv => {
-  const env = { ...process.env };
-  for (const key of Object.keys(env)) {
-    if (key.startsWith('GITNEXUS_EMBEDDING_')) delete env[key];
-  }
-  return {
-    ...env,
+  return createHermeticProcessEnv(process.env, gitnexusHome, {
     CI: '1',
     NODE_ENV: 'test',
     GITNEXUS_HOME: gitnexusHome,
@@ -57,7 +60,7 @@ const childEnv = (gitnexusHome: string, embeddingUrl: string): NodeJS.ProcessEnv
     GITNEXUS_EMBEDDING_MAX_ATTEMPTS: '1',
     GITNEXUS_EMBEDDING_RETRY_CAP_MS: '1',
     GITNEXUS_EMBEDDING_MIN_INTERVAL_MS: '0',
-  };
+  });
 };
 
 const commitAll = (repoPath: string, message: string): void => {
@@ -83,12 +86,21 @@ const commitAll = (repoPath: string, message: string): void => {
 };
 
 const setupLargeRepo = (): { root: string; repoPath: string; gitnexusHome: string } => {
+  const installedExtensions = path.join(os.homedir(), '.lbdb', 'extension');
+  if (!fs.existsSync(installedExtensions)) {
+    throw new Error(
+      `large incremental test requires preinstalled extensions: ${installedExtensions}`,
+    );
+  }
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-large-incremental-'));
   const repoPath = path.join(root, 'repo');
   const gitnexusHome = path.join(root, 'home');
   const src = path.join(repoPath, 'src');
   fs.mkdirSync(src, { recursive: true });
   fs.mkdirSync(gitnexusHome, { recursive: true });
+  fs.cpSync(installedExtensions, path.join(gitnexusHome, '.lbdb', 'extension'), {
+    recursive: true,
+  });
 
   fs.writeFileSync(
     path.join(src, 'hub.ts'),
@@ -133,40 +145,16 @@ const runChild = (
   return parseHarnessResult(result.stdout);
 };
 
-const startEmbeddingServer = async (): Promise<{ child: ChildProcess; url: string }> => {
-  const child = spawn(process.execPath, [embeddingServerRunner], {
-    env: { ...process.env, NODE_ENV: 'test' },
-    stdio: ['ignore', 'pipe', 'pipe'],
+const startEmbeddingServer = async (
+  isolatedHome: string,
+): Promise<{ child: ChildProcess; url: string }> => {
+  const ready = await startReadyProcess({
+    command: process.execPath,
+    args: [embeddingServerRunner],
+    env: createHermeticProcessEnv(process.env, isolatedHome, { NODE_ENV: 'test' }),
+    readyPrefix: 'EMBEDDING_SERVER=',
   });
-  const url = await new Promise<string>((resolve, reject) => {
-    let stdout = '';
-    let stderr = '';
-    const timer = setTimeout(() => reject(new Error('embedding server did not start')), 30_000);
-    child.stdout?.on('data', (chunk) => {
-      stdout += chunk.toString();
-      const line = stdout
-        .split(/\r?\n/u)
-        .find((candidate) => candidate.startsWith('EMBEDDING_SERVER='));
-      if (line) {
-        clearTimeout(timer);
-        resolve(line.slice('EMBEDDING_SERVER='.length));
-      }
-    });
-    child.stderr?.on('data', (chunk) => {
-      stderr += chunk.toString();
-    });
-    child.once('error', (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-    child.once('exit', (code, signal) => {
-      clearTimeout(timer);
-      reject(
-        new Error(`embedding server exited before ready: code=${code} signal=${signal} ${stderr}`),
-      );
-    });
-  });
-  return { child, url };
+  return { child: ready.child, url: ready.value };
 };
 
 const waitForFile = async (filePath: string, child: ChildProcess): Promise<void> => {
@@ -180,21 +168,6 @@ const waitForFile = async (filePath: string, child: ChildProcess): Promise<void>
   }
   throw new Error('timed out waiting for the incremental pause point');
 };
-
-const stopChild = async (
-  child: ChildProcess,
-): Promise<{ code: number | null; signal: string | null }> =>
-  new Promise((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error('child did not terminate after SIGTERM')),
-      30_000,
-    );
-    child.once('exit', (code, signal) => {
-      clearTimeout(timer);
-      resolve({ code, signal });
-    });
-    child.kill('SIGTERM');
-  });
 
 const readEmbeddingDimensions = async (repoPath: string): Promise<number[]> => {
   const adapter = await import('../../src/core/lbug/lbug-adapter.js');
@@ -218,8 +191,9 @@ describe('large incremental analysis subprocess contract', () => {
       `missing embedding server: ${embeddingServerRunner}`,
     ).toBe(true);
     const fixture = setupLargeRepo();
-    const embeddingServer = await startEmbeddingServer();
+    let embeddingServer: Awaited<ReturnType<typeof startEmbeddingServer>> | undefined;
     try {
+      embeddingServer = await startEmbeddingServer(fixture.gitnexusHome);
       const initial = runChild(fixture.repoPath, fixture.gitnexusHome, embeddingServer.url);
       expect(initial.stats.files).toBe(61);
       expect(initial.stats.nodes).toBeGreaterThan(61);
@@ -273,12 +247,12 @@ describe('large incremental analysis subprocess contract', () => {
       );
       commitAll(fixture.repoPath, 'exercise incremental write set');
 
-      const boundaries = [
-        ['before-delete', 'escalated-full-write'],
-        ['during-delete', 'escalated-full-write'],
-        ['during-insert', 'escalated-load-graph'],
-        ['before-finalize', 'escalated-load-graph'],
-      ] as const;
+      const selectedBoundaries = new Set(
+        selectRecoveryBoundaries(process.env.GITNEXUS_RECOVERY_BOUNDARIES),
+      );
+      const boundaries = RECOVERY_BOUNDARY_CASES.filter(([boundary]) =>
+        selectedBoundaries.has(boundary),
+      );
       let recovered: HarnessResult | undefined;
       for (const [index, [boundary, expectedDirtyPhase]] of boundaries.entries()) {
         if (index > 0) {
@@ -312,13 +286,14 @@ describe('large incremental analysis subprocess contract', () => {
           expect(pauseState.details.table).toBeTruthy();
         }
 
-        const stopped = await stopChild(interrupted);
+        const stopped = await terminateChild(interrupted);
         expect(stopped.code).not.toBe(0);
         expect(stopped.signal).toBe('SIGTERM');
         const dirtyMeta = await loadMeta(storagePath);
         expect(dirtyMeta?.incrementalInProgress?.phase).toBe(expectedDirtyPhase);
 
         recovered = runChild(fixture.repoPath, fixture.gitnexusHome, embeddingServer.url, [
+          '--embeddings',
           '--fts-query',
           'r09FtsNeedle',
         ]);
@@ -333,8 +308,11 @@ describe('large incremental analysis subprocess contract', () => {
           `${boundary} recovery silently lost every preserved or regenerated embedding`,
         ).toBeGreaterThanOrEqual(4);
         expect(recovered.stats.embeddings).toBe(recoveredEmbeddingIds.length);
+        const recoveredEmbeddingRows = await readEmbeddingRowFingerprints(fixture.repoPath);
         const forced = runChild(fixture.repoPath, fixture.gitnexusHome, embeddingServer.url, [
           '--force',
+          '--embeddings',
+          '--drop-embeddings',
           '--fts-query',
           'r09FtsNeedle',
         ]);
@@ -342,6 +320,9 @@ describe('large incremental analysis subprocess contract', () => {
         expect(forced.ftsSearch).toEqual(recovered.ftsSearch);
         expect((await readEmbeddingNodeIds(fixture.repoPath)).toSorted()).toEqual(
           recoveredEmbeddingIds.toSorted(),
+        );
+        expect(await readEmbeddingRowFingerprints(fixture.repoPath)).toEqual(
+          recoveredEmbeddingRows,
         );
       }
       if (!recovered) throw new Error('recovery matrix produced no successful run');
@@ -365,10 +346,17 @@ describe('large incremental analysis subprocess contract', () => {
       expect(survivingEmbeddingIds).not.toContain(seeded.get('src/spoke-002.ts')?.[0]);
       expect(await readEmbeddingDimensions(fixture.repoPath)).toEqual([384]);
     } finally {
-      if (embeddingServer.child.exitCode === null && embeddingServer.child.signalCode === null) {
-        await stopChild(embeddingServer.child);
+      try {
+        if (
+          embeddingServer &&
+          embeddingServer.child.exitCode === null &&
+          embeddingServer.child.signalCode === null
+        ) {
+          await terminateChild(embeddingServer.child);
+        }
+      } finally {
+        fs.rmSync(fixture.root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
       }
-      fs.rmSync(fixture.root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     }
   }, 2_400_000);
 });

--- a/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
+++ b/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
@@ -14,6 +14,10 @@ import { getStoragePaths, loadMeta } from '../../src/storage/repo-manager.js';
 
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const childRunner = path.resolve(testDir, '../fixtures/large-incremental-child.mjs');
+const embeddingServerRunner = path.resolve(
+  testDir,
+  '../fixtures/deterministic-embedding-server.mjs',
+);
 
 type HarnessResult = {
   stats: Record<string, number>;
@@ -28,18 +32,33 @@ type HarnessResult = {
   };
 };
 
-const childEnv = (gitnexusHome: string): NodeJS.ProcessEnv => ({
-  ...process.env,
-  CI: '1',
-  NODE_ENV: 'test',
-  GITNEXUS_HOME: gitnexusHome,
-  // The R09 contract requires FTS but must never install during the child
-  // process. CI and local setup preinstall the extension; load-only fails
-  // closed when that prerequisite is absent.
-  GITNEXUS_LBUG_EXTENSION_INSTALL: 'load-only',
-  GITNEXUS_WORKER_POOL_SIZE: '2',
-  GITNEXUS_PARSE_CHUNK_CONCURRENCY: '1',
-});
+const childEnv = (gitnexusHome: string, embeddingUrl: string): NodeJS.ProcessEnv => {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GITNEXUS_EMBEDDING_')) delete env[key];
+  }
+  return {
+    ...env,
+    CI: '1',
+    NODE_ENV: 'test',
+    GITNEXUS_HOME: gitnexusHome,
+    // The R09 contract requires FTS but must never install during the child
+    // process. CI and local setup preinstall the extension; load-only fails
+    // closed when that prerequisite is absent.
+    GITNEXUS_LBUG_EXTENSION_INSTALL: 'load-only',
+    GITNEXUS_WORKER_POOL_SIZE: '2',
+    GITNEXUS_PARSE_CHUNK_CONCURRENCY: '1',
+    // Recovery may need to regenerate embeddings after a destructive phase.
+    // Keep that proof real but hermetic: a local deterministic endpoint means
+    // no model download, credentials, or external network can affect the test.
+    GITNEXUS_EMBEDDING_URL: embeddingUrl,
+    GITNEXUS_EMBEDDING_MODEL: 'gitnexus-test-deterministic-v1',
+    GITNEXUS_EMBEDDING_DIMS: '384',
+    GITNEXUS_EMBEDDING_MAX_ATTEMPTS: '1',
+    GITNEXUS_EMBEDDING_RETRY_CAP_MS: '1',
+    GITNEXUS_EMBEDDING_MIN_INTERVAL_MS: '0',
+  };
+};
 
 const commitAll = (repoPath: string, message: string): void => {
   for (const args of [
@@ -96,17 +115,58 @@ const parseHarnessResult = (stdout: string): HarnessResult => {
   return JSON.parse(line.slice('HARNESS_RESULT='.length)) as HarnessResult;
 };
 
-const runChild = (repoPath: string, gitnexusHome: string, args: string[] = []): HarnessResult => {
+const runChild = (
+  repoPath: string,
+  gitnexusHome: string,
+  embeddingUrl: string,
+  args: string[] = [],
+): HarnessResult => {
   const result = spawnSync(process.execPath, [childRunner, repoPath, ...args], {
     encoding: 'utf8',
     timeout: 300_000,
-    env: childEnv(gitnexusHome),
+    env: childEnv(gitnexusHome, embeddingUrl),
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   expect(result.error).toBeUndefined();
   expect(result.signal, result.stderr).toBeNull();
   expect(result.status, result.stderr).toBe(0);
   return parseHarnessResult(result.stdout);
+};
+
+const startEmbeddingServer = async (): Promise<{ child: ChildProcess; url: string }> => {
+  const child = spawn(process.execPath, [embeddingServerRunner], {
+    env: { ...process.env, NODE_ENV: 'test' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const url = await new Promise<string>((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => reject(new Error('embedding server did not start')), 30_000);
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+      const line = stdout
+        .split(/\r?\n/u)
+        .find((candidate) => candidate.startsWith('EMBEDDING_SERVER='));
+      if (line) {
+        clearTimeout(timer);
+        resolve(line.slice('EMBEDDING_SERVER='.length));
+      }
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      reject(
+        new Error(`embedding server exited before ready: code=${code} signal=${signal} ${stderr}`),
+      );
+    });
+  });
+  return { child, url };
 };
 
 const waitForFile = async (filePath: string, child: ChildProcess): Promise<void> => {
@@ -153,9 +213,14 @@ const readEmbeddingDimensions = async (repoPath: string): Promise<number[]> => {
 describe('large incremental analysis subprocess contract', () => {
   it('surfaces process failure and recovers add/edit/rename/delete plus importer closure and embeddings', async () => {
     expect(fs.existsSync(childRunner), `missing child runner: ${childRunner}`).toBe(true);
+    expect(
+      fs.existsSync(embeddingServerRunner),
+      `missing embedding server: ${embeddingServerRunner}`,
+    ).toBe(true);
     const fixture = setupLargeRepo();
+    const embeddingServer = await startEmbeddingServer();
     try {
-      const initial = runChild(fixture.repoPath, fixture.gitnexusHome);
+      const initial = runChild(fixture.repoPath, fixture.gitnexusHome, embeddingServer.url);
       expect(initial.stats.files).toBe(61);
       expect(initial.stats.nodes).toBeGreaterThan(61);
 
@@ -172,10 +237,12 @@ describe('large incremental analysis subprocess contract', () => {
       );
       commitAll(fixture.repoPath, 'exercise active FTS row deletion');
 
-      const smallIncremental = runChild(fixture.repoPath, fixture.gitnexusHome, [
-        '--fts-query',
-        'r09SmallFtsNeedle',
-      ]);
+      const smallIncremental = runChild(
+        fixture.repoPath,
+        fixture.gitnexusHome,
+        embeddingServer.url,
+        ['--fts-query', 'r09SmallFtsNeedle'],
+      );
       expect(smallIncremental.logs.join('\n')).not.toContain('switching to a full DB write');
       expect(smallIncremental.stats.files).toBe(61);
       expect(smallIncremental.ftsSearch?.ftsAvailable).toBe(true);
@@ -223,7 +290,7 @@ describe('large incremental analysis subprocess contract', () => {
           process.execPath,
           [childRunner, fixture.repoPath, '--pause-at', boundary, '--pause-ready', readyFile],
           {
-            env: childEnv(fixture.gitnexusHome),
+            env: childEnv(fixture.gitnexusHome, embeddingServer.url),
             stdio: ['ignore', 'pipe', 'pipe'],
           },
         );
@@ -251,7 +318,7 @@ describe('large incremental analysis subprocess contract', () => {
         const dirtyMeta = await loadMeta(storagePath);
         expect(dirtyMeta?.incrementalInProgress?.phase).toBe(expectedDirtyPhase);
 
-        recovered = runChild(fixture.repoPath, fixture.gitnexusHome, [
+        recovered = runChild(fixture.repoPath, fixture.gitnexusHome, embeddingServer.url, [
           '--fts-query',
           'r09FtsNeedle',
         ]);
@@ -261,14 +328,21 @@ describe('large incremental analysis subprocess contract', () => {
         expect((await loadMeta(storagePath))?.incrementalInProgress).toBeUndefined();
 
         const recoveredEmbeddingIds = await readEmbeddingNodeIds(fixture.repoPath);
-        const forced = runChild(fixture.repoPath, fixture.gitnexusHome, [
+        expect(
+          recoveredEmbeddingIds.length,
+          `${boundary} recovery silently lost every preserved or regenerated embedding`,
+        ).toBeGreaterThanOrEqual(4);
+        expect(recovered.stats.embeddings).toBe(recoveredEmbeddingIds.length);
+        const forced = runChild(fixture.repoPath, fixture.gitnexusHome, embeddingServer.url, [
           '--force',
           '--fts-query',
           'r09FtsNeedle',
         ]);
         expect(forced.stats).toEqual(recovered.stats);
         expect(forced.ftsSearch).toEqual(recovered.ftsSearch);
-        expect(await readEmbeddingNodeIds(fixture.repoPath)).toEqual(recoveredEmbeddingIds);
+        expect((await readEmbeddingNodeIds(fixture.repoPath)).toSorted()).toEqual(
+          recoveredEmbeddingIds.toSorted(),
+        );
       }
       if (!recovered) throw new Error('recovery matrix produced no successful run');
       const finalRecovered = recovered;
@@ -291,6 +365,9 @@ describe('large incremental analysis subprocess contract', () => {
       expect(survivingEmbeddingIds).not.toContain(seeded.get('src/spoke-002.ts')?.[0]);
       expect(await readEmbeddingDimensions(fixture.repoPath)).toEqual([384]);
     } finally {
+      if (embeddingServer.child.exitCode === null && embeddingServer.child.signalCode === null) {
+        await stopChild(embeddingServer.child);
+      }
       fs.rmSync(fixture.root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     }
   }, 2_400_000);

--- a/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
+++ b/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
@@ -259,6 +259,16 @@ describe('large incremental analysis subprocess contract', () => {
           'Previous analyze run did not complete cleanly (incrementalInProgress flag set)',
         );
         expect((await loadMeta(storagePath))?.incrementalInProgress).toBeUndefined();
+
+        const recoveredEmbeddingIds = await readEmbeddingNodeIds(fixture.repoPath);
+        const forced = runChild(fixture.repoPath, fixture.gitnexusHome, [
+          '--force',
+          '--fts-query',
+          'r09FtsNeedle',
+        ]);
+        expect(forced.stats).toEqual(recovered.stats);
+        expect(forced.ftsSearch).toEqual(recovered.ftsSearch);
+        expect(await readEmbeddingNodeIds(fixture.repoPath)).toEqual(recoveredEmbeddingIds);
       }
       if (!recovered) throw new Error('recovery matrix produced no successful run');
       const finalRecovered = recovered;
@@ -280,17 +290,8 @@ describe('large incremental analysis subprocess contract', () => {
       expect(survivingEmbeddingIds).not.toContain(seeded.get('src/spoke-001.ts')?.[0]);
       expect(survivingEmbeddingIds).not.toContain(seeded.get('src/spoke-002.ts')?.[0]);
       expect(await readEmbeddingDimensions(fixture.repoPath)).toEqual([384]);
-
-      const forced = runChild(fixture.repoPath, fixture.gitnexusHome, [
-        '--force',
-        '--fts-query',
-        'r09FtsNeedle',
-      ]);
-      expect(forced.stats).toEqual(finalRecovered.stats);
-      expect(forced.ftsSearch).toEqual(finalRecovered.ftsSearch);
-      expect(await readEmbeddingNodeIds(fixture.repoPath)).toEqual(survivingEmbeddingIds);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     }
-  }, 1_800_000);
+  }, 2_400_000);
 });

--- a/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
+++ b/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
@@ -14,7 +14,9 @@ import {
 import {
   createHermeticProcessEnv,
   RECOVERY_BOUNDARY_CASES,
+  setupDisposableRoot,
   selectRecoveryBoundaries,
+  stageRegularFileTree,
   startReadyProcess,
   terminateChild,
 } from '../helpers/large-incremental-contract.js';
@@ -92,31 +94,30 @@ const setupLargeRepo = (): { root: string; repoPath: string; gitnexusHome: strin
       `large incremental test requires preinstalled extensions: ${installedExtensions}`,
     );
   }
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-large-incremental-'));
-  const repoPath = path.join(root, 'repo');
-  const gitnexusHome = path.join(root, 'home');
-  const src = path.join(repoPath, 'src');
-  fs.mkdirSync(src, { recursive: true });
-  fs.mkdirSync(gitnexusHome, { recursive: true });
-  fs.cpSync(installedExtensions, path.join(gitnexusHome, '.lbdb', 'extension'), {
-    recursive: true,
-  });
+  return setupDisposableRoot(path.join(os.tmpdir(), 'gitnexus-large-incremental-'), (root) => {
+    const repoPath = path.join(root, 'repo');
+    const gitnexusHome = path.join(root, 'home');
+    const src = path.join(repoPath, 'src');
+    fs.mkdirSync(src, { recursive: true });
+    fs.mkdirSync(gitnexusHome, { recursive: true });
+    stageRegularFileTree(installedExtensions, path.join(gitnexusHome, '.lbdb', 'extension'));
 
-  fs.writeFileSync(
-    path.join(src, 'hub.ts'),
-    'export function hubValue(value: number): number {\n  return value + 1;\n}\n',
-  );
-  for (let index = 0; index < 60; index++) {
-    const suffix = String(index).padStart(3, '0');
     fs.writeFileSync(
-      path.join(src, `spoke-${suffix}.ts`),
-      `import { hubValue } from './hub';\n\nexport function spoke${index}(): number {\n  return hubValue(${index});\n}\n`,
+      path.join(src, 'hub.ts'),
+      'export function hubValue(value: number): number {\n  return value + 1;\n}\n',
     );
-  }
+    for (let index = 0; index < 60; index++) {
+      const suffix = String(index).padStart(3, '0');
+      fs.writeFileSync(
+        path.join(src, `spoke-${suffix}.ts`),
+        `import { hubValue } from './hub';\n\nexport function spoke${index}(): number {\n  return hubValue(${index});\n}\n`,
+      );
+    }
 
-  expect(spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: repoPath }).status).toBe(0);
-  commitAll(repoPath, 'initial large fixture');
-  return { root, repoPath, gitnexusHome };
+    expect(spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: repoPath }).status).toBe(0);
+    commitAll(repoPath, 'initial large fixture');
+    return { root, repoPath, gitnexusHome };
+  });
 };
 
 const parseHarnessResult = (stdout: string): HarnessResult => {

--- a/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
+++ b/gitnexus/test/integration/large-incremental-subprocess-e2e.test.ts
@@ -206,53 +206,77 @@ describe('large incremental analysis subprocess contract', () => {
       );
       commitAll(fixture.repoPath, 'exercise incremental write set');
 
-      const readyFile = path.join(fixture.root, 'pause-ready.json');
-      const interrupted = spawn(
-        process.execPath,
-        [childRunner, fixture.repoPath, '--pause-on-escalation', readyFile],
-        {
-          env: childEnv(fixture.gitnexusHome),
-          stdio: ['ignore', 'pipe', 'pipe'],
-        },
-      );
-      await waitForFile(readyFile, interrupted);
-      const pauseState = JSON.parse(fs.readFileSync(readyFile, 'utf8')) as {
-        message: string;
-        dirty: { phase?: string; effectiveWriteCount?: number; deleteCount?: number };
-      };
-      expect(pauseState.message).toContain('switching to a full DB write');
-      expect(pauseState.dirty.phase).toBe('effective-write-set');
-      expect(pauseState.dirty.effectiveWriteCount).toBeGreaterThanOrEqual(50);
-      expect(pauseState.dirty.deleteCount).toBeGreaterThanOrEqual(50);
+      const boundaries = [
+        ['before-delete', 'escalated-full-write'],
+        ['during-delete', 'escalated-full-write'],
+        ['during-insert', 'escalated-load-graph'],
+        ['before-finalize', 'escalated-load-graph'],
+      ] as const;
+      let recovered: HarnessResult | undefined;
+      for (const [index, [boundary, expectedDirtyPhase]] of boundaries.entries()) {
+        if (index > 0) {
+          fs.appendFileSync(path.join(src, 'hub.ts'), `\n// ${boundary} interruption\n`);
+          commitAll(fixture.repoPath, `prepare ${boundary} interruption`);
+        }
+        const readyFile = path.join(fixture.root, `pause-ready-${boundary}.json`);
+        const interrupted = spawn(
+          process.execPath,
+          [childRunner, fixture.repoPath, '--pause-at', boundary, '--pause-ready', readyFile],
+          {
+            env: childEnv(fixture.gitnexusHome),
+            stdio: ['ignore', 'pipe', 'pipe'],
+          },
+        );
+        await waitForFile(readyFile, interrupted);
+        const pauseState = JSON.parse(fs.readFileSync(readyFile, 'utf8')) as {
+          boundary: string;
+          details: { phase?: string; removedPath?: string; table?: string };
+          dirty: { phase?: string; effectiveWriteCount?: number; deleteCount?: number };
+        };
+        expect(pauseState.boundary).toBe(boundary);
+        expect(pauseState.details.phase).toBe(expectedDirtyPhase);
+        expect(pauseState.dirty.phase).toBe(expectedDirtyPhase);
+        expect(pauseState.dirty.effectiveWriteCount).toBeGreaterThanOrEqual(50);
+        expect(pauseState.dirty.deleteCount).toBeGreaterThanOrEqual(50);
+        if (boundary === 'during-delete') {
+          expect(pauseState.details.removedPath).toMatch(/lbug$/);
+        }
+        if (boundary === 'during-insert') {
+          expect(pauseState.details.table).toBeTruthy();
+        }
 
-      const stopped = await stopChild(interrupted);
-      expect(stopped.code).not.toBe(0);
-      expect(stopped.signal).toBe('SIGTERM');
-      const dirtyMeta = await loadMeta(storagePath);
-      expect(dirtyMeta?.incrementalInProgress).toBeDefined();
+        const stopped = await stopChild(interrupted);
+        expect(stopped.code).not.toBe(0);
+        expect(stopped.signal).toBe('SIGTERM');
+        const dirtyMeta = await loadMeta(storagePath);
+        expect(dirtyMeta?.incrementalInProgress?.phase).toBe(expectedDirtyPhase);
 
-      const recovered = runChild(fixture.repoPath, fixture.gitnexusHome, [
-        '--fts-query',
-        'r09FtsNeedle',
-      ]);
-      expect(recovered.logs.join('\n')).toContain(
-        'Previous analyze run did not complete cleanly (incrementalInProgress flag set)',
-      );
+        recovered = runChild(fixture.repoPath, fixture.gitnexusHome, [
+          '--fts-query',
+          'r09FtsNeedle',
+        ]);
+        expect(recovered.logs.join('\n')).toContain(
+          'Previous analyze run did not complete cleanly (incrementalInProgress flag set)',
+        );
+        expect((await loadMeta(storagePath))?.incrementalInProgress).toBeUndefined();
+      }
+      if (!recovered) throw new Error('recovery matrix produced no successful run');
+      const finalRecovered = recovered;
       const recoveredMeta = await loadMeta(storagePath);
       expect(recoveredMeta?.incrementalInProgress).toBeUndefined();
-      expect(recovered.stats.files).toBe(61);
-      expect(recovered.stats.nodes).toBeGreaterThan(61);
-      expect(recovered.capabilities).toHaveProperty('fts');
-      expect(recovered.capabilities).toHaveProperty('vectorSearch');
-      expect(Array.isArray(recovered.sidecars)).toBe(true);
-      expect(recovered.ftsSearch?.ftsAvailable).toBe(true);
-      expect(recovered.ftsSearch?.results.map((result) => result.filePath)).toContain(
+      expect(finalRecovered.stats.files).toBe(61);
+      expect(finalRecovered.stats.nodes).toBeGreaterThan(61);
+      expect(finalRecovered.capabilities).toHaveProperty('fts');
+      expect(finalRecovered.capabilities).toHaveProperty('vectorSearch');
+      expect(Array.isArray(finalRecovered.sidecars)).toBe(true);
+      expect(finalRecovered.ftsSearch?.ftsAvailable).toBe(true);
+      expect(finalRecovered.ftsSearch?.results.map((result) => result.filePath)).toContain(
         'src/added.ts',
       );
 
       const survivingEmbeddingIds = await readEmbeddingNodeIds(fixture.repoPath);
       expect(survivingEmbeddingIds.length).toBeGreaterThanOrEqual(4);
-      expect(recovered.stats.embeddings).toBe(survivingEmbeddingIds.length);
+      expect(finalRecovered.stats.embeddings).toBe(survivingEmbeddingIds.length);
       expect(survivingEmbeddingIds).not.toContain(seeded.get('src/spoke-001.ts')?.[0]);
       expect(survivingEmbeddingIds).not.toContain(seeded.get('src/spoke-002.ts')?.[0]);
       expect(await readEmbeddingDimensions(fixture.repoPath)).toEqual([384]);
@@ -262,11 +286,11 @@ describe('large incremental analysis subprocess contract', () => {
         '--fts-query',
         'r09FtsNeedle',
       ]);
-      expect(forced.stats).toEqual(recovered.stats);
-      expect(forced.ftsSearch).toEqual(recovered.ftsSearch);
+      expect(forced.stats).toEqual(finalRecovered.stats);
+      expect(forced.ftsSearch).toEqual(finalRecovered.ftsSearch);
       expect(await readEmbeddingNodeIds(fixture.repoPath)).toEqual(survivingEmbeddingIds);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     }
-  }, 600_000);
+  }, 1_800_000);
 });

--- a/gitnexus/test/unit/incremental-orchestration.test.ts
+++ b/gitnexus/test/unit/incremental-orchestration.test.ts
@@ -319,16 +319,34 @@ describe('runFullAnalysis — incremental orchestration', () => {
       await writeFile(hub, (await readFile(hub, 'utf-8')) + '// escalation touch\n', 'utf-8');
 
       const logs: string[] = [];
+      const recoveryBoundaries: Array<{
+        boundary: string;
+        details: Readonly<Record<string, unknown>>;
+      }> = [];
       const incremental = await runFullAnalysis(
         repo.dbPath,
         { skipAgentsMd: true },
-        { onProgress: () => {}, onLog: (m) => logs.push(m) },
+        {
+          onProgress: () => {},
+          onLog: (m) => logs.push(m),
+          onRecoveryBoundary: (boundary, details) => recoveryBoundaries.push({ boundary, details }),
+        },
       );
       expect(incremental.alreadyUpToDate).toBeUndefined();
       const joined = logs.join('\n');
       // The importer expansion fired AND the valve rerouted the write plan.
       expect(joined).toContain('importer(s) added to writable set');
       expect(joined).toContain('switching to a full DB write');
+      expect(recoveryBoundaries.map(({ boundary }) => boundary)).toEqual([
+        'before-delete',
+        'during-delete',
+        'during-insert',
+        'before-finalize',
+      ]);
+      expect(recoveryBoundaries[0]?.details.phase).toBe('escalated-full-write');
+      expect(recoveryBoundaries[1]?.details.phase).toBe('escalated-full-write');
+      expect(recoveryBoundaries[2]?.details.phase).toBe('escalated-load-graph');
+      expect(recoveryBoundaries[3]?.details.phase).toBe('escalated-load-graph');
 
       const { storagePath } = getStoragePaths(repo.dbPath);
       const escalatedMeta = await loadMeta(storagePath);

--- a/gitnexus/test/unit/large-incremental-contract.test.ts
+++ b/gitnexus/test/unit/large-incremental-contract.test.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  ALL_RECOVERY_BOUNDARIES,
+  createHermeticProcessEnv,
+  selectRecoveryBoundaries,
+  startReadyProcess,
+  terminateChild,
+} from '../helpers/large-incremental-contract.js';
+
+const temporaryRoots: string[] = [];
+
+const makeTemporaryRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-large-contract-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('large incremental subprocess isolation', () => {
+  it('passes only portable process keys into an isolated home', () => {
+    const home = makeTemporaryRoot();
+    const env = createHermeticProcessEnv(
+      {
+        PATH: '/safe/bin',
+        LANG: 'C.UTF-8',
+        SSH_AUTH_SOCK: '/private/agent.sock',
+        GITHUB_TOKEN: 'must-not-leak',
+        NODE_OPTIONS: '--require private-hook.cjs',
+        HTTPS_PROXY: 'http://user:secret@example.invalid',
+      },
+      home,
+      { NODE_ENV: 'test', GITNEXUS_HOME: path.join(home, '.gitnexus') },
+      'linux',
+    );
+
+    expect(env).toMatchObject({
+      PATH: '/safe/bin',
+      LANG: 'C.UTF-8',
+      HOME: home,
+      USERPROFILE: home,
+      CI: '1',
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      NODE_ENV: 'test',
+      GITNEXUS_HOME: path.join(home, '.gitnexus'),
+    });
+    expect(env).not.toHaveProperty('SSH_AUTH_SOCK');
+    expect(env).not.toHaveProperty('GITHUB_TOKEN');
+    expect(env).not.toHaveProperty('NODE_OPTIONS');
+    expect(env).not.toHaveProperty('HTTPS_PROXY');
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'kills and reaps a child that never emits readiness',
+    async () => {
+      const home = makeTemporaryRoot();
+      const pidFile = path.join(home, 'child.pid');
+      const script =
+        "require('node:fs').writeFileSync(process.argv[1], String(process.pid)); " +
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);";
+
+      await expect(
+        startReadyProcess({
+          command: process.execPath,
+          args: ['-e', script, pidFile],
+          env: createHermeticProcessEnv(process.env, home, {}, process.platform),
+          readyPrefix: 'READY=',
+          timeoutMs: 100,
+          terminateGraceMs: 100,
+        }),
+      ).rejects.toThrow('did not become ready');
+
+      const pid = Number(fs.readFileSync(pidFile, 'utf8'));
+      expect(() => process.kill(pid, 0)).toThrow();
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'escalates a signal-resistant child to SIGKILL',
+    async () => {
+      const home = makeTemporaryRoot();
+      const readyScript =
+        "process.on('SIGTERM', () => {}); process.stdout.write('READY=ok\\n'); " +
+        'setInterval(() => {}, 1000);';
+      const ready = await startReadyProcess({
+        command: process.execPath,
+        args: ['-e', readyScript],
+        env: createHermeticProcessEnv(process.env, home, {}, process.platform),
+        readyPrefix: 'READY=',
+        timeoutMs: 1_000,
+      });
+
+      await expect(terminateChild(ready.child, 100)).resolves.toEqual({
+        code: null,
+        signal: 'SIGKILL',
+      });
+      const pid = ready.child.pid;
+      expect(pid).toBeDefined();
+      if (!pid) throw new Error('ready child did not expose a pid');
+      expect(() => process.kill(pid, 0)).toThrow();
+    },
+  );
+});
+
+describe('large incremental recovery boundary selection', () => {
+  it('runs every durable interruption boundary by default', () => {
+    expect(selectRecoveryBoundaries(undefined)).toEqual(ALL_RECOVERY_BOUNDARIES);
+  });
+
+  it('accepts an explicit bounded subset for the cross-platform matrix', () => {
+    expect(selectRecoveryBoundaries('during-delete,before-finalize,during-delete')).toEqual([
+      'during-delete',
+      'before-finalize',
+    ]);
+  });
+
+  it('rejects empty or unknown boundary configuration', () => {
+    expect(() => selectRecoveryBoundaries('  ')).toThrow('must name at least one');
+    expect(() => selectRecoveryBoundaries('during-delete,unknown')).toThrow('unknown');
+  });
+});

--- a/gitnexus/test/unit/large-incremental-contract.test.ts
+++ b/gitnexus/test/unit/large-incremental-contract.test.ts
@@ -7,7 +7,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   ALL_RECOVERY_BOUNDARIES,
   createHermeticProcessEnv,
+  setupDisposableRoot,
   selectRecoveryBoundaries,
+  stageRegularFileTree,
   startReadyProcess,
   terminateChild,
 } from '../helpers/large-incremental-contract.js';
@@ -109,6 +111,55 @@ describe('large incremental subprocess isolation', () => {
       expect(() => process.kill(pid, 0)).toThrow();
     },
   );
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects extension symlinks before creating the isolated destination',
+    () => {
+      const root = makeTemporaryRoot();
+      const source = path.join(root, 'source');
+      const destination = path.join(root, 'destination');
+      const outside = path.join(root, 'outside.bin');
+      fs.mkdirSync(path.join(source, '0.18.0', 'osx_arm64', 'fts'), { recursive: true });
+      fs.writeFileSync(outside, 'outside\n');
+      fs.symlinkSync(
+        outside,
+        path.join(source, '0.18.0', 'osx_arm64', 'fts', 'libfts.lbug_extension'),
+      );
+
+      expect(() => stageRegularFileTree(source, destination)).toThrow('symbolic link');
+      expect(fs.existsSync(destination)).toBe(false);
+    },
+  );
+
+  it('copies only validated regular extension files', () => {
+    const root = makeTemporaryRoot();
+    const source = path.join(root, 'source');
+    const destination = path.join(root, 'destination');
+    const relative = path.join('0.18.0', 'platform', 'fts', 'libfts.lbug_extension');
+    fs.mkdirSync(path.dirname(path.join(source, relative)), { recursive: true });
+    fs.writeFileSync(path.join(source, relative), 'extension-bytes\n');
+
+    stageRegularFileTree(source, destination);
+
+    expect(fs.readFileSync(path.join(destination, relative), 'utf8')).toBe('extension-bytes\n');
+    expect(fs.lstatSync(path.join(destination, relative)).isFile()).toBe(true);
+  });
+
+  it('removes an allocated disposable root when setup fails', () => {
+    const parent = makeTemporaryRoot();
+    let allocated = '';
+
+    expect(() =>
+      setupDisposableRoot(path.join(parent, 'fixture-'), (root) => {
+        allocated = root;
+        fs.writeFileSync(path.join(root, 'partial.txt'), 'partial\n');
+        throw new Error('injected setup failure');
+      }),
+    ).toThrow('injected setup failure');
+
+    expect(allocated).not.toBe('');
+    expect(fs.existsSync(allocated)).toBe(false);
+  });
 });
 
 describe('large incremental recovery boundary selection', () => {

--- a/gitnexus/test/unit/reconciliation-canary-environment.test.ts
+++ b/gitnexus/test/unit/reconciliation-canary-environment.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSanitizedEnvironment } from '../../scripts/reconciliation/canary-environment.mjs';
+
+describe('reconciliation canary environment', () => {
+  it('retains only process plumbing and replaces user Git configuration', () => {
+    const result = createSanitizedEnvironment(
+      {
+        PATH: '/usr/bin',
+        LANG: 'en_US.UTF-8',
+        TMPDIR: '/tmp/canary',
+        GH_TOKEN: 'github-secret',
+        GITHUB_TOKEN: 'actions-secret',
+        OPENAI_API_KEY: 'openai-secret',
+        AWS_SECRET_ACCESS_KEY: 'aws-secret',
+        npm_config_token: 'npm-secret',
+      },
+      { home: '/tmp/isolated-home', platform: 'darwin' },
+    );
+
+    expect(result).toEqual({
+      PATH: '/usr/bin',
+      TMPDIR: '/tmp/canary',
+      LANG: 'en_US.UTF-8',
+      HOME: '/tmp/isolated-home',
+      USERPROFILE: '/tmp/isolated-home',
+      CI: '1',
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_GLOBAL: '/dev/null',
+    });
+    expect(Object.values(result)).not.toContain('github-secret');
+    expect(Object.values(result)).not.toContain('openai-secret');
+  });
+
+  it('retains required Windows process keys without inheriting credentials', () => {
+    const result = createSanitizedEnvironment(
+      {
+        PATH: 'C:\\Windows\\System32',
+        SystemRoot: 'C:\\Windows',
+        COMSPEC: 'C:\\Windows\\System32\\cmd.exe',
+        GH_TOKEN: 'github-secret',
+      },
+      { home: 'C:\\canary-home', platform: 'win32' },
+    );
+
+    expect(result.SystemRoot).toBe('C:\\Windows');
+    expect(result.COMSPEC).toBe('C:\\Windows\\System32\\cmd.exe');
+    expect(result.GIT_CONFIG_GLOBAL).toBe('NUL');
+    expect(result).not.toHaveProperty('GH_TOKEN');
+  });
+
+  it('requires an isolated home', () => {
+    expect(() => createSanitizedEnvironment({ PATH: '/usr/bin' }, {})).toThrow(
+      'sanitized environment requires an isolated home',
+    );
+  });
+});

--- a/gitnexus/test/unit/reconciliation-canary-safety.test.ts
+++ b/gitnexus/test/unit/reconciliation-canary-safety.test.ts
@@ -8,6 +8,7 @@ import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  ChildSupervisor,
   createSafeContainedDirectory,
   openArtifactLogs,
   selectSafeTrackedFiles,
@@ -29,6 +30,61 @@ afterEach(() => {
 });
 
 describe('reconciliation canary filesystem safety', () => {
+  it.skipIf(process.platform === 'win32')(
+    'refuses a symlinked command ledger before reading resume evidence',
+    () => {
+      const root = makeTemporaryRoot();
+      const source = path.join(root, 'source');
+      const evidence = path.join(root, 'evidence');
+      const extensionSource = path.join(root, 'extension');
+      const fakeCli = path.join(root, 'fake-cli.mjs');
+      const victim = path.join(root, 'private-ledger.json');
+      const worktree = path.join(root, 'worktree');
+
+      fs.mkdirSync(source);
+      fs.mkdirSync(evidence);
+      fs.mkdirSync(extensionSource);
+      fs.mkdirSync(worktree);
+      fs.writeFileSync(path.join(source, 'README.md'), 'fixture\n');
+      fs.writeFileSync(path.join(extensionSource, 'extension.bin'), 'fixture\n');
+      fs.writeFileSync(fakeCli, 'process.exit(1);\n');
+      fs.writeFileSync(victim, '[{"private":"preserve-me"}]\n');
+      fs.symlinkSync(victim, path.join(evidence, 'command-ledger.json'));
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          'scripts/reconciliation/large-repository-canary.mjs',
+          '--source',
+          source,
+          '--source-sha',
+          '0123456789abcdef0123456789abcdef01234567',
+          '--public-origin',
+          'https://example.invalid/repository.git',
+          '--worktree',
+          worktree,
+          '--evidence',
+          evidence,
+          '--gitnexus-cli',
+          fakeCli,
+          '--incremental-child',
+          fakeCli,
+          '--extension-source',
+          extensionSource,
+          '--run-id',
+          'ledger-symlink-test',
+          '--resume-from',
+          'wide',
+        ],
+        { cwd: path.resolve(import.meta.dirname, '../..'), encoding: 'utf8' },
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toContain('symbolic link');
+      expect(fs.readFileSync(victim, 'utf8')).toBe('[{"private":"preserve-me"}]\n');
+    },
+  );
+
   it.skipIf(process.platform === 'win32')(
     'refuses a preexisting evidence symlink without truncating its target',
     () => {
@@ -161,7 +217,7 @@ describe('reconciliation canary filesystem safety', () => {
   );
 
   it.skipIf(process.platform === 'win32')(
-    'forwards an orchestrator signal to its owned child process tree',
+    'force-kills a signal-resistant grandchild after its direct child exits',
     async () => {
       const root = makeTemporaryRoot();
       const pidFile = path.join(root, 'pids.json');
@@ -175,8 +231,8 @@ describe('reconciliation canary filesystem safety', () => {
         childScript,
         `import { spawn } from 'node:child_process';\n` +
           `import fs from 'node:fs';\n` +
-          `const grandchild = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)']);\n` +
-          `fs.writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify({ child: process.pid, grandchild: grandchild.pid }));\n` +
+          `const grandchild = spawn(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); process.stdout.write("ready\\\\n"); setInterval(() => {}, 1000)'], { stdio: ['ignore', 'pipe', 'ignore'] });\n` +
+          `grandchild.stdout.once('data', () => fs.writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify({ child: process.pid, grandchild: grandchild.pid })));\n` +
           `setInterval(() => {}, 1000);\n`,
       );
       fs.writeFileSync(
@@ -220,4 +276,37 @@ describe('reconciliation canary filesystem safety', () => {
       expect(isAlive(pids.grandchild)).toBe(false);
     },
   );
+
+  it('uses an absolute taskkill path and sanitized environment on Windows', () => {
+    const calls: Array<{ command: string; options: { env?: NodeJS.ProcessEnv } }> = [];
+    const terminationEnv = {
+      SystemRoot: 'C:\\Windows',
+      WINDIR: 'C:\\Windows',
+      PATH: 'C:\\Windows\\System32',
+      HOME: 'C:\\isolated',
+    };
+    const supervisor = new ChildSupervisor({
+      platform: 'win32',
+      terminationEnv,
+      spawnSyncImpl: (command: string, _args: string[], options: { env?: NodeJS.ProcessEnv }) => {
+        calls.push({ command, options });
+        return { status: 0 };
+      },
+    });
+    const child = {
+      pid: 1234,
+      exitCode: null,
+      signalCode: null,
+      kill: () => {
+        throw new Error('taskkill fallback should not run');
+      },
+    };
+
+    supervisor.terminate(child);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe('C:\\Windows\\System32\\taskkill.exe');
+    expect(calls[0]?.options.env).toEqual(terminationEnv);
+    expect(calls[0]?.options.env).not.toHaveProperty('GH_TOKEN');
+  });
 });

--- a/gitnexus/test/unit/reconciliation-canary-safety.test.ts
+++ b/gitnexus/test/unit/reconciliation-canary-safety.test.ts
@@ -1,0 +1,223 @@
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createSafeContainedDirectory,
+  openArtifactLogs,
+  selectSafeTrackedFiles,
+  writeJsonArtifact,
+} from '../../scripts/reconciliation/canary-safety.mjs';
+
+const temporaryRoots: string[] = [];
+
+const makeTemporaryRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-canary-safety-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe('reconciliation canary filesystem safety', () => {
+  it.skipIf(process.platform === 'win32')(
+    'refuses a preexisting evidence symlink without truncating its target',
+    () => {
+      const root = makeTemporaryRoot();
+      const source = path.join(root, 'source');
+      const evidence = path.join(root, 'evidence');
+      const commands = path.join(evidence, 'commands');
+      const extensionSource = path.join(root, 'extension');
+      const fakeCli = path.join(root, 'fake-cli.mjs');
+      const victim = path.join(root, 'victim.txt');
+      const worktree = path.join(root, 'worktree');
+
+      fs.mkdirSync(source);
+      fs.mkdirSync(commands, { recursive: true });
+      fs.mkdirSync(extensionSource);
+      fs.writeFileSync(path.join(source, 'README.md'), 'fixture\n');
+      fs.writeFileSync(path.join(extensionSource, 'extension.bin'), 'fixture\n');
+      fs.writeFileSync(fakeCli, 'process.exit(1);\n');
+      fs.writeFileSync(victim, 'preserve-me\n');
+      fs.symlinkSync(victim, path.join(commands, 'clone.stdout.log'));
+
+      execFileSync('git', ['init', '-q'], { cwd: source });
+      execFileSync('git', ['add', 'README.md'], { cwd: source });
+      execFileSync(
+        'git',
+        [
+          '-c',
+          'user.name=Canary Test',
+          '-c',
+          'user.email=canary-test@example.invalid',
+          'commit',
+          '-q',
+          '-m',
+          'fixture',
+        ],
+        { cwd: source },
+      );
+      const sourceSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: source,
+        encoding: 'utf8',
+      }).trim();
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          'scripts/reconciliation/large-repository-canary.mjs',
+          '--source',
+          source,
+          '--source-sha',
+          sourceSha,
+          '--public-origin',
+          'https://example.invalid/repository.git',
+          '--worktree',
+          worktree,
+          '--evidence',
+          evidence,
+          '--gitnexus-cli',
+          fakeCli,
+          '--incremental-child',
+          fakeCli,
+          '--extension-source',
+          extensionSource,
+          '--run-id',
+          'symlink-safety-test',
+        ],
+        { cwd: path.resolve(import.meta.dirname, '../..'), encoding: 'utf8' },
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toContain('symbolic link');
+      expect(fs.readFileSync(victim, 'utf8')).toBe('preserve-me\n');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'refuses a symlinked fixture-directory component outside the worktree',
+    () => {
+      const root = makeTemporaryRoot();
+      const worktree = path.join(root, 'worktree');
+      const victimDirectory = path.join(root, 'victim');
+      fs.mkdirSync(worktree);
+      fs.mkdirSync(victimDirectory);
+      fs.symlinkSync(victimDirectory, path.join(worktree, 'src'));
+
+      expect(() => createSafeContainedDirectory(worktree, 'src/r19-canary')).toThrow(
+        'symbolic link',
+      );
+      expect(fs.readdirSync(victimDirectory)).toEqual([]);
+    },
+  );
+
+  it('preserves prior command logs and snapshots across retry attempts', () => {
+    const root = makeTemporaryRoot();
+    const commands = path.join(root, 'commands');
+    const snapshots = path.join(root, 'snapshots');
+    fs.mkdirSync(commands);
+    fs.mkdirSync(snapshots);
+    fs.writeFileSync(path.join(commands, 'clone.stdout.log'), 'first stdout\n');
+    fs.writeFileSync(path.join(commands, 'clone.stderr.log'), 'first stderr\n');
+    fs.writeFileSync(path.join(snapshots, 'initial.json'), '{"attempt":1}\n');
+
+    const logs = openArtifactLogs(commands, 'clone');
+    fs.writeSync(logs.stdout, 'second stdout\n');
+    fs.writeSync(logs.stderr, 'second stderr\n');
+    fs.closeSync(logs.stdout);
+    fs.closeSync(logs.stderr);
+    const retrySnapshot = writeJsonArtifact(snapshots, 'initial', { attempt: 2 });
+
+    expect(path.basename(logs.stdoutPath)).toBe('clone-attempt-2.stdout.log');
+    expect(path.basename(logs.stderrPath)).toBe('clone-attempt-2.stderr.log');
+    expect(path.basename(retrySnapshot)).toBe('initial-attempt-2.json');
+    expect(fs.readFileSync(path.join(commands, 'clone.stdout.log'), 'utf8')).toBe('first stdout\n');
+    expect(fs.readFileSync(path.join(commands, 'clone.stderr.log'), 'utf8')).toBe('first stderr\n');
+    expect(fs.readFileSync(path.join(snapshots, 'initial.json'), 'utf8')).toBe('{"attempt":1}\n');
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a tracked TypeScript symlink without modifying its target',
+    () => {
+      const root = makeTemporaryRoot();
+      const worktree = path.join(root, 'worktree');
+      const victim = path.join(root, 'victim.ts');
+      fs.mkdirSync(worktree);
+      fs.writeFileSync(victim, 'export const preserve = true;\n');
+      fs.symlinkSync(victim, path.join(worktree, 'linked.ts'));
+
+      expect(() => selectSafeTrackedFiles(worktree, ['linked.ts'], 1)).toThrow('symbolic link');
+      expect(fs.readFileSync(victim, 'utf8')).toBe('export const preserve = true;\n');
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'forwards an orchestrator signal to its owned child process tree',
+    async () => {
+      const root = makeTemporaryRoot();
+      const pidFile = path.join(root, 'pids.json');
+      const childScript = path.join(root, 'child.mjs');
+      const wrapperScript = path.join(root, 'wrapper.mjs');
+      const safetyModule = path.resolve(
+        import.meta.dirname,
+        '../../scripts/reconciliation/canary-safety.mjs',
+      );
+      fs.writeFileSync(
+        childScript,
+        `import { spawn } from 'node:child_process';\n` +
+          `import fs from 'node:fs';\n` +
+          `const grandchild = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)']);\n` +
+          `fs.writeFileSync(${JSON.stringify(pidFile)}, JSON.stringify({ child: process.pid, grandchild: grandchild.pid }));\n` +
+          `setInterval(() => {}, 1000);\n`,
+      );
+      fs.writeFileSync(
+        wrapperScript,
+        `import { once } from 'node:events';\n` +
+          `import { ChildSupervisor } from ${JSON.stringify(pathToFileURL(safetyModule).href)};\n` +
+          `const supervisor = new ChildSupervisor({ killTimeoutMs: 200 });\n` +
+          `supervisor.installSignalHandlers();\n` +
+          `const child = supervisor.spawn(process.execPath, [${JSON.stringify(childScript)}], { stdio: 'ignore' });\n` +
+          `await once(child, 'close');\n` +
+          `supervisor.disposeSignalHandlers();\n`,
+      );
+
+      const wrapper = spawn(process.execPath, [wrapperScript], { stdio: 'ignore' });
+      const deadline = Date.now() + 5_000;
+      while (!fs.existsSync(pidFile) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(fs.existsSync(pidFile)).toBe(true);
+      const pids = JSON.parse(fs.readFileSync(pidFile, 'utf8')) as {
+        child: number;
+        grandchild: number;
+      };
+
+      wrapper.kill('SIGTERM');
+      await once(wrapper, 'close');
+
+      const isAlive = (pid: number): boolean => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      };
+      const exitDeadline = Date.now() + 5_000;
+      while ((isAlive(pids.child) || isAlive(pids.grandchild)) && Date.now() < exitDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(isAlive(pids.child)).toBe(false);
+      expect(isAlive(pids.grandchild)).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add a fail-closed, resumable disposable-repository canary for OpenClaw-scale analysis
- record source identity, command ledger, graph/relationship fingerprints, embeddings, sidecars, disk state, dirty markers, and bounded failure evidence
- exercise controlled add/edit/rename/delete, importer closure, forced escalation, SIGTERM interruption, recovery, full rebuild, FTS, vector, query, context, impact, status, and doctor
- extend the subprocess child with explicit embedding execution while keeping skills and agent-document mutation disabled

## Safety boundary
- refuses an existing worktree on a fresh run
- requires an exact public source SHA and isolated HOME/GITNEXUS_HOME
- uses a deterministic local embedding endpoint and disposable index only
- does not publish, deploy, mutate the live OpenClaw index, or copy credentials

## Validation
- `node --check gitnexus/scripts/reconciliation/large-repository-canary.mjs`
- `node --check gitnexus/test/fixtures/large-incremental-child.mjs`
- `npx prettier --check scripts/reconciliation/large-repository-canary.mjs test/fixtures/large-incremental-child.mjs`
- `npx vitest run test/integration/large-incremental-subprocess-e2e.test.ts` (1/1 passed, 248.25s)
- first disposable OpenClaw run retained 251,532 deterministic test embeddings and correctly stopped on an unexplained graph-fingerprint mismatch; diagnostic repeat remains isolated and active

Tracks #58. R19 acceptance and issue closure remain gated on two complete successful disposable canaries.
