### PR TITLE
feat(ci): recover proven drafts after main advances

### DIFF
--- a/.github/scripts/check-electric-release-policy.mjs
+++ b/.github/scripts/check-electric-release-policy.mjs
@@ -63,6 +63,23 @@ function checkRunRequirements(match, stepDescription, requirements) {
 const failures = [];
 const fail = (message) => failures.push(message);
 
+function checkDraftSafeReleaseLookup(match, stepDescription) {
+  checkRunRequirements(match, stepDescription, [
+    [
+      'gh api --paginate --slurp "repos/$REPO/releases?per_page=100"',
+      'draft-safe paginated release list lookup',
+    ],
+    ['.tag_name == $tag', 'exact release tag filter'],
+    ['RELEASE_COUNT', 'bounded release match count'],
+    ['Multiple releases exist for $TAG', 'duplicate release rejection'],
+  ]);
+  if (typeof match?.step?.run === 'string' && match.step.run.includes('releases/tags/')) {
+    fail(
+      `electric-release.yml ${stepDescription} must not use the draft-invisible releases/tags endpoint`,
+    );
+  }
+}
+
 const APPROVED_OIDC_JOBS = new Set([
   'build-tree-sitter-prebuilds.yml:aggregate',
   'claude.yml:claude',
@@ -214,6 +231,7 @@ function checkReleaseWorkflow(workflows) {
     ['manifest version mismatch', 'manifest mismatch failure'],
     ['MAX_MANIFEST_BYTES', 'bounded manifest parsing'],
   ]);
+  checkDraftSafeReleaseLookup(inspectStep, 'manifest verification step');
 
   const packageStep = findNamedStep(workflow?.jobs?.package, 'Pack and install isolated CLI');
   checkRunRequirements(packageStep, 'package proof step', [
@@ -251,6 +269,7 @@ function checkReleaseWorkflow(workflows) {
     ['TAG_EXISTS', 'fresh tag-state output'],
     ['RELEASE_EXISTS', 'fresh release-state output'],
   ]);
+  checkDraftSafeReleaseLookup(reverifyStep, 'reverify resumable release state step');
 
   const tagStep = findNamedStep(releaseJob, 'Create annotated Electric tag when absent');
   if (tagStep?.step?.if !== "steps.resume_state.outputs.tag_exists != 'true'") {
@@ -276,11 +295,10 @@ function checkReleaseWorkflow(workflows) {
   checkRunRequirements(publishStep, 'publish the verified draft step', [
     ['gh release download', 'fresh release asset download'],
     ['sha256sum --check', 'fresh release checksum verification'],
-    ['ENCODED_TAG', 'URL-encoded final release lookup'],
-    ['releases/tags/$ENCODED_TAG', 'URL-encoded final release lookup'],
     ['gh api --method PATCH', 'GitHub Release PATCH'],
     ['-F draft=false', 'publish the verified draft'],
   ]);
+  checkDraftSafeReleaseLookup(publishStep, 'publish the verified draft step');
 
   const releaseNeeds = Array.isArray(releaseJob?.needs) ? releaseJob.needs : [releaseJob?.needs];
   if (!releaseNeeds.includes('inspect') || !releaseNeeds.includes('package')) {

--- a/.github/scripts/check-electric-release-policy.mjs
+++ b/.github/scripts/check-electric-release-policy.mjs
@@ -71,11 +71,27 @@ function checkDraftSafeReleaseLookup(match, stepDescription) {
     ],
     ['.tag_name == $tag', 'exact release tag filter'],
     ['RELEASE_COUNT', 'bounded release match count'],
-    ['Multiple releases exist for $TAG', 'duplicate release rejection'],
+    [
+      '',
+      'exit-bearing duplicate release rejection',
+      /case\s+"\$RELEASE_COUNT"\s+in[\s\S]*?\*\)[\s\S]*?Multiple releases exist for \$TAG[\s\S]*?exit 1[\s\S]*?;;[\s\S]*?esac/,
+    ],
   ]);
   if (typeof match?.step?.run === 'string' && match.step.run.includes('releases/tags/')) {
     fail(
       `electric-release.yml ${stepDescription} must not use the draft-invisible releases/tags endpoint`,
+    );
+  }
+}
+
+function checkExactPermissions(job, expected, description) {
+  const entries = Object.entries(job?.permissions ?? {}).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  const wanted = Object.entries(expected).sort(([left], [right]) => left.localeCompare(right));
+  if (JSON.stringify(entries) !== JSON.stringify(wanted)) {
+    fail(
+      `electric-release-resume.yml ${description} permissions must be ${JSON.stringify(expected)}`,
     );
   }
 }
@@ -317,11 +333,154 @@ function checkReleaseWorkflow(workflows) {
   }
 }
 
+function checkRecoveryWorkflow(workflows) {
+  const candidate = workflows.get('electric-release-resume.yml');
+  if (!candidate) {
+    fail('electric-release-resume.yml must exist');
+    return;
+  }
+
+  const workflow = candidate.value;
+  const triggers = workflow?.on;
+  if (
+    !triggers ||
+    typeof triggers !== 'object' ||
+    Array.isArray(triggers) ||
+    Object.keys(triggers).length !== 1 ||
+    !triggers.workflow_dispatch
+  ) {
+    fail('electric-release-resume.yml must be manual-only through workflow_dispatch');
+  }
+  const inputs = triggers?.workflow_dispatch?.inputs ?? {};
+  for (const inputName of [
+    'expected_version',
+    'release_id',
+    'source_sha',
+    'source_run_id',
+    'tarball_sha256',
+  ]) {
+    if (inputs[inputName]?.required !== true || inputs[inputName]?.type !== 'string') {
+      fail(`electric-release-resume.yml must require string input ${inputName}`);
+    }
+  }
+  if (inputs.prerelease?.type !== 'boolean') {
+    fail('electric-release-resume.yml must declare boolean input prerelease');
+  }
+
+  const jobNames = Object.keys(workflow?.jobs ?? {}).sort();
+  if (JSON.stringify(jobNames) !== JSON.stringify(['inspect', 'recover'])) {
+    fail('electric-release-resume.yml may define only inspect and recover jobs');
+  }
+  const inspectJob = workflow?.jobs?.inspect;
+  const recoverJob = workflow?.jobs?.recover;
+  checkExactPermissions(inspectJob, { actions: 'read', contents: 'read' }, 'inspect job');
+  checkExactPermissions(recoverJob, { actions: 'read', contents: 'write' }, 'recovery job');
+
+  const environment =
+    typeof recoverJob?.environment === 'string'
+      ? recoverJob.environment
+      : recoverJob?.environment?.name;
+  if (environment !== 'internal-release') {
+    fail('electric-release-resume.yml recovery job must require internal-release environment');
+  }
+  const recoveryNeeds = Array.isArray(recoverJob?.needs) ? recoverJob.needs : [recoverJob?.needs];
+  if (!recoveryNeeds.includes('inspect')) {
+    fail('electric-release-resume.yml recovery job must depend on read-only inspection');
+  }
+
+  const inputStep = findNamedStep(inspectJob, 'Validate recovery inputs');
+  checkRunRequirements(inputStep, 'recovery input validation step', [
+    ['refs/heads/main', 'main ref guard'],
+    ['^[0-9a-f]{40}$', 'full source SHA validation'],
+    ['^[0-9a-f]{64}$', 'full tarball SHA-256 validation'],
+  ]);
+
+  const inspectStep = findNamedStep(inspectJob, 'Verify proven Electric draft recovery');
+  checkRunRequirements(inspectStep, 'read-only recovery inspection step', [
+    ['git/ref/heads/main', 'current-main policy guard'],
+    ['if [ "$CURRENT_MAIN_SHA" != "$POLICY_SHA" ]; then', 'current-main policy guard'],
+    ['git merge-base --is-ancestor', 'release source ancestry guard'],
+    ['gitnexus-claude-plugin/.claude-plugin/plugin.json', 'source Claude manifest proof'],
+    ['gitnexus-claude-plugin/.codex-plugin/plugin.json', 'source Codex manifest proof'],
+    ['.claude-plugin/marketplace.json', 'source Claude marketplace proof'],
+    ['.agents/plugins/marketplace.json', 'source Codex marketplace proof'],
+    ['manifest version mismatch', 'source manifest version proof'],
+    ['MAX_MANIFEST_BYTES', 'bounded source manifest parsing'],
+    ['repos/$REPO/actions/runs/$SOURCE_RUN_ID', 'original Electric Release run proof'],
+    ['.github/workflows/electric-release.yml', 'original Electric Release workflow identity'],
+    ['Exact-head CI / CI Gate', 'successful exact-head CI proof'],
+    ['Build and prove release tarball', 'successful package proof'],
+    ['Create protected Electric GitHub Release', 'failed protected release proof'],
+    ['repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals', 'original environment approval proof'],
+    ['internal-release', 'internal-release approval proof'],
+    ['$RELEASE_ID', 'immutable release ID binding'],
+    ['$SOURCE_SHA', 'immutable source SHA binding'],
+    ['sha256:$TARBALL_SHA256', 'exact tarball digest binding'],
+  ]);
+  checkDraftSafeReleaseLookup(inspectStep, 'read-only recovery inspection step');
+
+  const reverifyStep = findNamedStep(recoverJob, 'Reverify proven Electric draft recovery');
+  checkRunRequirements(reverifyStep, 'protected recovery reverify step', [
+    ['git/ref/heads/main', 'current-main policy guard'],
+    ['if [ "$CURRENT_MAIN_SHA" != "$POLICY_SHA" ]; then', 'current-main policy guard'],
+    ['repos/$REPO/actions/runs/$SOURCE_RUN_ID', 'original Electric Release run proof'],
+    ['Exact-head CI / CI Gate', 'successful exact-head CI proof'],
+    ['Build and prove release tarball', 'successful package proof'],
+    ['repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals', 'original environment approval proof'],
+    ['$RELEASE_ID', 'immutable release ID binding'],
+    ['$SOURCE_SHA', 'immutable source SHA binding'],
+    ['sha256:$TARBALL_SHA256', 'exact tarball digest binding'],
+  ]);
+  checkDraftSafeReleaseLookup(reverifyStep, 'protected recovery reverify step');
+
+  const publishStep = findNamedStep(
+    recoverJob,
+    'Verify retained assets and publish by immutable ID',
+  );
+  checkRunRequirements(publishStep, 'retained recovery asset proof step', [
+    ['releases/assets/$TARBALL_ASSET_ID', 'immutable tarball asset download'],
+    ['releases/assets/$CHECKSUM_ASSET_ID', 'immutable checksum asset download'],
+    ['sha256sum --check --strict SHA256SUMS', 'strict checksum verification'],
+    ['npm install --global', 'retained tarball install'],
+    ['if [ "$VERSION_OUTPUT" != "$VERSION" ]; then', 'exact retained version smoke'],
+    ['$PREFIX/bin/gitnexus" --help', 'retained CLI help smoke'],
+    ['$PREFIX/bin/gitnexus" mcp --help', 'retained MCP CLI smoke'],
+    ['git/ref/heads/main', 'final current-main guard'],
+    ['if [ "$FINAL_MAIN_SHA" != "$POLICY_SHA" ]; then', 'final current-main guard'],
+    ['git/ref/tags/$ENCODED_TAG', 'final immutable tag guard'],
+    ['if [ "$OBJECT_SHA" != "$SOURCE_SHA" ]; then', 'final immutable tag guard'],
+    ['gh api --method PATCH "repos/$REPO/releases/$RELEASE_ID"', 'immutable release ID PATCH'],
+    ['-F draft=false', 'draft publication PATCH'],
+  ]);
+
+  const orderedSteps = [reverifyStep, publishStep];
+  if (
+    orderedSteps.some((match) => !match) ||
+    orderedSteps.some((match, index) => index > 0 && match.index <= orderedSteps[index - 1].index)
+  ) {
+    fail('electric-release-resume.yml must reverify all mutable state before publication');
+  }
+
+  const forbiddenRecoveryMutation =
+    /\bgh\s+release\s+(?:create|upload)\b|\bnpm\s+pack\b|git\/(?:tags|refs)[\s\S]{0,120}--method\s+POST|--method\s+POST[\s\S]{0,120}git\/(?:tags|refs)/i;
+  if (forbiddenRecoveryMutation.test(candidate.raw)) {
+    fail('electric-release-resume.yml recovery may only PATCH the immutable release ID');
+  }
+  const patchCalls = candidate.raw.match(/gh api --method PATCH/g) ?? [];
+  if (patchCalls.length !== 1) {
+    fail('electric-release-resume.yml recovery may contain exactly one GitHub PATCH');
+  }
+  if (candidate.raw.includes('releases/tags/')) {
+    fail('electric-release-resume.yml must not use the draft-invisible releases/tags endpoint');
+  }
+}
+
 function main() {
   const repoRoot = parseRepoRoot(process.argv.slice(2));
   const workflows = readWorkflows(repoRoot);
   checkNoRegistryPublication(workflows);
   checkReleaseWorkflow(workflows);
+  checkRecoveryWorkflow(workflows);
   if (failures.length > 0) {
     for (const message of failures) {
       process.stderr.write(`electric release policy check failed: ${message}\n`);

--- a/.github/scripts/check-electric-release-policy.test.mjs
+++ b/.github/scripts/check-electric-release-policy.test.mjs
@@ -44,7 +44,10 @@ jobs:
           gh api --paginate --slurp "repos/$REPO/releases?per_page=100" > /tmp/release-pages.json
           RELEASE_MATCHES="$(jq --arg tag "$TAG" '[.[][] | select(.tag_name == $tag)]' /tmp/release-pages.json)"
           RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
-          echo "Multiple releases exist for $TAG"
+          case "$RELEASE_COUNT" in
+            0|1) ;;
+            *) echo "Multiple releases exist for $TAG"; exit 1 ;;
+          esac
   ci:
     needs: inspect
     uses: ./.github/workflows/ci.yml
@@ -88,7 +91,10 @@ jobs:
           gh api --paginate --slurp "repos/$REPO/releases?per_page=100" > /tmp/release-pages.json
           RELEASE_MATCHES="$(jq --arg tag "$TAG" '[.[][] | select(.tag_name == $tag)]' /tmp/release-pages.json)"
           RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
-          echo "Multiple releases exist for $TAG"
+          case "$RELEASE_COUNT" in
+            0|1) ;;
+            *) echo "Multiple releases exist for $TAG"; exit 1 ;;
+          esac
           echo "tag_exists=$TAG_EXISTS"
           echo "release_exists=$RELEASE_EXISTS"
       - name: Create annotated Electric tag when absent
