### PR TITLE
chore(release): prepare 1.6.10-electric.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-rc.19",
+      "version": "1.6.10-electric.1",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-rc.19",
+      "version": "1.6.10-electric.1",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.1.md
+++ b/Documentation/releases/1.6.10-electric.1.md
@@ -1,0 +1,68 @@
+# GitNexus 1.6.10-electric.1
+
+`1.6.10-electric.1` is the first long-term Electric Sheep GitHub-only release
+from the reconciled GitNexus fork. It packages the proven internal source
+candidate as an installable tarball with a SHA-256 checksum, without publishing
+to npm or a container registry.
+
+## Highlights
+
+- Static, configuration, and document-heavy repositories keep searchable
+  embeddings through a text-bearing File-node fallback.
+- Large incremental updates have subprocess coverage for adds, edits, renames,
+  deletes, FTS, vectors, embeddings, escalation, interruption, and resume.
+- MCP operators can bound output, use compatible parameter aliases, restrict
+  repositories, and run a fail-closed read-only surface.
+- Interrupted analysis gains a strict no-force incremental contract and a
+  read-only recovery plan before any unsafe rebuild.
+- HTTP embeddings use bounded retry and resume behavior, while optional
+  reranking remains isolated behind a provider interface.
+
+## Changes
+
+- Non-loopback eval-server binding now requires bearer authentication.
+- VECTOR diagnostics cover extension loading, existing indexes, and exact-scan
+  fallback behavior.
+- Repository traversal, graph lookup, community projection, and Rust/PHP import
+  resolution are deterministic across input order.
+- Release governance is manual-only, exact-head, protected by
+  `internal-release`, and limited to a GitHub Release tarball plus
+  `SHA256SUMS`.
+
+## Fixes
+
+- Node deletion and Cypher CLI failures surface non-zero outcomes instead of
+  false success.
+- FTS deletion, durable sidecars, dirty markers, and ParsedFile generations are
+  covered by bounded recovery behavior.
+- Release-state retries verify the encoded Electric tag, exact commit, and
+  resumable draft before mutation.
+- Dependency, Gitleaks, terminal-output, canary-manifest, and container-base
+  hardening from the reconciliation program are included.
+
+## Known Boundaries
+
+- Provenance is upstream `v1.6.10-rc.19` at
+  `d43c479ac58c18d397958f48a99465d6c3110b1d`, reconciled through fork PR #98.
+  This version does not imply that an upstream stable `v1.6.10` tag existed.
+- Distribution is a GitHub Release only. Public npm dist-tags and container
+  registries are outside this release and must remain unchanged.
+- Publishing the artifact does not install it into OpenClaw or evaOS, mutate a
+  live GitNexus index, rebuild embeddings, or change runtime configuration.
+- The earlier full OpenClaw corpus run remains non-blocking diagnostic evidence;
+  release confidence uses the bounded disposable canaries and cross-platform CI
+  recorded in PR #98.
+
+## Release Verification
+
+- Release PR: package, lockfile, Claude/Codex plugin manifests, and both
+  marketplaces agree on `1.6.10-electric.1`.
+- Required CI: build, typecheck, unit/integration coverage, platform-sensitive
+  macOS/Linux/Windows tests, package-install smoke, security checks, and review.
+- Protected workflow: pack dry-run, build, isolated tarball install,
+  `gitnexus --version`, CLI/MCP help, SHA-256 generation, asset verification,
+  and publish-last draft promotion.
+- Post-release: download both assets, verify `SHA256SUMS`, reinstall in a fresh
+  prefix, and confirm npm/container/runtime/index/embedding state is unchanged.
+
+Tracking: #98, #109, #110, #111.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-rc.19",
+  "version": "1.6.10-electric.1",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-rc.19",
+  "version": "1.6.10-electric.1",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.1] - 2026-07-14
+
+### Added
+
+- **Protected GitHub-only Electric releases** with exact-head CI, isolated package installation, SHA-256 assets, resumable drafts, and a protected approval gate (#109, #110, #111)
+- **Bounded MCP interfaces** with parameter aliases, deterministic output budgets, fail-closed read-only mode, and repository allowlist/default policy (#73, #74, #76, #77)
+- **Read-only recovery planning and strict incremental-only analysis** for safer interrupted-analysis handling (#72)
+- **Resilient HTTP embeddings and isolated optional reranking** with bounded retries, durable resume, and upstream-compatible ranking when reranking is disabled (#78, #79)
+
+### Fixed
+
+- **Static and document-heavy repositories retain searchable embeddings** through text-bearing File-node fallback (#66)
+- **Large incremental analysis fails loudly and recovers deterministically** across deletes, FTS, staged sidecars, dirty markers, and escalation boundaries (#67, #68, #71)
+- **Non-loopback eval-server binds require bearer authentication** while loopback development remains available without a token (#75)
+- **VECTOR delete/reopen diagnostics and fallback behavior** are explicit and tested (#80, #82)
+- **Graph construction is deterministic** across community projection, graph lookup collisions, repository traversal, and Rust/PHP import resolution (#91, #94, #96)
+- **Release, dependency, CLI, cache, and terminal-output hardening** carried by the reconciled internal source candidate (#85, #87, #89, #100, #102, #104, #106, #108)
+
+### Changed
+
+- This Electric release is distributed as a downloadable GitHub Release tarball and checksum only. It does not publish to npm or a container registry and does not perform a runtime rollout, index migration, or embedding refresh.
+- Source provenance is upstream `v1.6.10-rc.19` at `d43c479ac58c18d397958f48a99465d6c3110b1d`, reconciled through fork PR #98. It does not claim ancestry from an upstream stable `v1.6.10` tag.
+
 ## [1.6.9] - 2026-07-04
 
 ### Added

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-rc.19",
+  "version": "1.6.10-electric.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-rc.19",
+      "version": "1.6.10-electric.1",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-rc.19",
+  "version": "1.6.10-electric.1",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Summary

- set the CLI, lockfile, Claude/Codex plugin manifests, and both marketplace manifests to `1.6.10-electric.1`
- add the fork changelog entry and versioned GitHub Release notes
- prepare the first long-term Electric GitHub-only artifact release

## Provenance

- reconciled source promotion: #98
- release governance: #109 / #110
- RC19 peeled source floor: `d43c479ac58c18d397958f48a99465d6c3110b1d`
- current fork `main` base: `b3b94040808b1f11f5628803ecacb54d79d8239c`
- this release remains explicitly RC19-based and does not claim upstream stable `v1.6.10` ancestry

## Validation

- release policy suite: 24/24
- plugin and marketplace version sync: 3/3
- `npm run build`
- `npx tsc --noEmit`
- `npm pack` dry-run and real pack
- isolated tarball install reports `1.6.10-electric.1`
- packaged CLI `--help` and `mcp --help`
- local tarball SHA-256 verification
- `git diff --check`

Remote CI on this exact PR head is the canonical broad validation gate.

## Release boundary

This PR only promotes source and version metadata. It does not create a tag or release and does not publish npm packages or containers. It does not change OpenClaw runtime state, live GitNexus indexes, or embeddings.

After merge, the protected `Electric Release` workflow will independently rebuild, install, checksum, and require `internal-release` approval before creating `electric/v1.6.10-electric.1`.

Relates #111