### PR TITLE
fix(container): repin patched Node base image

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -9,7 +9,7 @@ ARG NPM_VERSION=11.14.1
 # Native modules (tree-sitter-*, onnxruntime-node, node-gyp builds for
 # tree-sitter-proto / tree-sitter-swift) require python3 + a C/C++ toolchain.
 # node:22-bookworm-slim
-FROM node:22-bookworm-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e AS builder
+FROM node:22-bookworm-slim@sha256:c29352e5563688e726158e23480bc2d4bd0af23bbdd055f8b837a12ecfd6a2a1 AS builder
 ARG NPM_VERSION
 
 WORKDIR /app
@@ -49,7 +49,7 @@ RUN npm run postinstall --prefix gitnexus
 
 # -- Runtime -----------------------------------------------------------
 # node:22-bookworm-slim
-FROM node:22-bookworm-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e AS runtime
+FROM node:22-bookworm-slim@sha256:c29352e5563688e726158e23480bc2d4bd0af23bbdd055f8b837a12ecfd6a2a1 AS runtime
 
 # curl for the healthcheck; git for cloning; ca-certificates for TLS verification.
 RUN apt-get update && apt-get install -y --no-install-recommends curl git ca-certificates && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -5,7 +5,7 @@ ARG TARGETPLATFORM
 ARG NPM_VERSION=11.14.1
 
 # node:22-bookworm-slim
-FROM --platform=$BUILDPLATFORM node:22-bookworm-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e AS builder
+FROM --platform=$BUILDPLATFORM node:22-bookworm-slim@sha256:c29352e5563688e726158e23480bc2d4bd0af23bbdd055f8b837a12ecfd6a2a1 AS builder
 ARG NPM_VERSION
 
 WORKDIR /app
@@ -27,7 +27,7 @@ COPY gitnexus-web ./gitnexus-web
 RUN npm run build --prefix gitnexus-web
 
 # node:22-bookworm-slim
-FROM node:22-bookworm-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e AS runtime
+FROM node:22-bookworm-slim@sha256:c29352e5563688e726158e23480bc2d4bd0af23bbdd055f8b837a12ecfd6a2a1 AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/lib/node_modules/npm \

--- a/gitnexus/Dockerfile.test
+++ b/gitnexus/Dockerfile.test
@@ -3,7 +3,7 @@
 ARG NPM_VERSION=11.14.1
 
 # node:22-bookworm-slim
-FROM node:22-bookworm-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e
+FROM node:22-bookworm-slim@sha256:c29352e5563688e726158e23480bc2d4bd0af23bbdd055f8b837a12ecfd6a2a1
 ARG NPM_VERSION
 WORKDIR /app
 RUN npx --yes npm@${NPM_VERSION} install -g npm@${NPM_VERSION} \


### PR DESCRIPTION
Closes #105

## What changed

Repins all coordinated Node 22 Bookworm Slim Dockerfiles from the older immutable digest to `sha256:c29352e5563688e726158e23480bc2d4bd0af23bbdd055f8b837a12ecfd6a2a1`.

## Security proof

- old digest `liblzma5`: `5.4.1-1`
- new digest `liblzma5`: `5.4.1-1+deb12u1`
- Trivy alert #367 requires `5.4.1-1+deb12u1`
- the new digest is a verified multi-architecture OCI index
- all five Dockerfile references were updated together; no floating tag was introduced

## Validation

- immutable digest manifest inspection: passed
- runtime `dpkg-query` package-version assertion: passed
- coordinated-reference count and stale-digest absence checks: passed
- `git diff --check`: passed
- remote Docker builds and Trivy scans are required before integration

## Boundaries

No application dependency, embedding, indexing, provider, publication, release, deployment, promotion merge, or live-index mutation.