@@ -110,15 +116,139 @@ jobs:
           gh api --paginate --slurp "repos/$REPO/releases?per_page=100" > /tmp/release-pages.json
           RELEASE_MATCHES="$(jq --arg tag "$TAG" '[.[][] | select(.tag_name == $tag)]' /tmp/release-pages.json)"
           RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
-          echo "Multiple releases exist for $TAG"
+          case "$RELEASE_COUNT" in
+            0|1) ;;
+            *) echo "Multiple releases exist for $TAG"; exit 1 ;;
+          esac
           gh api --method PATCH releases/1 -F draft=false
 `;
 
-function createFixture(workflow = validWorkflow) {
+const validRecoveryWorkflow = `name: Recover Electric Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        required: true
+        type: string
+      release_id:
+        required: true
+        type: string
+      source_sha:
+        required: true
+        type: string
+      source_run_id:
+        required: true
+        type: string
+      tarball_sha256:
+        required: true
+        type: string
+      prerelease:
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  inspect:
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Validate recovery inputs
+        run: |
+          test "$GITHUB_REF" = refs/heads/main
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$TARBALL_SHA256" =~ ^[0-9a-f]{64}$ ]]
+      - name: Verify proven Electric draft recovery
+        run: |
+          test "$GITHUB_REF" = refs/heads/main
+          POLICY_SHA="$(git rev-parse HEAD)"
+          CURRENT_MAIN_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"
+          if [ "$CURRENT_MAIN_SHA" != "$POLICY_SHA" ]; then exit 1; fi
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$TARBALL_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          git merge-base --is-ancestor "$SOURCE_SHA" "$POLICY_SHA"
+          echo gitnexus-claude-plugin/.claude-plugin/plugin.json
+          echo gitnexus-claude-plugin/.codex-plugin/plugin.json
+          echo .claude-plugin/marketplace.json
+          echo .agents/plugins/marketplace.json
+          echo "manifest version mismatch"
+          echo MAX_MANIFEST_BYTES
+          gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID"
+          echo .github/workflows/electric-release.yml
+          echo "Exact-head CI / CI Gate"
+          echo "Build and prove release tarball"
+          echo "Create protected Electric GitHub Release"
+          gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals"
+          echo internal-release
+          ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
+          gh api "repos/$REPO/git/ref/tags/$ENCODED_TAG"
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" > /tmp/release-pages.json
+          RELEASE_MATCHES="$(jq --arg tag "$TAG" '[.[][] | select(.tag_name == $tag)]' /tmp/release-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
+          case "$RELEASE_COUNT" in
+            0) echo "No draft release exists for $TAG"; exit 1 ;;
+            1) ;;
+            *) echo "Multiple releases exist for $TAG"; exit 1 ;;
+          esac
+          echo "$RELEASE_ID $SOURCE_SHA sha256:$TARBALL_SHA256"
+  recover:
+    needs: inspect
+    environment:
+      name: internal-release
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Reverify proven Electric draft recovery
+        run: |
+          CURRENT_MAIN_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"
+          if [ "$CURRENT_MAIN_SHA" != "$POLICY_SHA" ]; then exit 1; fi
+          gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID"
+          echo "Exact-head CI / CI Gate"
+          echo "Build and prove release tarball"
+          gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals"
+          ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
+          gh api "repos/$REPO/git/ref/tags/$ENCODED_TAG"
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" > /tmp/release-pages.json
+          RELEASE_MATCHES="$(jq --arg tag "$TAG" '[.[][] | select(.tag_name == $tag)]' /tmp/release-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
+          case "$RELEASE_COUNT" in
+            0) echo "No draft release exists for $TAG"; exit 1 ;;
+            1) ;;
+            *) echo "Multiple releases exist for $TAG"; exit 1 ;;
+          esac
+          echo "$RELEASE_ID $SOURCE_SHA sha256:$TARBALL_SHA256"
+      - name: Verify retained assets and publish by immutable ID
+        run: |
+          gh api -H "Accept: application/octet-stream" "repos/$REPO/releases/assets/$TARBALL_ASSET_ID" > "gitnexus-$VERSION.tgz"
+          gh api -H "Accept: application/octet-stream" "repos/$REPO/releases/assets/$CHECKSUM_ASSET_ID" > SHA256SUMS
+          sha256sum --check --strict SHA256SUMS
+          npm install --global --prefix "$PREFIX" "gitnexus-$VERSION.tgz"
+          VERSION_OUTPUT="$("$PREFIX/bin/gitnexus" --version)"
+          if [ "$VERSION_OUTPUT" != "$VERSION" ]; then exit 1; fi
+          "$PREFIX/bin/gitnexus" --help >/dev/null
+          "$PREFIX/bin/gitnexus" mcp --help >/dev/null
+          FINAL_MAIN_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"
+          if [ "$FINAL_MAIN_SHA" != "$POLICY_SHA" ]; then exit 1; fi
+          ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
+          gh api "repos/$REPO/git/ref/tags/$ENCODED_TAG"
+          OBJECT_SHA="$SOURCE_SHA"
+          if [ "$OBJECT_SHA" != "$SOURCE_SHA" ]; then exit 1; fi
+          gh api --method PATCH "repos/$REPO/releases/$RELEASE_ID" -F draft=false
+`;
+
+function createFixture(workflow = validWorkflow, recoveryWorkflow = validRecoveryWorkflow) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-electric-release-policy-'));
   temporaryRoots.push(root);
   fs.mkdirSync(path.join(root, '.github/workflows'), { recursive: true });
   fs.writeFileSync(path.join(root, '.github/workflows/electric-release.yml'), workflow);
+  fs.writeFileSync(
+    path.join(root, '.github/workflows/electric-release-resume.yml'),
+    recoveryWorkflow,
+  );
   fs.writeFileSync(
     path.join(root, '.github/workflows/ci.yml'),
     'name: CI\non:\n  workflow_call:\npermissions: {}\njobs: {}\n',
@@ -133,6 +263,23 @@ function runChecker(root) {
 function replaceOnce(value, search, replacement) {
   assert.ok(value.includes(search), `fixture is missing ${JSON.stringify(search)}`);
   return value.replace(search, replacement);
+}
+
+function replaceOccurrence(value, search, replacement, occurrence) {
+  let offset = 0;
+  for (let index = 0; index <= occurrence; index += 1) {
+    offset = value.indexOf(search, offset);
+    assert.notEqual(
+      offset,
+      -1,
+      `fixture is missing occurrence ${occurrence} of ${JSON.stringify(search)}`,
+    );
+    if (index === occurrence) {
+      return value.slice(0, offset) + replacement + value.slice(offset + search.length);
+    }
+    offset += search.length;
+  }
+  throw new Error('unreachable');
 }
 
 test.after(() => {
@@ -418,15 +565,111 @@ test('rejects release discovery without exact tag filtering', () => {
   assert.match(result.stderr, /exact release tag filter/);
 });
 
-test('rejects release discovery without duplicate detection', () => {
+for (const [stage, occurrence] of [
+  ['inspect', 0],
+  ['protected reverify', 1],
+  ['publish', 2],
+]) {
+  test(`rejects ${stage} release discovery without exit-bearing duplicate detection`, () => {
+    const workflow = replaceOccurrence(
+      validWorkflow,
+      '*) echo "Multiple releases exist for $TAG"; exit 1 ;;',
+      '*) echo "Multiple releases exist for $TAG" ;;',
+      occurrence,
+    );
+    const result = runChecker(createFixture(workflow));
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /exit-bearing duplicate release rejection/);
+  });
+}
+
+test('rejects recovery without the protected internal-release environment', () => {
   const workflow = replaceOnce(
-    validWorkflow,
-    '          echo "Multiple releases exist for $TAG"\n',
-    '',
+    validRecoveryWorkflow,
+    '      name: internal-release\n',
+    '      name: none\n',
   );
-  const result = runChecker(createFixture(workflow));
+  const result = runChecker(createFixture(validWorkflow, workflow));
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /duplicate release rejection/);
+  assert.match(result.stderr, /recovery job must require internal-release environment/);
+});
+
+test('rejects recovery without current-policy and source-ancestor guards', () => {
+  let workflow = replaceOnce(validRecoveryWorkflow, 'git/ref/heads/main', 'git/ref/heads/stale');
+  workflow = replaceOnce(workflow, 'git merge-base --is-ancestor', 'git merge-base');
+  const result = runChecker(createFixture(validWorkflow, workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /current-main policy guard/);
+  assert.match(result.stderr, /release source ancestry guard/);
+});
+
+test('rejects recovery without original run, CI, package, and approval proof', () => {
+  let workflow = validRecoveryWorkflow.replaceAll(
+    'repos/$REPO/actions/runs/$SOURCE_RUN_ID',
+    'repos/$REPO/actions/runs/stale',
+  );
+  workflow = workflow.replaceAll('Exact-head CI / CI Gate', 'Unproven CI');
+  workflow = workflow.replaceAll('Build and prove release tarball', 'Unproven package');
+  workflow = workflow.replaceAll('/approvals', '/missing-approvals');
+  const result = runChecker(createFixture(validWorkflow, workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /original Electric Release run proof/);
+  assert.match(result.stderr, /successful exact-head CI proof/);
+  assert.match(result.stderr, /successful package proof/);
+  assert.match(result.stderr, /original environment approval proof/);
+});
+
+test('rejects recovery without exact release identity and artifact digest binding', () => {
+  let workflow = validRecoveryWorkflow.replaceAll('$RELEASE_ID', '$OTHER_RELEASE_ID');
+  workflow = workflow.replaceAll('sha256:$TARBALL_SHA256', 'sha256:unknown');
+  const result = runChecker(createFixture(validWorkflow, workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /immutable release ID binding/);
+  assert.match(result.stderr, /exact tarball digest binding/);
+});
+
+test('rejects recovery without retained asset checksum and install smoke', () => {
+  let workflow = replaceOnce(
+    validRecoveryWorkflow,
+    'sha256sum --check --strict SHA256SUMS',
+    'true',
+  );
+  workflow = replaceOnce(workflow, 'npm install --global', 'echo install');
+  workflow = replaceOnce(workflow, '"$PREFIX/bin/gitnexus" mcp --help', 'echo mcp-help');
+  const result = runChecker(createFixture(validWorkflow, workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /strict checksum verification/);
+  assert.match(result.stderr, /retained tarball install/);
+  assert.match(result.stderr, /retained MCP CLI smoke/);
+});
+
+test('rejects recovery that creates or uploads release state', () => {
+  const workflow = replaceOnce(
+    validRecoveryWorkflow,
+    '          gh api --method PATCH "repos/$REPO/releases/$RELEASE_ID" -F draft=false\n',
+    '          gh release create "$TAG" --draft\n          gh release upload "$TAG" bundle.tgz\n',
+  );
+  const result = runChecker(createFixture(validWorkflow, workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /recovery may only PATCH the immutable release ID/);
+});
+
+test('rejects recovery publication without final current-main and tag guards', () => {
+  let workflow = replaceOnce(
+    validRecoveryWorkflow,
+    'FINAL_MAIN_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"',
+    'FINAL_MAIN_SHA="$POLICY_SHA"',
+  );
+  workflow = replaceOccurrence(
+    workflow,
+    'gh api "repos/$REPO/git/ref/tags/$ENCODED_TAG"',
+    'echo tag',
+    2,
+  );
+  const result = runChecker(createFixture(validWorkflow, workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /final current-main guard/);
+  assert.match(result.stderr, /final immutable tag guard/);
 });
 
 test('rejects publish without re-downloading and checksum-verifying release assets', () => {

--- a/.github/scripts/check-electric-release-policy.test.mjs
+++ b/.github/scripts/check-electric-release-policy.test.mjs
@@ -41,6 +41,10 @@ jobs:
           echo .agents/plugins/marketplace.json
           echo "manifest version mismatch"
           echo MAX_MANIFEST_BYTES
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" > /tmp/release-pages.json
+          RELEASE_MATCHES="$(jq --arg tag "$TAG" '[.[][] | select(.tag_name == $tag)]' /tmp/release-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
+          echo "Multiple releases exist for $TAG"
   ci:
     needs: inspect
     uses: ./.github/workflows/ci.yml
@@ -81,6 +85,10 @@ jobs:
           if [ "$CURRENT_MAIN_SHA" != "$HEAD_SHA" ]; then exit 1; fi
           ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
           curl "https://api.github.com/repos/$REPO/git/ref/tags/$ENCODED_TAG"
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" > /tmp/release-pages.json
+          RELEASE_MATCHES="$(jq --arg tag "$TAG" '[.[][] | select(.tag_name == $tag)]' /tmp/release-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
+          echo "Multiple releases exist for $TAG"
           echo "tag_exists=$TAG_EXISTS"
           echo "release_exists=$RELEASE_EXISTS"
       - name: Create annotated Electric tag when absent
@@ -99,7 +107,10 @@ jobs:
           ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
           gh release download "$TAG" --pattern "gitnexus-$VERSION.tgz" --pattern SHA256SUMS
           sha256sum --check SHA256SUMS
-          gh api "repos/$REPO/releases/tags/$ENCODED_TAG"
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" > /tmp/release-pages.json
+          RELEASE_MATCHES="$(jq --arg tag "$TAG" '[.[][] | select(.tag_name == $tag)]' /tmp/release-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
+          echo "Multiple releases exist for $TAG"
           gh api --method PATCH releases/1 -F draft=false
 `;
 
