### PR TITLE
fix(canary): hash extension files from one read

### DIFF
--- a/gitnexus/scripts/reconciliation/large-repository-canary.mjs
+++ b/gitnexus/scripts/reconciliation/large-repository-canary.mjs
@@ -108,10 +108,11 @@ const collectExtensionFiles = (dir) => {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) collectExtensionFiles(fullPath);
     if (entry.isFile()) {
+      const contents = fs.readFileSync(fullPath);
       extensionFiles.push({
         path: path.relative(extensionSource, fullPath),
-        bytes: fs.statSync(fullPath).size,
-        sha256: crypto.createHash('sha256').update(fs.readFileSync(fullPath)).digest('hex'),
+        bytes: contents.byteLength,
+        sha256: crypto.createHash('sha256').update(contents).digest('hex'),
       });
     }
   }


### PR DESCRIPTION
## Summary

- remove the extension-manifest `statSync` / `readFileSync` time-of-check/time-of-use pair
- read each file once and derive both `bytes` and `sha256` from the same immutable buffer
- preserve manifest paths, ordering, hash algorithm, and output schema

## Proof

- `node --check gitnexus/scripts/reconciliation/large-repository-canary.mjs`: passed
- `git diff --check`: passed
- `reconciliation-canary-safety.test.ts`: 7/7 passed
- promotion PR #98 supplies canonical current-head CodeQL and full remote CI after incorporation

Closes #101
Parent: #39
Promotion: #98

This changes only the disposable canary harness. It does not merge promotion, publish, release, deploy, roll out runtime changes, or mutate an index.