### PR TITLE
fix(ci): avoid parsing npm pack lifecycle output

### DIFF
--- a/.github/scripts/check-electric-release-policy.mjs
+++ b/.github/scripts/check-electric-release-policy.mjs
@@ -220,11 +220,21 @@ function checkReleaseWorkflow(workflows) {
     ['npm pack --dry-run', 'npm pack dry-run'],
     ['FILENAME="gitnexus-$EXPECTED_VERSION.tgz"', 'deterministic package asset filename'],
     [
+      'if [ ! -f "$ASSET_PATH" ] || [ ! -s "$ASSET_PATH" ]; then',
+      'non-empty regular package asset validation',
+    ],
+    [
       'if [ "$VERSION_OUTPUT" != "$EXPECTED_VERSION" ]; then',
       'exact packaged-version equality check',
     ],
     ['SHA256SUMS', 'SHA256SUMS asset'],
   ]);
+  if (
+    typeof packageStep?.step?.run === 'string' &&
+    /\bJSON\.parse\s*\(/.test(packageStep.step.run)
+  ) {
+    fail('electric-release.yml package proof step must not parse npm pack stdout as JSON');
+  }
   const packageNeeds = Array.isArray(workflow?.jobs?.package?.needs)
     ? workflow.jobs.package.needs
     : [workflow?.jobs?.package?.needs];

--- a/.github/scripts/check-electric-release-policy.mjs
+++ b/.github/scripts/check-electric-release-policy.mjs
@@ -218,6 +218,7 @@ function checkReleaseWorkflow(workflows) {
   const packageStep = findNamedStep(workflow?.jobs?.package, 'Pack and install isolated CLI');
   checkRunRequirements(packageStep, 'package proof step', [
     ['npm pack --dry-run', 'npm pack dry-run'],
+    ['FILENAME="gitnexus-$EXPECTED_VERSION.tgz"', 'deterministic package asset filename'],
     [
       'if [ "$VERSION_OUTPUT" != "$EXPECTED_VERSION" ]; then',
       'exact packaged-version equality check',

--- a/.github/scripts/check-electric-release-policy.test.mjs
+++ b/.github/scripts/check-electric-release-policy.test.mjs
@@ -57,7 +57,8 @@ jobs:
           npm pack --dry-run
           npm pack
           FILENAME="gitnexus-$EXPECTED_VERSION.tgz"
-          test -s "$FILENAME"
+          ASSET_PATH="$FILENAME"
+          if [ ! -f "$ASSET_PATH" ] || [ ! -s "$ASSET_PATH" ]; then exit 1; fi
           VERSION_OUTPUT="$EXPECTED_VERSION"
           if [ "$VERSION_OUTPUT" != "$EXPECTED_VERSION" ]; then exit 1; fi
           shasum -a 256 gitnexus-*.tgz > SHA256SUMS
@@ -311,7 +312,7 @@ test('rejects packaging that does not depend on exact-head CI', () => {
   assert.match(result.stderr, /package job must depend on exact-head ci/);
 });
 
-test('rejects parsing npm pack stdout instead of using the deterministic asset name', () => {
+test('rejects packaging without the deterministic asset name', () => {
   const workflow = replaceOnce(
     validWorkflow,
     '          FILENAME="gitnexus-$EXPECTED_VERSION.tgz"\n',
@@ -320,6 +321,29 @@ test('rejects parsing npm pack stdout instead of using the deterministic asset n
   const result = runChecker(createFixture(workflow));
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /deterministic package asset filename/);
+});
+
+test('rejects npm pack stdout parsing even when deterministic naming remains', () => {
+  const workflow = replaceOnce(
+    validWorkflow,
+    '          FILENAME="gitnexus-$EXPECTED_VERSION.tgz"\n',
+    '          FILENAME="gitnexus-$EXPECTED_VERSION.tgz"\n' +
+      "          node -e 'JSON.parse(process.env.PACK_OUTPUT)'\n",
+  );
+  const result = runChecker(createFixture(workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /must not parse npm pack stdout as JSON/);
+});
+
+test('rejects package proof without regular-file and non-empty validation', () => {
+  const workflow = replaceOnce(
+    validWorkflow,
+    '          if [ ! -f "$ASSET_PATH" ] || [ ! -s "$ASSET_PATH" ]; then exit 1; fi\n',
+    '          if [ ! -s "$ASSET_PATH" ]; then exit 1; fi\n',
+  );
+  const result = runChecker(createFixture(workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /non-empty regular package asset validation/);
 });
 
 test('rejects an unencoded slash-bearing tag-state lookup', () => {

--- a/.github/scripts/check-electric-release-policy.test.mjs
+++ b/.github/scripts/check-electric-release-policy.test.mjs
@@ -56,6 +56,8 @@ jobs:
         run: |
           npm pack --dry-run
           npm pack
+          FILENAME="gitnexus-$EXPECTED_VERSION.tgz"
+          test -s "$FILENAME"
           VERSION_OUTPUT="$EXPECTED_VERSION"
           if [ "$VERSION_OUTPUT" != "$EXPECTED_VERSION" ]; then exit 1; fi
           shasum -a 256 gitnexus-*.tgz > SHA256SUMS
@@ -307,6 +309,17 @@ test('rejects packaging that does not depend on exact-head CI', () => {
   const result = runChecker(createFixture(workflow));
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /package job must depend on exact-head ci/);
+});
+
+test('rejects parsing npm pack stdout instead of using the deterministic asset name', () => {
+  const workflow = replaceOnce(
+    validWorkflow,
+    '          FILENAME="gitnexus-$EXPECTED_VERSION.tgz"\n',
+    '          FILENAME="$(node -e \'JSON.parse(process.env.PACK_OUTPUT)\')"\n',
+  );
+  const result = runChecker(createFixture(workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /deterministic package asset filename/);
 });
 
 test('rejects an unencoded slash-bearing tag-state lookup', () => {

--- a/.github/workflows/electric-release.yml
+++ b/.github/workflows/electric-release.yml
@@ -211,11 +211,11 @@ jobs:
           PREFIX="$RUNNER_TEMP/electric-release-prefix"
           mkdir -p "$ASSET_DIR" "$PREFIX"
 
-          npm pack --dry-run --json > "$RUNNER_TEMP/npm-pack-dry-run.json"
-          npm pack --json --pack-destination "$ASSET_DIR" > "$RUNNER_TEMP/npm-pack.json"
-          FILENAME="$(PACK_JSON="$RUNNER_TEMP/npm-pack.json" node -e "const fs=require('node:fs'); const value=JSON.parse(fs.readFileSync(process.env.PACK_JSON,'utf8')); if(value.length!==1) process.exit(1); process.stdout.write(value[0].filename)")"
+          npm pack --dry-run > "$RUNNER_TEMP/npm-pack-dry-run.log"
+          npm pack --pack-destination "$ASSET_DIR" > "$RUNNER_TEMP/npm-pack.log"
+          FILENAME="gitnexus-$EXPECTED_VERSION.tgz"
           ASSET_PATH="$ASSET_DIR/$FILENAME"
-          if [ ! -s "$ASSET_PATH" ]; then
+          if [ ! -f "$ASSET_PATH" ] || [ ! -s "$ASSET_PATH" ]; then
             echo "::error::npm pack did not create $ASSET_PATH"
             exit 1
           fi


### PR DESCRIPTION
## Root cause

Protected release run [29331821077](https://github.com/electricsheephq/evaOS-gitnexus/actions/runs/29331821077) failed before mutation because `npm pack --json` emitted `[publish-guard] OK` before the JSON payload. Parsing that stdout with `JSON.parse` raised `Unexpected token p` even though packing and building succeeded.

## Fix

- capture `npm pack` output as a diagnostic log rather than a machine-pure JSON document
- derive the asset name from the already verified package identity and strict release version: `gitnexus-$EXPECTED_VERSION.tgz`
- require the exact asset to be a non-empty regular file
- make the release policy reject reintroduction of stdout parsing in place of the deterministic filename contract

## Focused proof

- policy regression fails before the checker change
- committed-workflow self-test fails until the workflow fix is applied
- policy suite passes 25/25 after the fix
- `npm run check:electric-release-policy` passes
- real local pack creates `gitnexus-1.6.10-electric.1.tgz`
- tarball size: 14,376,981 bytes
- SHA-256: `9dafd6965c78877b7e1cb47a8fd469d938a2464d3eda4aa855ce94975ec43362`
- `git diff --check` passes

## Boundary

No tag, GitHub Release, npm publication, container publication, OpenClaw runtime, live index, or embedding state was changed. A new protected release dispatch will occur only after this PR passes exact-head review and CI and merges.

Closes #113
Relates #111