@@ -271,8 +282,8 @@ test('rejects a release flow without resumable draft and asset upload semantics'
 test('rejects a release flow without protected-job state re-verification', () => {
   const workflow = replaceOnce(
     validWorkflow,
-    '      - name: Reverify resumable release state\n        run: |\n          CURRENT_MAIN_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"\n          if [ "$CURRENT_MAIN_SHA" != "$HEAD_SHA" ]; then exit 1; fi\n          ENCODED_TAG="$(jq -rn --arg value "$TAG" \'$value | @uri\')"\n          curl "https://api.github.com/repos/$REPO/git/ref/tags/$ENCODED_TAG"\n          echo "tag_exists=$TAG_EXISTS"\n          echo "release_exists=$RELEASE_EXISTS"\n',
-    '',
+    '      - name: Reverify resumable release state\n',
+    '      - name: Missing protected state verification\n',
   );
   const result = runChecker(createFixture(workflow));
   assert.notEqual(result.status, 0);
@@ -378,11 +389,44 @@ test('rejects tag creation that does not target the exact inspected head', () =>
   assert.match(result.stderr, /exact-head tag target/);
 });
 
-test('rejects a raw slash-bearing final release lookup', () => {
-  const workflow = replaceOnce(validWorkflow, 'releases/tags/$ENCODED_TAG', 'releases/tags/$TAG');
+test('rejects the draft-invisible release-by-tag endpoint', () => {
+  const workflow = replaceOnce(
+    validWorkflow,
+    'gh api --paginate --slurp "repos/$REPO/releases?per_page=100"',
+    'gh api "repos/$REPO/releases/tags/$ENCODED_TAG"',
+  );
   const result = runChecker(createFixture(workflow));
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /URL-encoded final release lookup/);
+  assert.match(result.stderr, /draft-safe paginated release list lookup/);
+});
+
+test('rejects a release list lookup without pagination', () => {
+  const workflow = replaceOnce(
+    validWorkflow,
+    'gh api --paginate --slurp "repos/$REPO/releases?per_page=100"',
+    'gh api "repos/$REPO/releases?per_page=100"',
+  );
+  const result = runChecker(createFixture(workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /draft-safe paginated release list lookup/);
+});
+
+test('rejects release discovery without exact tag filtering', () => {
+  const workflow = replaceOnce(validWorkflow, '.tag_name == $tag', '.draft == true');
+  const result = runChecker(createFixture(workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /exact release tag filter/);
+});
+
+test('rejects release discovery without duplicate detection', () => {
+  const workflow = replaceOnce(
+    validWorkflow,
+    '          echo "Multiple releases exist for $TAG"\n',
+    '',
+  );
+  const result = runChecker(createFixture(workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /duplicate release rejection/);
 });
 
 test('rejects publish without re-downloading and checksum-verifying release assets', () => {

--- a/.github/workflows/electric-release-resume.yml
+++ b/.github/workflows/electric-release-resume.yml
@@ -1,0 +1,479 @@
+name: Recover Electric Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: 'Exact retained fork version, for example 1.6.10-electric.2'
+        required: true
+        type: string
+      release_id:
+        description: 'Immutable numeric ID of the retained draft release'
+        required: true
+        type: string
+      source_sha:
+        description: 'Exact 40-hex release source commit proven by the original run'
+        required: true
+        type: string
+      source_run_id:
+        description: 'Original failed Electric Release workflow run ID'
+        required: true
+        type: string
+      tarball_sha256:
+        description: 'Exact 64-hex SHA-256 of the retained tarball'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark the recovered GitHub Release as a prerelease'
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    name: Verify proven Electric draft recovery
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      policy_sha: ${{ steps.proof.outputs.policy_sha }}
+      version: ${{ steps.proof.outputs.version }}
+      tag: ${{ steps.proof.outputs.tag }}
+      release_id: ${{ steps.proof.outputs.release_id }}
+      source_sha: ${{ steps.proof.outputs.source_sha }}
+      source_run_id: ${{ steps.proof.outputs.source_run_id }}
+      tarball_sha256: ${{ steps.proof.outputs.tarball_sha256 }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Validate recovery inputs
+        id: inputs
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          RELEASE_ID: ${{ inputs.release_id }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          TARBALL_SHA256: ${{ inputs.tarball_sha256 }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Electric release recovery may run only from refs/heads/main."
+            exit 1
+          fi
+          if ! [[ "$EXPECTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-electric\.[0-9]+$ ]]; then
+            echo "::error::Version must match X.Y.Z-electric.N."
+            exit 1
+          fi
+          if ! [[ "$RELEASE_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::release_id must be a positive integer."
+            exit 1
+          fi
+          if ! [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::source_run_id must be a positive integer."
+            exit 1
+          fi
+          if ! [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::source_sha must be exactly 40 lowercase hexadecimal characters."
+            exit 1
+          fi
+          if ! [[ "$TARBALL_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::tarball_sha256 must be exactly 64 lowercase hexadecimal characters."
+            exit 1
+          fi
+          {
+            echo "version=$EXPECTED_VERSION"
+            echo "release_id=$RELEASE_ID"
+            echo "source_sha=$SOURCE_SHA"
+            echo "source_run_id=$SOURCE_RUN_ID"
+            echo "tarball_sha256=$TARBALL_SHA256"
+          } >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.inputs.outputs.source_sha }}
+          path: release-source
+          persist-credentials: false
+      - name: Verify proven Electric draft recovery
+        id: proof
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ steps.inputs.outputs.version }}
+          RELEASE_ID: ${{ steps.inputs.outputs.release_id }}
+          SOURCE_SHA: ${{ steps.inputs.outputs.source_sha }}
+          SOURCE_RUN_ID: ${{ steps.inputs.outputs.source_run_id }}
+          TARBALL_SHA256: ${{ steps.inputs.outputs.tarball_sha256 }}
+        run: |
+          set -euo pipefail
+          POLICY_SHA="$(git rev-parse HEAD)"
+          if [ "$POLICY_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::Recovery policy checkout does not match the workflow run SHA."
+            exit 1
+          fi
+          CURRENT_MAIN_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"
+          if [ "$CURRENT_MAIN_SHA" != "$POLICY_SHA" ]; then
+            echo "::error::Recovery policy SHA is not current GitHub main."
+            exit 1
+          fi
+          git cat-file -e "$SOURCE_SHA^{commit}"
+          if ! git merge-base --is-ancestor "$SOURCE_SHA" "$POLICY_SHA"; then
+            echo "::error::Release source $SOURCE_SHA is not an ancestor of current main $POLICY_SHA."
+            exit 1
+          fi
+
+          SOURCE_DIR="$GITHUB_WORKSPACE/release-source" VERSION="$VERSION" node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const expected = process.env.VERSION;
+          const sourceDir = process.env.SOURCE_DIR;
+          const MAX_MANIFEST_BYTES = 64 * 1024;
+          function readManifest(file) {
+            const absolute = path.join(sourceDir, file);
+            const stat = fs.lstatSync(absolute);
+            if (!stat.isFile() || stat.size <= 0 || stat.size > MAX_MANIFEST_BYTES) {
+              throw new Error(`manifest must be a non-empty regular file under ${MAX_MANIFEST_BYTES} bytes: ${file}`);
+            }
+            const value = JSON.parse(fs.readFileSync(absolute, 'utf8'));
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+              throw new Error(`manifest must contain a JSON object: ${file}`);
+            }
+            return value;
+          }
+          const packageManifest = readManifest('gitnexus/package.json');
+          if (packageManifest.name !== 'gitnexus' || packageManifest.version !== expected) {
+            throw new Error('manifest version mismatch: gitnexus/package.json');
+          }
+          for (const file of [
+            'gitnexus-claude-plugin/.claude-plugin/plugin.json',
+            'gitnexus-claude-plugin/.codex-plugin/plugin.json',
+          ]) {
+            if (readManifest(file).version !== expected) {
+              throw new Error(`manifest version mismatch: ${file}`);
+            }
+          }
+          for (const file of ['.claude-plugin/marketplace.json', '.agents/plugins/marketplace.json']) {
+            const value = readManifest(file);
+            const matches = Array.isArray(value.plugins)
+              ? value.plugins.filter((plugin) => plugin?.name === 'gitnexus')
+              : [];
+            if (matches.length !== 1 || matches[0].version !== expected) {
+              throw new Error(`manifest version mismatch: ${file}`);
+            }
+          }
+          const notes = path.join(sourceDir, 'Documentation/releases', `${expected}.md`);
+          const notesStat = fs.lstatSync(notes);
+          if (!notesStat.isFile() || notesStat.size <= 0) {
+            throw new Error(`missing release notes for ${expected}`);
+          }
+          NODE
+
+          RUN_JSON="$(gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID")"
+          jq -e --arg sha "$SOURCE_SHA" '
+            .path == ".github/workflows/electric-release.yml" and
+            .event == "workflow_dispatch" and
+            .status == "completed" and
+            .conclusion == "failure" and
+            .head_sha == $sha
+          ' <<< "$RUN_JSON" >/dev/null
+          gh api --paginate --slurp "repos/$REPO/actions/runs/$SOURCE_RUN_ID/jobs?per_page=100" \
+            > /tmp/electric-recovery-jobs.json
+          jq -e '
+            ([.[] | .jobs[] | select(.name == "Verify Electric release identity" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name == "Exact-head CI / CI Gate" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name | startswith("Exact-head CI /")) | select(.conclusion != "success" and .conclusion != "skipped")] | length) == 0 and
+            ([.[] | .jobs[] | select(.name == "Build and prove release tarball" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name == "Create protected Electric GitHub Release" and .conclusion == "failure")] | length) == 1
+          ' /tmp/electric-recovery-jobs.json >/dev/null
+          gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals" \
+            > /tmp/electric-recovery-approvals.json
+          jq -e '
+            [.[] | select(.state == "approved") | .environments[]? | select(.name == "internal-release")]
+            | length > 0
+          ' /tmp/electric-recovery-approvals.json >/dev/null
+
+          TAG="electric/v$VERSION"
+          ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
+          gh api "repos/$REPO/git/ref/tags/$ENCODED_TAG" > /tmp/electric-recovery-tag.json
+          OBJECT_TYPE="$(jq -r .object.type /tmp/electric-recovery-tag.json)"
+          OBJECT_SHA="$(jq -r .object.sha /tmp/electric-recovery-tag.json)"
+          for _ in 1 2 3 4; do
+            if [ "$OBJECT_TYPE" != "tag" ]; then break; fi
+            gh api "repos/$REPO/git/tags/$OBJECT_SHA" > /tmp/electric-recovery-tag-object.json
+            OBJECT_TYPE="$(jq -r .object.type /tmp/electric-recovery-tag-object.json)"
+            OBJECT_SHA="$(jq -r .object.sha /tmp/electric-recovery-tag-object.json)"
+          done
+          if [ "$OBJECT_TYPE" != "commit" ] || [ "$OBJECT_SHA" != "$SOURCE_SHA" ]; then
+            echo "::error::Immutable tag $TAG does not resolve to source $SOURCE_SHA."
+            exit 1
+          fi
+
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" \
+            > /tmp/electric-recovery-release-pages.json
+          RELEASE_MATCHES="$(jq -c --arg tag "$TAG" \
+            '[.[][] | select(.tag_name == $tag)]' \
+            /tmp/electric-recovery-release-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
+          case "$RELEASE_COUNT" in
+            0)
+              echo "::error::No draft release exists for $TAG"
+              exit 1
+              ;;
+            1) ;;
+            *)
+              echo "::error::Multiple releases exist for $TAG"
+              exit 1
+              ;;
+          esac
+          RELEASE_JSON="$(jq -c '.[0]' <<< "$RELEASE_MATCHES")"
+          ASSET_NAME="gitnexus-$VERSION.tgz"
+          jq -e \
+            --arg id "$RELEASE_ID" \
+            --arg source "$SOURCE_SHA" \
+            --arg asset "$ASSET_NAME" \
+            --arg digest "sha256:$TARBALL_SHA256" '
+              (.id | tostring) == $id and
+              .draft == true and
+              .target_commitish == $source and
+              (.assets | length) == 2 and
+              ([.assets[] | select(.name == $asset and .size > 0 and .digest == $digest)] | length) == 1 and
+              ([.assets[] | select(.name == "SHA256SUMS" and .size > 0 and (.digest | startswith("sha256:")))] | length) == 1
+            ' <<< "$RELEASE_JSON" >/dev/null
+
+          {
+            echo "policy_sha=$POLICY_SHA"
+            echo "version=$VERSION"
+            echo "tag=$TAG"
+            echo "release_id=$RELEASE_ID"
+            echo "source_sha=$SOURCE_SHA"
+            echo "source_run_id=$SOURCE_RUN_ID"
+            echo "tarball_sha256=$TARBALL_SHA256"
+          } >> "$GITHUB_OUTPUT"
+
+  recover:
+    name: Publish proven Electric draft
+    needs: inspect
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: internal-release
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.inspect.outputs.policy_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Reverify proven Electric draft recovery
+        id: state
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          POLICY_SHA: ${{ needs.inspect.outputs.policy_sha }}
+          VERSION: ${{ needs.inspect.outputs.version }}
+          TAG: ${{ needs.inspect.outputs.tag }}
+          RELEASE_ID: ${{ needs.inspect.outputs.release_id }}
+          SOURCE_SHA: ${{ needs.inspect.outputs.source_sha }}
+          SOURCE_RUN_ID: ${{ needs.inspect.outputs.source_run_id }}
+          TARBALL_SHA256: ${{ needs.inspect.outputs.tarball_sha256 }}
+        run: |
+          set -euo pipefail
+          CURRENT_MAIN_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"
+          if [ "$CURRENT_MAIN_SHA" != "$POLICY_SHA" ]; then
+            echo "::error::main advanced after recovery inspection."
+            exit 1
+          fi
+
+          RUN_JSON="$(gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID")"
+          jq -e --arg sha "$SOURCE_SHA" '
+            .path == ".github/workflows/electric-release.yml" and
+            .event == "workflow_dispatch" and
+            .status == "completed" and
+            .conclusion == "failure" and
+            .head_sha == $sha
+          ' <<< "$RUN_JSON" >/dev/null
+          gh api --paginate --slurp "repos/$REPO/actions/runs/$SOURCE_RUN_ID/jobs?per_page=100" \
+            > /tmp/electric-recovery-reverify-jobs.json
+          jq -e '
+            ([.[] | .jobs[] | select(.name == "Exact-head CI / CI Gate" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name | startswith("Exact-head CI /")) | select(.conclusion != "success" and .conclusion != "skipped")] | length) == 0 and
+            ([.[] | .jobs[] | select(.name == "Build and prove release tarball" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name == "Create protected Electric GitHub Release" and .conclusion == "failure")] | length) == 1
+          ' /tmp/electric-recovery-reverify-jobs.json >/dev/null
+          gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals" \
+            > /tmp/electric-recovery-reverify-approvals.json
+          jq -e '
+            [.[] | select(.state == "approved") | .environments[]? | select(.name == "internal-release")]
+            | length > 0
+          ' /tmp/electric-recovery-reverify-approvals.json >/dev/null
+
+          ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
+          gh api "repos/$REPO/git/ref/tags/$ENCODED_TAG" > /tmp/electric-recovery-reverify-tag.json
+          OBJECT_TYPE="$(jq -r .object.type /tmp/electric-recovery-reverify-tag.json)"
+          OBJECT_SHA="$(jq -r .object.sha /tmp/electric-recovery-reverify-tag.json)"
+          for _ in 1 2 3 4; do
+            if [ "$OBJECT_TYPE" != "tag" ]; then break; fi
+            gh api "repos/$REPO/git/tags/$OBJECT_SHA" > /tmp/electric-recovery-reverify-tag-object.json
+            OBJECT_TYPE="$(jq -r .object.type /tmp/electric-recovery-reverify-tag-object.json)"
+            OBJECT_SHA="$(jq -r .object.sha /tmp/electric-recovery-reverify-tag-object.json)"
+          done
+          if [ "$OBJECT_TYPE" != "commit" ] || [ "$OBJECT_SHA" != "$SOURCE_SHA" ]; then
+            echo "::error::Immutable tag moved or no longer resolves to the proven source."
+            exit 1
+          fi
+
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" \
+            > /tmp/electric-recovery-reverify-release-pages.json
+          RELEASE_MATCHES="$(jq -c --arg tag "$TAG" \
+            '[.[][] | select(.tag_name == $tag)]' \
+            /tmp/electric-recovery-reverify-release-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
+          case "$RELEASE_COUNT" in
+            0)
+              echo "::error::No draft release exists for $TAG"
+              exit 1
+              ;;
+            1) ;;
+            *)
+              echo "::error::Multiple releases exist for $TAG"
+              exit 1
+              ;;
+          esac
+          RELEASE_JSON="$(jq -c '.[0]' <<< "$RELEASE_MATCHES")"
+          ASSET_NAME="gitnexus-$VERSION.tgz"
+          jq -e \
+            --arg id "$RELEASE_ID" \
+            --arg source "$SOURCE_SHA" \
+            --arg asset "$ASSET_NAME" \
+            --arg digest "sha256:$TARBALL_SHA256" '
+              (.id | tostring) == $id and
+              .draft == true and
+              .target_commitish == $source and
+              (.assets | length) == 2 and
+              ([.assets[] | select(.name == $asset and .size > 0 and .digest == $digest)] | length) == 1 and
+              ([.assets[] | select(.name == "SHA256SUMS" and .size > 0 and (.digest | startswith("sha256:")))] | length) == 1
+            ' <<< "$RELEASE_JSON" >/dev/null
+          TARBALL_ASSET_ID="$(jq -r --arg asset "$ASSET_NAME" '.assets[] | select(.name == $asset) | .id' <<< "$RELEASE_JSON")"
+          CHECKSUM_ASSET_ID="$(jq -r '.assets[] | select(.name == "SHA256SUMS") | .id' <<< "$RELEASE_JSON")"
+          {
+            echo "tarball_asset_id=$TARBALL_ASSET_ID"
+            echo "checksum_asset_id=$CHECKSUM_ASSET_ID"
+          } >> "$GITHUB_OUTPUT"
+      - name: Verify retained assets and publish by immutable ID
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          POLICY_SHA: ${{ needs.inspect.outputs.policy_sha }}
+          VERSION: ${{ needs.inspect.outputs.version }}
+          TAG: ${{ needs.inspect.outputs.tag }}
+          RELEASE_ID: ${{ needs.inspect.outputs.release_id }}
+          SOURCE_SHA: ${{ needs.inspect.outputs.source_sha }}
+          TARBALL_SHA256: ${{ needs.inspect.outputs.tarball_sha256 }}
+          TARBALL_ASSET_ID: ${{ steps.state.outputs.tarball_asset_id }}
+          CHECKSUM_ASSET_ID: ${{ steps.state.outputs.checksum_asset_id }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          set -euo pipefail
+          VERIFY_DIR="$(mktemp -d)"
+          PREFIX="$RUNNER_TEMP/electric-recovery-prefix"
+          FILENAME="gitnexus-$VERSION.tgz"
+          cd "$VERIFY_DIR"
+          gh api -H "Accept: application/octet-stream" \
+            "repos/$REPO/releases/assets/$TARBALL_ASSET_ID" > "$FILENAME"
+          gh api -H "Accept: application/octet-stream" \
+            "repos/$REPO/releases/assets/$CHECKSUM_ASSET_ID" > SHA256SUMS
+          if [ ! -f "$FILENAME" ] || [ ! -s "$FILENAME" ] || [ ! -f SHA256SUMS ] || [ ! -s SHA256SUMS ]; then
+            echo "::error::Retained release assets are missing or empty."
+            exit 1
+          fi
+          EXPECTED_SUM_LINE="$TARBALL_SHA256  $FILENAME"
+          if [ "$(wc -l < SHA256SUMS | tr -d ' ')" != "1" ] || [ "$(cat SHA256SUMS)" != "$EXPECTED_SUM_LINE" ]; then
+            echo "::error::SHA256SUMS must contain exactly the proven tarball digest and filename."
+            exit 1
+          fi
+          sha256sum --check --strict SHA256SUMS
+          if [ "$(sha256sum "$FILENAME" | awk '{print $1}')" != "$TARBALL_SHA256" ]; then
+            echo "::error::Downloaded tarball digest does not match the proven digest."
+            exit 1
+          fi
+
+          npm install --global --prefix "$PREFIX" "$FILENAME"
+          VERSION_OUTPUT="$("$PREFIX/bin/gitnexus" --version)"
+          if [ "$VERSION_OUTPUT" != "$VERSION" ]; then
+            echo "::error::Retained CLI version '$VERSION_OUTPUT' does not equal $VERSION."
+            exit 1
+          fi
+          "$PREFIX/bin/gitnexus" --help >/dev/null
+          "$PREFIX/bin/gitnexus" mcp --help >/dev/null
+
+          FINAL_MAIN_SHA="$(gh api "repos/$REPO/git/ref/heads/main" --jq .object.sha)"
+          if [ "$FINAL_MAIN_SHA" != "$POLICY_SHA" ]; then
+            echo "::error::main advanced during retained asset verification."
+            exit 1
+          fi
+          ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
+          gh api "repos/$REPO/git/ref/tags/$ENCODED_TAG" > /tmp/electric-recovery-final-tag.json
+          OBJECT_TYPE="$(jq -r .object.type /tmp/electric-recovery-final-tag.json)"
+          OBJECT_SHA="$(jq -r .object.sha /tmp/electric-recovery-final-tag.json)"
+          for _ in 1 2 3 4; do
+            if [ "$OBJECT_TYPE" != "tag" ]; then break; fi
+            gh api "repos/$REPO/git/tags/$OBJECT_SHA" > /tmp/electric-recovery-final-tag-object.json
+            OBJECT_TYPE="$(jq -r .object.type /tmp/electric-recovery-final-tag-object.json)"
+            OBJECT_SHA="$(jq -r .object.sha /tmp/electric-recovery-final-tag-object.json)"
+          done
+          if [ "$OBJECT_TYPE" != "commit" ]; then
+            echo "::error::Immutable tag no longer resolves to a commit."
+            exit 1
+          fi
+          if [ "$OBJECT_SHA" != "$SOURCE_SHA" ]; then
+            echo "::error::Immutable tag moved during retained asset verification."
+            exit 1
+          fi
+
+          FINAL_JSON="$(gh api "repos/$REPO/releases/$RELEASE_ID")"
+          jq -e \
+            --arg id "$RELEASE_ID" \
+            --arg tag "$TAG" \
+            --arg source "$SOURCE_SHA" \
+            --arg asset "$FILENAME" \
+            --arg digest "sha256:$TARBALL_SHA256" '
+              (.id | tostring) == $id and
+              .tag_name == $tag and
+              .draft == true and
+              .target_commitish == $source and
+              (.assets | length) == 2 and
+              ([.assets[] | select(.name == $asset and .size > 0 and .digest == $digest)] | length) == 1 and
+              ([.assets[] | select(.name == "SHA256SUMS" and .size > 0)] | length) == 1
+            ' <<< "$FINAL_JSON" >/dev/null
+
+          PUBLISHED_JSON="$(gh api --method PATCH "repos/$REPO/releases/$RELEASE_ID" \
+            -F draft=false \
+            -F prerelease="$PRERELEASE")"
+          jq -e \
+            --arg id "$RELEASE_ID" \
+            --arg tag "$TAG" \
+            --argjson prerelease "$PRERELEASE" '
+              (.id | tostring) == $id and .tag_name == $tag and .draft == false and .prerelease == $prerelease
+            ' <<< "$PUBLISHED_JSON" >/dev/null

--- a/.github/workflows/electric-release.yml
+++ b/.github/workflows/electric-release.yml
@@ -141,18 +141,18 @@ jobs:
             TAG_EXISTS=true
           fi
 
-          ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
-          STATUS="$(curl --silent --show-error --output /tmp/electric-release.json \
-            --write-out '%{http_code}' \
-            --header "Authorization: Bearer $GH_TOKEN" \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "https://api.github.com/repos/$REPO/releases/tags/$ENCODED_TAG")"
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" \
+            > /tmp/electric-release-pages.json
+          RELEASE_MATCHES="$(jq -c --arg tag "$TAG" \
+            '[.[][] | select(.tag_name == $tag)]' \
+            /tmp/electric-release-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
           RELEASE_EXISTS=false
-          case "$STATUS" in
-            404) ;;
-            200)
-              if [ "$(jq -r .draft /tmp/electric-release.json)" != "true" ]; then
+          case "$RELEASE_COUNT" in
+            0) ;;
+            1)
+              RELEASE_JSON="$(jq -c '.[0]' <<< "$RELEASE_MATCHES")"
+              if [ "$(jq -r .draft <<< "$RELEASE_JSON")" != "true" ]; then
                 echo "::error::Published GitHub Release already exists for $TAG"
                 exit 1
               fi
@@ -163,7 +163,7 @@ jobs:
               RELEASE_EXISTS=true
               ;;
             *)
-              echo "::error::Unable to verify release absence; GitHub returned HTTP $STATUS"
+              echo "::error::Multiple releases exist for $TAG"
               exit 1
               ;;
           esac
@@ -315,24 +315,25 @@ jobs:
               exit 1
               ;;
           esac
-          RELEASE_STATUS="$(curl --silent --show-error --output /tmp/electric-release-state.json \
-            --write-out '%{http_code}' \
-            --header "Authorization: Bearer $GH_TOKEN" \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "https://api.github.com/repos/$REPO/releases/tags/$ENCODED_TAG")"
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" \
+            > /tmp/electric-release-state-pages.json
+          RELEASE_MATCHES="$(jq -c --arg tag "$TAG" \
+            '[.[][] | select(.tag_name == $tag)]' \
+            /tmp/electric-release-state-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
           RELEASE_EXISTS=false
-          case "$RELEASE_STATUS" in
-            404) ;;
-            200)
-              if [ "$TAG_EXISTS" != "true" ] || [ "$(jq -r .draft /tmp/electric-release-state.json)" != "true" ]; then
+          case "$RELEASE_COUNT" in
+            0) ;;
+            1)
+              RELEASE_JSON="$(jq -c '.[0]' <<< "$RELEASE_MATCHES")"
+              if [ "$TAG_EXISTS" != "true" ] || [ "$(jq -r .draft <<< "$RELEASE_JSON")" != "true" ]; then
                 echo "::error::Existing release state is not a resumable exact-head draft"
                 exit 1
               fi
               RELEASE_EXISTS=true
               ;;
             *)
