### PR TITLE
ci: run gitleaks without licensed action wrapper

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -38,9 +38,7 @@ jobs:
           # steps (and Gitleaks itself) don't need it for repo operations.
           persist-credentials: false
 
-      # gitleaks-action builds `base^..head` for pull_request events; both SHAs
-      # must exist locally (fork PRs and shallow checkouts otherwise fail with
-      # "unknown revision" — see gitleaks/gitleaks-action#199).
+      # Both SHAs must exist locally so the CLI can scan exactly the PR range.
       - name: Fetch PR refs for gitleaks range
         if: github.event_name == 'pull_request'
         env:
@@ -50,11 +48,42 @@ jobs:
           git fetch --no-tags origin "$BASE_SHA"
           git fetch --no-tags origin "$HEAD_SHA"
 
-      # No GITLEAKS_LICENSE secret is required for OSS / public-repo usage.
-      # If this repo becomes private, the action will require a license key.
+      # The Gitleaks Action wrapper requires a license for organization-owned
+      # repositories. Run the official CLI image directly so secret scanning
+      # remains local, deterministic, and independent of an external license.
       - name: Gitleaks
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
-          GITLEAKS_ENABLE_SUMMARY: true
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          log_opts="--all"
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            log_opts="${BASE_SHA}..${HEAD_SHA}"
+          fi
+
+          # Gitleaks can otherwise report success after a Git discovery error.
+          # Verify a non-empty range inside the same container before scanning.
+          docker run --rm \
+            --network none \
+            --user "$(id -u):$(id -g)" \
+            --env GIT_CONFIG_COUNT=1 \
+            --env GIT_CONFIG_KEY_0=safe.directory \
+            --env GIT_CONFIG_VALUE_0=/repo \
+            --volume "$PWD:/repo:ro" \
+            --workdir /repo \
+            --entrypoint /bin/sh \
+            ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f \
+            -eu -c '
+              range="$1"
+              if [ "$range" = "--all" ]; then
+                commit_count="$(git rev-list --count --all)"
+              else
+                commit_count="$(git rev-list --count "$range")"
+              fi
+              if [ "$commit_count" -eq 0 ]; then
+                echo "gitleaks preflight refused an empty commit range" >&2
+                exit 2
+              fi
+              exec gitleaks git --redact --verbose --exit-code 1 --log-opts="$range" .
+            ' sh "$log_opts"


### PR DESCRIPTION
## Summary

- replace the organization-licensed `gitleaks-action` wrapper with the official Gitleaks v8.30.1 CLI image pinned by immutable multi-platform digest
- keep PR scans bounded to `base..head` and `main` push scans on full history
- run with no network, a read-only repository mount, least-privilege workflow permissions, and redacted output
- preflight a non-empty Git range inside the same container so Git discovery failures cannot produce false-success zero-commit scans

## Proof

- `actionlint .github/workflows/gitleaks.yml`: passed
- `git diff --check`: passed
- linked-worktree inaccessible-Git proof: exited 128 before scanning
- standalone exact promotion range: preflighted 238 commits, Gitleaks scanned 227 patch-bearing commits / 40.35 MB, no leaks, 10.3s
- promotion PR #98 will supply the canonical current-head GitHub Actions proof after this workflow commit is incorporated

Closes #99
Parent: #39
Promotion: #98

This PR changes CI only. It does not merge the promotion candidate, publish, release, deploy, roll out runtime changes, or mutate an index.