-              echo "::error::Unable to reverify release state; GitHub returned HTTP $RELEASE_STATUS"
+              echo "::error::Multiple releases exist for $TAG"
               exit 1
               ;;
           esac
@@ -409,8 +410,25 @@ jobs:
             sha256sum --check SHA256SUMS
           )
 
-          ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
-          RELEASE_JSON="$(gh api "repos/$REPO/releases/tags/$ENCODED_TAG")"
+          gh api --paginate --slurp "repos/$REPO/releases?per_page=100" \
+            > /tmp/electric-publish-release-pages.json
+          RELEASE_MATCHES="$(jq -c --arg tag "$TAG" \
+            '[.[][] | select(.tag_name == $tag)]' \
+            /tmp/electric-publish-release-pages.json)"
+          RELEASE_COUNT="$(jq 'length' <<< "$RELEASE_MATCHES")"
+          case "$RELEASE_COUNT" in
+            0)
+              echo "::error::No draft release exists for $TAG"
+              exit 1
+              ;;
+            1)
+              RELEASE_JSON="$(jq -c '.[0]' <<< "$RELEASE_MATCHES")"
+              ;;
+            *)
+              echo "::error::Multiple releases exist for $TAG"
+              exit 1
+              ;;
+          esac
           RELEASE_ID="$(jq -r .id <<< "$RELEASE_JSON")"
           jq -e --arg tag "$TAG" --arg asset "gitnexus-$VERSION.tgz" '
             .tag_name == $tag and


### PR DESCRIPTION
## Summary

- replace draft-invisible release-by-tag lookups in the normal exact-head workflow with paginated exact-tag discovery and fail-closed duplicate handling
- add a separate manual `Recover Electric Release` workflow for a proven tagged draft after `main` advances
- require immutable release/source/run/digest inputs, original CI/package/environment-approval proof, current-main ancestry, exact source manifests, and exact draft assets
- reverify mutable state after fresh `internal-release` approval, download by immutable asset ID, strictly checksum and install-smoke the retained package, then allow exactly one ID-pinned publication PATCH
- strengthen policy enforcement and independently test inspect, protected reverify, publish, and recovery mutation boundaries

## Safety contract

The normal release path remains exact-head-only and still refuses an existing tag that does not resolve to current `main`.

Recovery does not rebuild, rerun CI, create or rewrite tags, create releases, upload/clobber assets, publish npm or containers, or touch runtime/index/embedding state. It accepts only an original failed Electric Release run whose identity, exact-head CI Gate, package job, failed protected release job, and `internal-release` approval are all proven.

The completed `electric/v1.6.10-electric.1` release is not a recovery target and was used only for read-only API validation; the new lane correctly refuses it because it is already published.

## Proof

- `node --test .github/scripts/check-electric-release-policy.test.mjs` (39/39)
- `node .github/scripts/check-electric-release-policy.mjs`
- `actionlint .github/workflows/electric-release.yml .github/workflows/electric-release-resume.yml`
- Prettier check and `git diff --check`
- live read-only proof: original run/job/approval validation, immutable asset-ID download, strict checksum verification, and published-release refusal

No release workflow was dispatched and no protected environment approval was requested.

Closes #115
Relates #111