### PR TITLE
build(release): pin and prove LadybugDB 0.18.1

### DIFF
--- a/.github/scripts/check-electric-release-policy.mjs
+++ b/.github/scripts/check-electric-release-policy.mjs
@@ -273,6 +273,9 @@ function checkReleaseWorkflow(workflows) {
   }
 
   const proofJob = workflow?.jobs?.package_proof;
+  if (proofJob?.name !== 'Prove release tarball (${{ matrix.os }})') {
+    fail('electric-release.yml package proof job name must match recovery proof identities');
+  }
   const proofOperatingSystems = proofJob?.strategy?.matrix?.os;
   const expectedOperatingSystems = ['macos-latest', 'ubuntu-latest', 'windows-latest'];
   if (

--- a/.github/scripts/check-electric-release-policy.mjs
+++ b/.github/scripts/check-electric-release-policy.mjs
@@ -188,12 +188,12 @@ function checkReleaseWorkflow(workflows) {
     }
   }
 
-  for (const jobName of ['inspect', 'ci', 'package', 'release']) {
+  for (const jobName of ['inspect', 'ci', 'package', 'package_proof', 'release']) {
     if (!workflow?.jobs?.[jobName]) fail(`electric-release.yml must define ${jobName} job`);
   }
 
   const releaseJob = workflow?.jobs?.release;
-  for (const jobName of ['inspect', 'ci', 'package']) {
+  for (const jobName of ['inspect', 'ci', 'package', 'package_proof']) {
     const permissions = workflow?.jobs?.[jobName]?.permissions;
     const entries =
       permissions && typeof permissions === 'object' ? Object.entries(permissions) : [];
@@ -249,17 +249,13 @@ function checkReleaseWorkflow(workflows) {
   ]);
   checkDraftSafeReleaseLookup(inspectStep, 'manifest verification step');
 
-  const packageStep = findNamedStep(workflow?.jobs?.package, 'Pack and install isolated CLI');
-  checkRunRequirements(packageStep, 'package proof step', [
+  const packageStep = findNamedStep(workflow?.jobs?.package, 'Pack release tarball');
+  checkRunRequirements(packageStep, 'package build step', [
     ['npm pack --dry-run', 'npm pack dry-run'],
     ['FILENAME="gitnexus-$EXPECTED_VERSION.tgz"', 'deterministic package asset filename'],
     [
       'if [ ! -f "$ASSET_PATH" ] || [ ! -s "$ASSET_PATH" ]; then',
       'non-empty regular package asset validation',
-    ],
-    [
-      'if [ "$VERSION_OUTPUT" != "$EXPECTED_VERSION" ]; then',
-      'exact packaged-version equality check',
     ],
     ['SHA256SUMS', 'SHA256SUMS asset'],
   ]);
@@ -267,7 +263,7 @@ function checkReleaseWorkflow(workflows) {
     typeof packageStep?.step?.run === 'string' &&
     /\bJSON\.parse\s*\(/.test(packageStep.step.run)
   ) {
-    fail('electric-release.yml package proof step must not parse npm pack stdout as JSON');
+    fail('electric-release.yml package build step must not parse npm pack stdout as JSON');
   }
   const packageNeeds = Array.isArray(workflow?.jobs?.package?.needs)
     ? workflow.jobs.package.needs
@@ -275,6 +271,31 @@ function checkReleaseWorkflow(workflows) {
   if (!packageNeeds.includes('ci')) {
     fail('electric-release.yml package job must depend on exact-head ci');
   }
+
+  const proofJob = workflow?.jobs?.package_proof;
+  const proofOperatingSystems = proofJob?.strategy?.matrix?.os;
+  const expectedOperatingSystems = ['macos-latest', 'ubuntu-latest', 'windows-latest'];
+  if (
+    !Array.isArray(proofOperatingSystems) ||
+    JSON.stringify([...proofOperatingSystems].sort()) !== JSON.stringify(expectedOperatingSystems)
+  ) {
+    fail('electric-release.yml package proof matrix must cover ubuntu, macOS, and Windows');
+  }
+  const proofNeeds = Array.isArray(proofJob?.needs) ? proofJob.needs : [proofJob?.needs];
+  if (!proofNeeds.includes('inspect') || !proofNeeds.includes('package')) {
+    fail(
+      'electric-release.yml package proof must depend on inspected release identity and tarball',
+    );
+  }
+  const proofStep = findNamedStep(proofJob, 'Install and verify release tarball');
+  checkRunRequirements(proofStep, 'cross-platform package proof step', [
+    ['npm install --global --prefix', 'clean-prefix package installation'],
+    ['verify-electric-package.mjs', 'shared package verifier'],
+    ['--asset', 'tarball checksum verification'],
+    ['--checksums', 'SHA256SUMS verification'],
+    ['--prefix', 'installed-prefix verification'],
+    ['--expected-version', 'exact packaged-version equality check'],
+  ]);
 
   const reverifyStep = findNamedStep(releaseJob, 'Reverify resumable release state');
   checkRunRequirements(reverifyStep, 'reverify resumable release state step', [
@@ -317,7 +338,11 @@ function checkReleaseWorkflow(workflows) {
   checkDraftSafeReleaseLookup(publishStep, 'publish the verified draft step');
 
   const releaseNeeds = Array.isArray(releaseJob?.needs) ? releaseJob.needs : [releaseJob?.needs];
-  if (!releaseNeeds.includes('inspect') || !releaseNeeds.includes('package')) {
+  if (
+    !releaseNeeds.includes('inspect') ||
+    !releaseNeeds.includes('package') ||
+    !releaseNeeds.includes('package_proof')
+  ) {
     fail('electric-release.yml manifest verification must run before release mutation');
   }
   const orderedReleaseSteps = [reverifyStep, tagStep, upsertStep, publishStep];
@@ -410,6 +435,9 @@ function checkRecoveryWorkflow(workflows) {
     ['.github/workflows/electric-release.yml', 'original Electric Release workflow identity'],
     ['Exact-head CI / CI Gate', 'successful exact-head CI proof'],
     ['Build and prove release tarball', 'successful package proof'],
+    ['Prove release tarball (ubuntu-latest)', 'successful Linux package proof'],
+    ['Prove release tarball (macos-latest)', 'successful macOS package proof'],
+    ['Prove release tarball (windows-latest)', 'successful Windows package proof'],
     ['Create protected Electric GitHub Release', 'failed protected release proof'],
     ['repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals', 'original environment approval proof'],
     ['internal-release', 'internal-release approval proof'],
@@ -426,6 +454,9 @@ function checkRecoveryWorkflow(workflows) {
     ['repos/$REPO/actions/runs/$SOURCE_RUN_ID', 'original Electric Release run proof'],
     ['Exact-head CI / CI Gate', 'successful exact-head CI proof'],
     ['Build and prove release tarball', 'successful package proof'],
+    ['Prove release tarball (ubuntu-latest)', 'successful Linux package proof'],
+    ['Prove release tarball (macos-latest)', 'successful macOS package proof'],
+    ['Prove release tarball (windows-latest)', 'successful Windows package proof'],
     ['repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals', 'original environment approval proof'],
     ['$RELEASE_ID', 'immutable release ID binding'],
     ['$SOURCE_SHA', 'immutable source SHA binding'],

--- a/.github/scripts/check-electric-release-policy.test.mjs
+++ b/.github/scripts/check-electric-release-policy.test.mjs
@@ -59,15 +59,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Pack and install isolated CLI
+      - name: Pack release tarball
         run: |
           npm pack --dry-run
           npm pack
           FILENAME="gitnexus-$EXPECTED_VERSION.tgz"
           ASSET_PATH="$FILENAME"
           if [ ! -f "$ASSET_PATH" ] || [ ! -s "$ASSET_PATH" ]; then exit 1; fi
-          VERSION_OUTPUT="$EXPECTED_VERSION"
-          if [ "$VERSION_OUTPUT" != "$EXPECTED_VERSION" ]; then exit 1; fi
           shasum -a 256 gitnexus-*.tgz > SHA256SUMS
       - uses: actions/upload-artifact@v4
         with:
@@ -75,8 +73,24 @@ jobs:
           path: |
             gitnexus-*.tgz
             SHA256SUMS
-  release:
+  package_proof:
     needs: [inspect, package]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    permissions:
+      contents: read
+    steps:
+      - name: Install and verify release tarball
+        run: |
+          npm install --global --prefix "$PREFIX" "$ASSET_PATH"
+          node .github/scripts/verify-electric-package.mjs \
+            --asset "$ASSET_PATH" \
+            --checksums "$ASSET_DIR/SHA256SUMS" \
+            --prefix "$PREFIX" \
+            --expected-version "$EXPECTED_VERSION"
+  release:
+    needs: [inspect, package, package_proof]
     environment:
       name: internal-release
     permissions:
@@ -180,6 +194,9 @@ jobs:
           echo .github/workflows/electric-release.yml
           echo "Exact-head CI / CI Gate"
           echo "Build and prove release tarball"
+          echo "Prove release tarball (ubuntu-latest)"
+          echo "Prove release tarball (macos-latest)"
+          echo "Prove release tarball (windows-latest)"
           echo "Create protected Electric GitHub Release"
           gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals"
           echo internal-release
@@ -209,6 +226,9 @@ jobs:
           gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID"
           echo "Exact-head CI / CI Gate"
           echo "Build and prove release tarball"
+          echo "Prove release tarball (ubuntu-latest)"
+          echo "Prove release tarball (macos-latest)"
+          echo "Prove release tarball (windows-latest)"
           gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals"
           ENCODED_TAG="$(jq -rn --arg value "$TAG" '$value | @uri')"
           gh api "repos/$REPO/git/ref/tags/$ENCODED_TAG"
@@ -451,7 +471,7 @@ test('rejects missing manifest verification or release ordering', () => {
 test('rejects release mutation that does not depend on manifest verification', () => {
   const workflow = replaceOnce(
     validWorkflow,
-    '  release:\n    needs: [inspect, package]',
+    '  release:\n    needs: [inspect, package, package_proof]',
     '  release:\n    needs: [package]',
   );
   const result = runChecker(createFixture(workflow));
@@ -468,6 +488,28 @@ test('rejects packaging that does not depend on exact-head CI', () => {
   const result = runChecker(createFixture(workflow));
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /package job must depend on exact-head ci/);
+});
+
+test('rejects package proof that omits a supported runner family', () => {
+  const workflow = replaceOnce(
+    validWorkflow,
+    '        os: [ubuntu-latest, macos-latest, windows-latest]',
+    '        os: [ubuntu-latest, windows-latest]',
+  );
+  const result = runChecker(createFixture(workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /package proof matrix must cover ubuntu, macOS, and Windows/);
+});
+
+test('rejects package proof that skips the shared verifier', () => {
+  const workflow = replaceOnce(
+    validWorkflow,
+    'verify-electric-package.mjs',
+    'unverified-package.mjs',
+  );
+  const result = runChecker(createFixture(workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /shared package verifier/);
 });
 
 test('rejects packaging without the deterministic asset name', () => {

--- a/.github/scripts/check-electric-release-policy.test.mjs
+++ b/.github/scripts/check-electric-release-policy.test.mjs
@@ -74,6 +74,7 @@ jobs:
             gitnexus-*.tgz
             SHA256SUMS
   package_proof:
+    name: Prove release tarball (\${{ matrix.os }})
     needs: [inspect, package]
     strategy:
       matrix:
@@ -499,6 +500,17 @@ test('rejects package proof that omits a supported runner family', () => {
   const result = runChecker(createFixture(workflow));
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /package proof matrix must cover ubuntu, macOS, and Windows/);
+});
+
+test('rejects a package proof display name that would break recovery', () => {
+  const workflow = replaceOnce(
+    validWorkflow,
+    '    name: Prove release tarball (${{ matrix.os }})',
+    '    name: Release package proof (${{ matrix.os }})',
+  );
+  const result = runChecker(createFixture(workflow));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /package proof job name must match recovery proof identities/);
 });
 
 test('rejects package proof that skips the shared verifier', () => {

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -86,6 +86,22 @@ function locateInstalledCli(prefix) {
   return entry;
 }
 
+function verifyInstalledLauncher(prefix, entry) {
+  const firstLine = fs.readFileSync(entry, 'utf8').split(/\r?\n/u, 1)[0];
+  if (!/^#!.*\bnode\b/u.test(firstLine)) {
+    throw new Error(`installed gitnexus CLI entry must declare a Node shebang: ${entry}`);
+  }
+  if (process.platform === 'win32') {
+    requireRegularFile(path.join(prefix, 'gitnexus.cmd'));
+    return;
+  }
+  const launcher = path.join(prefix, 'bin', 'gitnexus');
+  if (!fs.existsSync(launcher))
+    throw new Error(`installed gitnexus launcher is missing: ${launcher}`);
+  fs.accessSync(entry, fs.constants.X_OK);
+  fs.accessSync(launcher, fs.constants.X_OK);
+}
+
 export function runCli(prefix, args, timeoutMs = PACKAGED_CLI_TIMEOUT_MS) {
   for (const arg of args) {
     if (!/^[a-z0-9-]+$/iu.test(arg)) {
@@ -152,6 +168,7 @@ export function verifyElectricPackage({ asset, checksums, prefix, expectedVersio
     );
   }
   verifyVendorTree(installed);
+  verifyInstalledLauncher(prefix, locateInstalledCli(prefix));
 
   const ladybugPackagePath = path.join(
     installed,
@@ -187,6 +204,7 @@ export function verifyElectricPackage({ asset, checksums, prefix, expectedVersio
     sha256: digest,
     nativeImport: 'ok',
     vendorTree: 'ok',
+    launcher: 'ok',
     cli: 'ok',
     mcpHelp: 'ok',
   };

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -82,6 +82,7 @@ export function runCli(prefix, args, timeoutMs = PACKAGED_CLI_TIMEOUT_MS) {
   const result = spawnSync(executable, args, {
     encoding: 'utf8',
     env: { ...process.env, NO_COLOR: '1' },
+    killSignal: 'SIGKILL',
     shell: process.platform === 'win32',
     timeout: timeoutMs,
   });

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const EXPECTED_LADYBUG_VERSION = '0.18.1';
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || !value) {
+      throw new Error(
+        'usage: verify-electric-package.mjs --asset <tarball> --checksums <file> --prefix <dir> --expected-version <version>',
+      );
+    }
+    values[key.slice(2)] = value;
+  }
+  for (const key of ['asset', 'checksums', 'prefix', 'expected-version']) {
+    if (!values[key]) throw new Error(`missing --${key}`);
+  }
+  return values;
+}
+
+function requireRegularFile(file) {
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.size <= 0)
+    throw new Error(`expected a non-empty regular file: ${file}`);
+}
+
+function verifyChecksum(assetPath, checksumPath) {
+  requireRegularFile(assetPath);
+  requireRegularFile(checksumPath);
+  const filename = path.basename(assetPath);
+  const matches = fs
+    .readFileSync(checksumPath, 'utf8')
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .map((line) => line.match(/^([0-9a-f]{64})\s+\*?(.+)$/u))
+    .filter((match) => match?.[2] === filename);
+  if (matches.length !== 1) {
+    throw new Error(`SHA256SUMS must contain exactly one lowercase SHA-256 entry for ${filename}`);
+  }
+  const actual = createHash('sha256').update(fs.readFileSync(assetPath)).digest('hex');
+  if (actual !== matches[0][1]) throw new Error(`SHA-256 mismatch for ${filename}`);
+  return actual;
+}
+
+function locateInstalledPackage(prefix) {
+  const candidates = [
+    path.join(prefix, 'lib', 'node_modules', 'gitnexus'),
+    path.join(prefix, 'node_modules', 'gitnexus'),
+  ];
+  const installed = candidates.find((candidate) =>
+    fs.existsSync(path.join(candidate, 'package.json')),
+  );
+  if (!installed) throw new Error(`installed gitnexus package not found under ${prefix}`);
+  return installed;
+}
+
+function runCli(prefix, args) {
+  const executable =
+    process.platform === 'win32'
+      ? path.join(prefix, 'gitnexus.cmd')
+      : path.join(prefix, 'bin', 'gitnexus');
+  const result = spawnSync(executable, args, {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+    shell: process.platform === 'win32',
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `gitnexus ${args.join(' ')} failed: ${result.error?.message ?? result.stderr.trim()}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+export function verifyElectricPackage({ asset, checksums, prefix, expectedVersion }) {
+  const digest = verifyChecksum(asset, checksums);
+  const installed = locateInstalledPackage(prefix);
+  const packageJson = JSON.parse(fs.readFileSync(path.join(installed, 'package.json'), 'utf8'));
+  if (packageJson.name !== 'gitnexus' || packageJson.version !== expectedVersion) {
+    throw new Error(
+      `installed package identity is ${packageJson.name}@${packageJson.version}, expected gitnexus@${expectedVersion}`,
+    );
+  }
+
+  const ladybugPackagePath = path.join(
+    installed,
+    'node_modules',
+    '@ladybugdb',
+    'core',
+    'package.json',
+  );
+  const ladybugPackage = JSON.parse(fs.readFileSync(ladybugPackagePath, 'utf8'));
+  if (ladybugPackage.version !== EXPECTED_LADYBUG_VERSION) {
+    throw new Error(
+      `installed @ladybugdb/core is ${ladybugPackage.version}, expected ${EXPECTED_LADYBUG_VERSION}`,
+    );
+  }
+
+  const requireFromPackage = createRequire(path.join(installed, 'package.json'));
+  const loaded = requireFromPackage('@ladybugdb/core');
+  const api = loaded?.default ?? loaded;
+  if (typeof api?.Database !== 'function' || typeof api?.Connection !== 'function') {
+    throw new Error('@ladybugdb/core loaded without Database and Connection constructors');
+  }
+
+  const versionOutput = runCli(prefix, ['--version']);
+  if (versionOutput !== expectedVersion) {
+    throw new Error(`packaged CLI version is ${versionOutput}, expected ${expectedVersion}`);
+  }
+  runCli(prefix, ['--help']);
+  runCli(prefix, ['mcp', '--help']);
+
+  return {
+    package: `gitnexus@${expectedVersion}`,
+    ladybug: `@ladybugdb/core@${EXPECTED_LADYBUG_VERSION}`,
+    sha256: digest,
+    nativeImport: 'ok',
+    cli: 'ok',
+    mcpHelp: 'ok',
+  };
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))
+) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const result = verifyElectricPackage({
+      asset: path.resolve(args.asset),
+      checksums: path.resolve(args.checksums),
+      prefix: path.resolve(args.prefix),
+      expectedVersion: args['expected-version'],
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -13,6 +13,12 @@ const ARGUMENT_KEYS = new Set(['asset', 'checksums', 'prefix', 'expected-version
 const USAGE =
   'usage: verify-electric-package.mjs --asset <tarball> --checksums <file> --prefix <dir> --expected-version <version>';
 
+export function isCliTimeout(result) {
+  return (
+    result.error?.code === 'ETIMEDOUT' || (result.status === null && result.signal === 'SIGKILL')
+  );
+}
+
 function parseArgs(argv) {
   const values = {};
   for (let index = 0; index < argv.length; index += 2) {
@@ -127,7 +133,7 @@ export function runCli(prefix, args, timeoutMs = PACKAGED_CLI_TIMEOUT_MS) {
     shell: false,
     timeout: timeoutMs,
   });
-  if (result.error?.code === 'ETIMEDOUT') {
+  if (isCliTimeout(result)) {
     throw new Error(`gitnexus ${args.join(' ')} timed out after ${timeoutMs}ms`);
   }
   if (result.error || result.status !== 0) {

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -69,21 +69,35 @@ function locateInstalledPackage(prefix) {
   return installed;
 }
 
+function locateInstalledCli(prefix) {
+  const installed = locateInstalledPackage(prefix);
+  const packageJson = JSON.parse(fs.readFileSync(path.join(installed, 'package.json'), 'utf8'));
+  const relativeEntry =
+    typeof packageJson.bin === 'string' ? packageJson.bin : packageJson.bin?.gitnexus;
+  if (typeof relativeEntry !== 'string' || relativeEntry.trim() === '') {
+    throw new Error('installed gitnexus package must declare a gitnexus CLI entry');
+  }
+  const entry = path.resolve(installed, relativeEntry);
+  const relative = path.relative(installed, entry);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`installed gitnexus CLI entry escapes the package root: ${relativeEntry}`);
+  }
+  requireRegularFile(entry);
+  return entry;
+}
+
 export function runCli(prefix, args, timeoutMs = PACKAGED_CLI_TIMEOUT_MS) {
   for (const arg of args) {
     if (!/^[a-z0-9-]+$/iu.test(arg)) {
       throw new Error(`unsafe packaged CLI argument: ${arg}`);
     }
   }
-  const executable =
-    process.platform === 'win32'
-      ? path.join(prefix, 'gitnexus.cmd')
-      : path.join(prefix, 'bin', 'gitnexus');
-  const result = spawnSync(executable, args, {
+  const entry = locateInstalledCli(prefix);
+  const result = spawnSync(process.execPath, [entry, ...args], {
     encoding: 'utf8',
     env: { ...process.env, NO_COLOR: '1' },
     killSignal: 'SIGKILL',
-    shell: process.platform === 'win32',
+    shell: false,
     timeout: timeoutMs,
   });
   if (result.error?.code === 'ETIMEDOUT') {

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -162,8 +162,14 @@ function verifyVendorTree(installed) {
     throw new Error(`vendor tree contains forbidden build artifacts: ${forbidden.join(', ')}`);
   }
 
-  for (const name of ['tree-sitter-dart', 'tree-sitter-proto', 'tree-sitter-swift']) {
-    const entry = path.join(installed, 'node_modules', name);
+  for (const name of [
+    'tree-sitter-c',
+    'tree-sitter-dart',
+    'tree-sitter-kotlin',
+    'tree-sitter-proto',
+    'tree-sitter-swift',
+  ]) {
+    const entry = path.join(vendorRoot, name);
     if (!fs.existsSync(entry)) continue;
     const stat = fs.lstatSync(entry);
     if (stat.isSymbolicLink()) {

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -7,7 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const EXPECTED_LADYBUG_VERSION = '0.18.1';
+export const EXPECTED_LADYBUG_VERSION = '0.18.1';
 const ARGUMENT_KEYS = new Set(['asset', 'checksums', 'prefix', 'expected-version']);
 const USAGE =
   'usage: verify-electric-package.mjs --asset <tarball> --checksums <file> --prefix <dir> --expected-version <version>';

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -43,7 +43,8 @@ function verifyChecksum(assetPath, checksumPath) {
   const filename = path.basename(assetPath);
   const matches = fs
     .readFileSync(checksumPath, 'utf8')
-    .split(/\r?\n/u)
+    .split(/\n/u)
+    .map((line) => line.replace(/\r$/u, ''))
     .filter(Boolean)
     .map((line) => line.match(/^([0-9a-f]{64})\s+\*?(.+)$/u))
     .filter((match) => match?.[2] === filename);
@@ -68,6 +69,11 @@ function locateInstalledPackage(prefix) {
 }
 
 function runCli(prefix, args) {
+  for (const arg of args) {
+    if (!/^[a-z0-9-]+$/iu.test(arg)) {
+      throw new Error(`unsafe packaged CLI argument: ${arg}`);
+    }
+  }
   const executable =
     process.platform === 'win32'
       ? path.join(prefix, 'gitnexus.cmd')
@@ -85,6 +91,37 @@ function runCli(prefix, args) {
   return result.stdout.trim();
 }
 
+function verifyVendorTree(installed) {
+  const vendorRoot = path.join(installed, 'vendor');
+  const forbidden = [];
+  if (fs.existsSync(vendorRoot)) {
+    const pending = [vendorRoot];
+    while (pending.length > 0) {
+      const current = pending.pop();
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        const entryPath = path.join(current, entry.name);
+        if (entry.name === 'node_modules' || entry.name === 'build') forbidden.push(entryPath);
+        if (entry.isDirectory() && !entry.isSymbolicLink()) pending.push(entryPath);
+      }
+    }
+  }
+  if (forbidden.length > 0) {
+    throw new Error(`vendor tree contains forbidden build artifacts: ${forbidden.join(', ')}`);
+  }
+
+  for (const name of ['tree-sitter-dart', 'tree-sitter-proto', 'tree-sitter-swift']) {
+    const entry = path.join(installed, 'node_modules', name);
+    if (!fs.existsSync(entry)) continue;
+    const stat = fs.lstatSync(entry);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`materialized grammar must not be a symlink or junction: ${entry}`);
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`materialized grammar must be a directory: ${entry}`);
+    }
+  }
+}
+
 export function verifyElectricPackage({ asset, checksums, prefix, expectedVersion }) {
   const digest = verifyChecksum(asset, checksums);
   const installed = locateInstalledPackage(prefix);
@@ -94,6 +131,7 @@ export function verifyElectricPackage({ asset, checksums, prefix, expectedVersio
       `installed package identity is ${packageJson.name}@${packageJson.version}, expected gitnexus@${expectedVersion}`,
     );
   }
+  verifyVendorTree(installed);
 
   const ladybugPackagePath = path.join(
     installed,
@@ -128,6 +166,7 @@ export function verifyElectricPackage({ asset, checksums, prefix, expectedVersio
     ladybug: `@ladybugdb/core@${EXPECTED_LADYBUG_VERSION}`,
     sha256: digest,
     nativeImport: 'ok',
+    vendorTree: 'ok',
     cli: 'ok',
     mcpHelp: 'ok',
   };

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export const EXPECTED_LADYBUG_VERSION = '0.18.1';
+const PACKAGED_CLI_TIMEOUT_MS = 60_000;
 const ARGUMENT_KEYS = new Set(['asset', 'checksums', 'prefix', 'expected-version']);
 const USAGE =
   'usage: verify-electric-package.mjs --asset <tarball> --checksums <file> --prefix <dir> --expected-version <version>';
@@ -68,7 +69,7 @@ function locateInstalledPackage(prefix) {
   return installed;
 }
 
-function runCli(prefix, args) {
+export function runCli(prefix, args, timeoutMs = PACKAGED_CLI_TIMEOUT_MS) {
   for (const arg of args) {
     if (!/^[a-z0-9-]+$/iu.test(arg)) {
       throw new Error(`unsafe packaged CLI argument: ${arg}`);
@@ -82,7 +83,11 @@ function runCli(prefix, args) {
     encoding: 'utf8',
     env: { ...process.env, NO_COLOR: '1' },
     shell: process.platform === 'win32',
+    timeout: timeoutMs,
   });
+  if (result.error?.code === 'ETIMEDOUT') {
+    throw new Error(`gitnexus ${args.join(' ')} timed out after ${timeoutMs}ms`);
+  }
   if (result.error || result.status !== 0) {
     throw new Error(
       `gitnexus ${args.join(' ')} failed: ${result.error?.message ?? result.stderr.trim()}`,

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -8,20 +8,24 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const EXPECTED_LADYBUG_VERSION = '0.18.1';
+const ARGUMENT_KEYS = new Set(['asset', 'checksums', 'prefix', 'expected-version']);
+const USAGE =
+  'usage: verify-electric-package.mjs --asset <tarball> --checksums <file> --prefix <dir> --expected-version <version>';
 
 function parseArgs(argv) {
   const values = {};
   for (let index = 0; index < argv.length; index += 2) {
     const key = argv[index];
     const value = argv[index + 1];
-    if (!key?.startsWith('--') || !value) {
-      throw new Error(
-        'usage: verify-electric-package.mjs --asset <tarball> --checksums <file> --prefix <dir> --expected-version <version>',
-      );
-    }
-    values[key.slice(2)] = value;
+    if (!key?.startsWith('--'))
+      throw new Error(`unexpected argument: ${key ?? '<missing>'}\n${USAGE}`);
+    const name = key.slice(2);
+    if (!ARGUMENT_KEYS.has(name)) throw new Error(`unexpected argument: ${key}\n${USAGE}`);
+    if (Object.hasOwn(values, name)) throw new Error(`duplicate argument: ${key}`);
+    if (!value || value.startsWith('--')) throw new Error(`missing value for ${key}\n${USAGE}`);
+    values[name] = value;
   }
-  for (const key of ['asset', 'checksums', 'prefix', 'expected-version']) {
+  for (const key of ARGUMENT_KEYS) {
     if (!values[key]) throw new Error(`missing --${key}`);
   }
   return values;

--- a/.github/scripts/verify-electric-package.mjs
+++ b/.github/scripts/verify-electric-package.mjs
@@ -92,7 +92,15 @@ function verifyInstalledLauncher(prefix, entry) {
     throw new Error(`installed gitnexus CLI entry must declare a Node shebang: ${entry}`);
   }
   if (process.platform === 'win32') {
-    requireRegularFile(path.join(prefix, 'gitnexus.cmd'));
+    const launcher = path.join(prefix, 'gitnexus.cmd');
+    requireRegularFile(launcher);
+    const installed = locateInstalledPackage(prefix);
+    const relativeEntry = path.relative(installed, entry).split(path.sep).join('/');
+    const launcherText = fs.readFileSync(launcher, 'utf8').split('\\').join('/').toLowerCase();
+    const expectedTarget = `node_modules/gitnexus/${relativeEntry}`.toLowerCase();
+    if (!launcherText.includes(expectedTarget)) {
+      throw new Error(`installed gitnexus launcher does not target ${expectedTarget}`);
+    }
     return;
   }
   const launcher = path.join(prefix, 'bin', 'gitnexus');
@@ -100,6 +108,9 @@ function verifyInstalledLauncher(prefix, entry) {
     throw new Error(`installed gitnexus launcher is missing: ${launcher}`);
   fs.accessSync(entry, fs.constants.X_OK);
   fs.accessSync(launcher, fs.constants.X_OK);
+  if (fs.realpathSync(launcher) !== fs.realpathSync(entry)) {
+    throw new Error(`installed gitnexus launcher does not target ${entry}`);
+  }
 }
 
 export function runCli(prefix, args, timeoutMs = PACKAGED_CLI_TIMEOUT_MS) {

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -65,22 +65,22 @@ else process.exit(2);
   return { root, prefix, asset, checksums };
 }
 
-function run(values) {
-  return spawnSync(
-    process.execPath,
-    [
-      SCRIPT,
-      '--asset',
-      values.asset,
-      '--checksums',
-      values.checksums,
-      '--prefix',
-      values.prefix,
-      '--expected-version',
-      '1.6.10-electric.2',
-    ],
-    { encoding: 'utf8' },
-  );
+function runArgs(args) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { encoding: 'utf8' });
+}
+
+function run(values, trailingArgs = []) {
+  return runArgs([
+    '--asset',
+    values.asset,
+    '--checksums',
+    values.checksums,
+    '--prefix',
+    values.prefix,
+    '--expected-version',
+    '1.6.10-electric.2',
+    ...trailingArgs,
+  ]);
 }
 
 test.after(() => {
@@ -104,4 +104,21 @@ test('fails closed when the installed LadybugDB version drifts', () => {
   const result = run(fixture({ ladybugVersion: '0.18.0' }));
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /expected 0\.18\.1/u);
+});
+
+test('rejects unknown and duplicate release-gate arguments', () => {
+  const values = fixture();
+  const unknown = run(values, ['--verbose', 'true']);
+  assert.notEqual(unknown.status, 0);
+  assert.match(unknown.stderr, /unexpected argument: --verbose/u);
+
+  const duplicate = run(values, ['--asset', values.asset]);
+  assert.notEqual(duplicate.status, 0);
+  assert.match(duplicate.stderr, /duplicate argument: --asset/u);
+});
+
+test('rejects a following flag as a missing argument value', () => {
+  const result = runArgs(['--asset', '--checksums', 'SHA256SUMS']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /missing value for --asset/u);
 });

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -136,7 +136,9 @@ test('fails fast when the packaged CLI hangs', () => {
     "#!/usr/bin/env node\nprocess.on('SIGTERM', () => {});\nsetTimeout(() => {}, 10_000);\n",
   );
   if (process.platform !== 'win32') fs.chmodSync(values.cliScript, 0o755);
-  assert.throws(() => runCli(values.prefix, ['--help'], 25), /timed out after 25ms/u);
+  const started = Date.now();
+  assert.throws(() => runCli(values.prefix, ['--help'], 1_000), /timed out after 1000ms/u);
+  assert.ok(Date.now() - started < 5_000, 'hard timeout must not wait for natural child exit');
 });
 
 test('fails closed on vendor build artifacts', () => {

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -131,7 +131,10 @@ test('accepts CRLF checksum files', () => {
 
 test('fails fast when the packaged CLI hangs', () => {
   const values = fixture();
-  fs.writeFileSync(values.cliScript, '#!/usr/bin/env node\nsetTimeout(() => {}, 10_000);\n');
+  fs.writeFileSync(
+    values.cliScript,
+    "#!/usr/bin/env node\nprocess.on('SIGTERM', () => {});\nsetTimeout(() => {}, 10_000);\n",
+  );
   if (process.platform !== 'win32') fs.chmodSync(values.cliScript, 0o755);
   assert.throws(() => runCli(values.prefix, ['--help'], 25), /timed out after 25ms/u);
 });

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'verify-electric-package.mjs',
+);
+const temporaryRoots = [];
+
+function fixture({ ladybugVersion = '0.18.1' } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-electric-package-'));
+  temporaryRoots.push(root);
+  const prefix = path.join(root, 'prefix');
+  const installed = path.join(
+    prefix,
+    process.platform === 'win32' ? '' : 'lib',
+    'node_modules',
+    'gitnexus',
+  );
+  const ladybug = path.join(installed, 'node_modules', '@ladybugdb', 'core');
+  fs.mkdirSync(ladybug, { recursive: true });
+  fs.writeFileSync(
+    path.join(installed, 'package.json'),
+    JSON.stringify({ name: 'gitnexus', version: '1.6.10-electric.2' }),
+  );
+  fs.writeFileSync(
+    path.join(ladybug, 'package.json'),
+    JSON.stringify({ name: '@ladybugdb/core', version: ladybugVersion, main: 'index.cjs' }),
+  );
+  fs.writeFileSync(
+    path.join(ladybug, 'index.cjs'),
+    'module.exports = { Database: class Database {}, Connection: class Connection {} };\n',
+  );
+
+  const cliSource = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === '--version') console.log('1.6.10-electric.2');
+else if (args[0] === '--help' || (args[0] === 'mcp' && args[1] === '--help')) process.exit(0);
+else process.exit(2);
+`;
+  if (process.platform === 'win32') {
+    const cliScript = path.join(prefix, 'gitnexus-test.cjs');
+    fs.mkdirSync(prefix, { recursive: true });
+    fs.writeFileSync(cliScript, cliSource);
+    fs.writeFileSync(path.join(prefix, 'gitnexus.cmd'), '@node "%~dp0\\gitnexus-test.cjs" %*\r\n');
+  } else {
+    const bin = path.join(prefix, 'bin');
+    fs.mkdirSync(bin, { recursive: true });
+    const executable = path.join(bin, 'gitnexus');
+    fs.writeFileSync(executable, cliSource);
+    fs.chmodSync(executable, 0o755);
+  }
+
+  const asset = path.join(root, 'gitnexus-1.6.10-electric.2.tgz');
+  fs.writeFileSync(asset, 'deterministic tarball fixture');
+  const digest = createHash('sha256').update(fs.readFileSync(asset)).digest('hex');
+  const checksums = path.join(root, 'SHA256SUMS');
+  fs.writeFileSync(checksums, `${digest}  ${path.basename(asset)}\n`);
+  return { root, prefix, asset, checksums };
+}
+
+function run(values) {
+  return spawnSync(
+    process.execPath,
+    [
+      SCRIPT,
+      '--asset',
+      values.asset,
+      '--checksums',
+      values.checksums,
+      '--prefix',
+      values.prefix,
+      '--expected-version',
+      '1.6.10-electric.2',
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+test.after(() => {
+  for (const root of temporaryRoots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('verifies checksum, package identity, native import, CLI, and MCP help', () => {
+  const result = run(fixture());
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    package: 'gitnexus@1.6.10-electric.2',
+    ladybug: '@ladybugdb/core@0.18.1',
+    sha256: createHash('sha256').update('deterministic tarball fixture').digest('hex'),
+    nativeImport: 'ok',
+    cli: 'ok',
+    mcpHelp: 'ok',
+  });
+});
+
+test('fails closed when the installed LadybugDB version drifts', () => {
+  const result = run(fixture({ ladybugVersion: '0.18.0' }));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /expected 0\.18\.1/u);
+});

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -13,7 +13,7 @@ const SCRIPT = path.join(
 );
 const temporaryRoots = [];
 
-function fixture({ ladybugVersion = '0.18.1' } = {}) {
+function fixture({ ladybugVersion = '0.18.1', checksumLineEnding = '\n' } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-electric-package-'));
   temporaryRoots.push(root);
   const prefix = path.join(root, 'prefix');
@@ -29,6 +29,10 @@ function fixture({ ladybugVersion = '0.18.1' } = {}) {
     path.join(installed, 'package.json'),
     JSON.stringify({ name: 'gitnexus', version: '1.6.10-electric.2' }),
   );
+  fs.mkdirSync(path.join(installed, 'vendor', 'tree-sitter-typescript'), { recursive: true });
+  for (const name of ['tree-sitter-dart', 'tree-sitter-proto', 'tree-sitter-swift']) {
+    fs.mkdirSync(path.join(installed, 'node_modules', name), { recursive: true });
+  }
   fs.writeFileSync(
     path.join(ladybug, 'package.json'),
     JSON.stringify({ name: '@ladybugdb/core', version: ladybugVersion, main: 'index.cjs' }),
@@ -61,8 +65,8 @@ else process.exit(2);
   fs.writeFileSync(asset, 'deterministic tarball fixture');
   const digest = createHash('sha256').update(fs.readFileSync(asset)).digest('hex');
   const checksums = path.join(root, 'SHA256SUMS');
-  fs.writeFileSync(checksums, `${digest}  ${path.basename(asset)}\n`);
-  return { root, prefix, asset, checksums };
+  fs.writeFileSync(checksums, `${digest}  ${path.basename(asset)}${checksumLineEnding}`);
+  return { root, prefix, installed, asset, checksums };
 }
 
 function runArgs(args) {
@@ -95,9 +99,35 @@ test('verifies checksum, package identity, native import, CLI, and MCP help', ()
     ladybug: '@ladybugdb/core@0.18.1',
     sha256: createHash('sha256').update('deterministic tarball fixture').digest('hex'),
     nativeImport: 'ok',
+    vendorTree: 'ok',
     cli: 'ok',
     mcpHelp: 'ok',
   });
+});
+
+test('accepts CRLF checksum files', () => {
+  const result = run(fixture({ checksumLineEnding: '\r\n' }));
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('fails closed on vendor build artifacts', () => {
+  const values = fixture();
+  fs.mkdirSync(path.join(values.installed, 'vendor', 'tree-sitter-typescript', 'build'));
+  const result = run(values);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /vendor tree contains forbidden build artifacts/u);
+});
+
+test('fails closed when a materialized grammar is a symlink or junction', () => {
+  const values = fixture();
+  const grammar = path.join(values.installed, 'node_modules', 'tree-sitter-dart');
+  const target = path.join(values.root, 'grammar-target');
+  fs.rmSync(grammar, { recursive: true });
+  fs.mkdirSync(target);
+  fs.symlinkSync(target, grammar, process.platform === 'win32' ? 'junction' : 'dir');
+  const result = run(values);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /must not be a symlink or junction/u);
 });
 
 test('fails closed when the installed LadybugDB version drifts', () => {

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -73,6 +73,17 @@ else process.exit(2);
   const cliScript = path.join(installed, 'dist', 'cli', 'index.js');
   fs.mkdirSync(path.dirname(cliScript), { recursive: true });
   fs.writeFileSync(cliScript, cliSource);
+  if (process.platform === 'win32') {
+    fs.writeFileSync(
+      path.join(prefix, 'gitnexus.cmd'),
+      '@node "%~dp0\\node_modules\\gitnexus\\dist\\cli\\index.js" %*\r\n',
+    );
+  } else {
+    fs.chmodSync(cliScript, 0o755);
+    const bin = path.join(prefix, 'bin');
+    fs.mkdirSync(bin, { recursive: true });
+    fs.symlinkSync(cliScript, path.join(bin, 'gitnexus'));
+  }
 
   const asset = path.join(root, 'gitnexus-1.6.10-electric.2.tgz');
   fs.writeFileSync(asset, 'deterministic tarball fixture');
@@ -113,6 +124,7 @@ test('verifies checksum, package identity, native import, CLI, and MCP help', ()
     sha256: createHash('sha256').update('deterministic tarball fixture').digest('hex'),
     nativeImport: 'ok',
     vendorTree: 'ok',
+    launcher: 'ok',
     cli: 'ok',
     mcpHelp: 'ok',
   });
@@ -135,6 +147,18 @@ test('fails fast when the packaged CLI hangs', () => {
   assert.ok(Date.now() - started < 5_000, 'hard timeout must not wait for natural child exit');
 });
 
+test('fails closed when the installed launcher is unusable', () => {
+  const values = fixture();
+  if (process.platform === 'win32') {
+    fs.rmSync(path.join(values.prefix, 'gitnexus.cmd'));
+  } else {
+    fs.chmodSync(values.cliScript, 0o644);
+  }
+  const result = run(values);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /gitnexus(?: CLI entry| launcher)|EACCES/u);
+});
+
 test('fails closed on vendor build artifacts', () => {
   const values = fixture();
   fs.mkdirSync(path.join(values.installed, 'vendor', 'tree-sitter-typescript', 'build'));
@@ -143,17 +167,19 @@ test('fails closed on vendor build artifacts', () => {
   assert.match(result.stderr, /vendor tree contains forbidden build artifacts/u);
 });
 
-test('fails closed when a materialized grammar is a symlink or junction', () => {
-  const values = fixture();
-  const grammar = path.join(values.installed, 'node_modules', 'tree-sitter-dart');
-  const target = path.join(values.root, 'grammar-target');
-  fs.rmSync(grammar, { recursive: true });
-  fs.mkdirSync(target);
-  fs.symlinkSync(target, grammar, process.platform === 'win32' ? 'junction' : 'dir');
-  const result = run(values);
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /must not be a symlink or junction/u);
-});
+for (const name of ['tree-sitter-dart', 'tree-sitter-proto', 'tree-sitter-swift']) {
+  test(`fails closed when ${name} is a symlink or junction`, () => {
+    const values = fixture();
+    const grammar = path.join(values.installed, 'node_modules', name);
+    const target = path.join(values.root, `${name}-target`);
+    fs.rmSync(grammar, { recursive: true });
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, grammar, process.platform === 'win32' ? 'junction' : 'dir');
+    const result = run(values);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /must not be a symlink or junction/u);
+  });
+}
 
 test('fails closed when the installed LadybugDB version drifts', () => {
   const result = run(fixture({ ladybugVersion: '0.18.0' }));

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -45,7 +45,11 @@ function fixture({ ladybugVersion = '0.18.1', checksumLineEnding = '\n' } = {}) 
   fs.mkdirSync(ladybug, { recursive: true });
   fs.writeFileSync(
     path.join(installed, 'package.json'),
-    JSON.stringify({ name: 'gitnexus', version: '1.6.10-electric.2' }),
+    JSON.stringify({
+      name: 'gitnexus',
+      version: '1.6.10-electric.2',
+      bin: { gitnexus: 'dist/cli/index.js' },
+    }),
   );
   fs.mkdirSync(path.join(installed, 'vendor', 'tree-sitter-typescript'), { recursive: true });
   for (const name of ['tree-sitter-dart', 'tree-sitter-proto', 'tree-sitter-swift']) {
@@ -66,19 +70,9 @@ if (args[0] === '--version') console.log('1.6.10-electric.2');
 else if (args[0] === '--help' || (args[0] === 'mcp' && args[1] === '--help')) process.exit(0);
 else process.exit(2);
 `;
-  let cliScript;
-  if (process.platform === 'win32') {
-    cliScript = path.join(prefix, 'gitnexus-test.cjs');
-    fs.mkdirSync(prefix, { recursive: true });
-    fs.writeFileSync(cliScript, cliSource);
-    fs.writeFileSync(path.join(prefix, 'gitnexus.cmd'), '@node "%~dp0\\gitnexus-test.cjs" %*\r\n');
-  } else {
-    const bin = path.join(prefix, 'bin');
-    fs.mkdirSync(bin, { recursive: true });
-    cliScript = path.join(bin, 'gitnexus');
-    fs.writeFileSync(cliScript, cliSource);
-    fs.chmodSync(cliScript, 0o755);
-  }
+  const cliScript = path.join(installed, 'dist', 'cli', 'index.js');
+  fs.mkdirSync(path.dirname(cliScript), { recursive: true });
+  fs.writeFileSync(cliScript, cliSource);
 
   const asset = path.join(root, 'gitnexus-1.6.10-electric.2.tgz');
   fs.writeFileSync(asset, 'deterministic tarball fixture');

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -51,9 +51,15 @@ function fixture({ ladybugVersion = '0.18.1', checksumLineEnding = '\n' } = {}) 
       bin: { gitnexus: 'dist/cli/index.js' },
     }),
   );
-  fs.mkdirSync(path.join(installed, 'vendor', 'tree-sitter-typescript'), { recursive: true });
-  for (const name of ['tree-sitter-dart', 'tree-sitter-proto', 'tree-sitter-swift']) {
-    fs.mkdirSync(path.join(installed, 'node_modules', name), { recursive: true });
+  for (const name of [
+    'tree-sitter-c',
+    'tree-sitter-dart',
+    'tree-sitter-kotlin',
+    'tree-sitter-proto',
+    'tree-sitter-swift',
+    'tree-sitter-typescript',
+  ]) {
+    fs.mkdirSync(path.join(installed, 'vendor', name), { recursive: true });
   }
   fs.writeFileSync(
     path.join(ladybug, 'package.json'),
@@ -190,10 +196,16 @@ test('fails closed on vendor build artifacts', () => {
   assert.match(result.stderr, /vendor tree contains forbidden build artifacts/u);
 });
 
-for (const name of ['tree-sitter-dart', 'tree-sitter-proto', 'tree-sitter-swift']) {
+for (const name of [
+  'tree-sitter-c',
+  'tree-sitter-dart',
+  'tree-sitter-kotlin',
+  'tree-sitter-proto',
+  'tree-sitter-swift',
+]) {
   test(`fails closed when ${name} is a symlink or junction`, () => {
     const values = fixture();
-    const grammar = path.join(values.installed, 'node_modules', name);
+    const grammar = path.join(values.installed, 'vendor', name);
     const target = path.join(values.root, `${name}-target`);
     fs.rmSync(grammar, { recursive: true });
     fs.mkdirSync(target);

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -7,11 +7,29 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+import { EXPECTED_LADYBUG_VERSION } from './verify-electric-package.mjs';
+
 const SCRIPT = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   'verify-electric-package.mjs',
 );
 const temporaryRoots = [];
+
+test('keeps the release verifier synchronized with the exact package pin', () => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '..',
+        '..',
+        'gitnexus',
+        'package.json',
+      ),
+      'utf8',
+    ),
+  );
+  assert.equal(packageJson.dependencies['@ladybugdb/core'], EXPECTED_LADYBUG_VERSION);
+});
 
 function fixture({ ladybugVersion = '0.18.1', checksumLineEnding = '\n' } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-electric-package-'));

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -7,7 +7,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { EXPECTED_LADYBUG_VERSION } from './verify-electric-package.mjs';
+import { EXPECTED_LADYBUG_VERSION, runCli } from './verify-electric-package.mjs';
 
 const SCRIPT = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -66,17 +66,18 @@ if (args[0] === '--version') console.log('1.6.10-electric.2');
 else if (args[0] === '--help' || (args[0] === 'mcp' && args[1] === '--help')) process.exit(0);
 else process.exit(2);
 `;
+  let cliScript;
   if (process.platform === 'win32') {
-    const cliScript = path.join(prefix, 'gitnexus-test.cjs');
+    cliScript = path.join(prefix, 'gitnexus-test.cjs');
     fs.mkdirSync(prefix, { recursive: true });
     fs.writeFileSync(cliScript, cliSource);
     fs.writeFileSync(path.join(prefix, 'gitnexus.cmd'), '@node "%~dp0\\gitnexus-test.cjs" %*\r\n');
   } else {
     const bin = path.join(prefix, 'bin');
     fs.mkdirSync(bin, { recursive: true });
-    const executable = path.join(bin, 'gitnexus');
-    fs.writeFileSync(executable, cliSource);
-    fs.chmodSync(executable, 0o755);
+    cliScript = path.join(bin, 'gitnexus');
+    fs.writeFileSync(cliScript, cliSource);
+    fs.chmodSync(cliScript, 0o755);
   }
 
   const asset = path.join(root, 'gitnexus-1.6.10-electric.2.tgz');
@@ -84,7 +85,7 @@ else process.exit(2);
   const digest = createHash('sha256').update(fs.readFileSync(asset)).digest('hex');
   const checksums = path.join(root, 'SHA256SUMS');
   fs.writeFileSync(checksums, `${digest}  ${path.basename(asset)}${checksumLineEnding}`);
-  return { root, prefix, installed, asset, checksums };
+  return { root, prefix, installed, cliScript, asset, checksums };
 }
 
 function runArgs(args) {
@@ -126,6 +127,13 @@ test('verifies checksum, package identity, native import, CLI, and MCP help', ()
 test('accepts CRLF checksum files', () => {
   const result = run(fixture({ checksumLineEnding: '\r\n' }));
   assert.equal(result.status, 0, result.stderr);
+});
+
+test('fails fast when the packaged CLI hangs', () => {
+  const values = fixture();
+  fs.writeFileSync(values.cliScript, '#!/usr/bin/env node\nsetTimeout(() => {}, 10_000);\n');
+  if (process.platform !== 'win32') fs.chmodSync(values.cliScript, 0o755);
+  assert.throws(() => runCli(values.prefix, ['--help'], 25), /timed out after 25ms/u);
 });
 
 test('fails closed on vendor build artifacts', () => {

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -159,6 +159,23 @@ test('fails closed when the installed launcher is unusable', () => {
   assert.match(result.stderr, /gitnexus(?: CLI entry| launcher)|EACCES/u);
 });
 
+test('fails closed when the installed launcher targets the wrong entry', () => {
+  const values = fixture();
+  if (process.platform === 'win32') {
+    fs.writeFileSync(path.join(values.prefix, 'gitnexus.cmd'), '@node "%~dp0\\wrong.js" %*\r\n');
+  } else {
+    const wrongEntry = path.join(values.installed, 'dist', 'cli', 'wrong.js');
+    fs.writeFileSync(wrongEntry, '#!/usr/bin/env node\n');
+    fs.chmodSync(wrongEntry, 0o755);
+    const launcher = path.join(values.prefix, 'bin', 'gitnexus');
+    fs.rmSync(launcher);
+    fs.symlinkSync(wrongEntry, launcher);
+  }
+  const result = run(values);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /launcher does not target/u);
+});
+
 test('fails closed on vendor build artifacts', () => {
   const values = fixture();
   fs.mkdirSync(path.join(values.installed, 'vendor', 'tree-sitter-typescript', 'build'));

--- a/.github/scripts/verify-electric-package.test.mjs
+++ b/.github/scripts/verify-electric-package.test.mjs
@@ -7,7 +7,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { EXPECTED_LADYBUG_VERSION, runCli } from './verify-electric-package.mjs';
+import { EXPECTED_LADYBUG_VERSION, isCliTimeout, runCli } from './verify-electric-package.mjs';
 
 const SCRIPT = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -147,6 +147,12 @@ test('fails fast when the packaged CLI hangs', () => {
   assert.ok(Date.now() - started < 5_000, 'hard timeout must not wait for natural child exit');
 });
 
+test('classifies timeout results consistently across Node platforms', () => {
+  assert.equal(isCliTimeout({ error: { code: 'ETIMEDOUT' }, status: null, signal: null }), true);
+  assert.equal(isCliTimeout({ error: undefined, status: null, signal: 'SIGKILL' }), true);
+  assert.equal(isCliTimeout({ error: { code: 'ENOENT' }, status: null, signal: null }), false);
+});
+
 test('fails closed when the installed launcher is unusable', () => {
   const values = fixture();
   if (process.platform === 'win32') {
@@ -156,7 +162,7 @@ test('fails closed when the installed launcher is unusable', () => {
   }
   const result = run(values);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /gitnexus(?: CLI entry| launcher)|EACCES/u);
+  assert.match(result.stderr, /gitnexus(?: CLI entry| launcher)|EACCES|ENOENT/u);
 });
 
 test('fails closed when the installed launcher targets the wrong entry', () => {

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -300,6 +300,9 @@ jobs:
         with:
           build: 'true'
 
+      - name: Test Electric package verifier
+        run: node --test .github/scripts/verify-electric-package.test.mjs
+
       - name: Pack gitnexus tarball
         shell: bash
         run: npm pack

--- a/.github/workflows/electric-release-resume.yml
+++ b/.github/workflows/electric-release-resume.yml
@@ -197,6 +197,9 @@ jobs:
             ([.[] | .jobs[] | select(.name == "Exact-head CI / CI Gate" and .conclusion == "success")] | length) == 1 and
             ([.[] | .jobs[] | select(.name | startswith("Exact-head CI /")) | select(.conclusion != "success" and .conclusion != "skipped")] | length) == 0 and
             ([.[] | .jobs[] | select(.name == "Build and prove release tarball" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name == "Prove release tarball (ubuntu-latest)" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name == "Prove release tarball (macos-latest)" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name == "Prove release tarball (windows-latest)" and .conclusion == "success")] | length) == 1 and
             ([.[] | .jobs[] | select(.name == "Create protected Electric GitHub Release" and .conclusion == "failure")] | length) == 1
           ' /tmp/electric-recovery-jobs.json >/dev/null
           gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals" \
@@ -319,6 +322,9 @@ jobs:
             ([.[] | .jobs[] | select(.name == "Exact-head CI / CI Gate" and .conclusion == "success")] | length) == 1 and
             ([.[] | .jobs[] | select(.name | startswith("Exact-head CI /")) | select(.conclusion != "success" and .conclusion != "skipped")] | length) == 0 and
             ([.[] | .jobs[] | select(.name == "Build and prove release tarball" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name == "Prove release tarball (ubuntu-latest)" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name == "Prove release tarball (macos-latest)" and .conclusion == "success")] | length) == 1 and
+            ([.[] | .jobs[] | select(.name == "Prove release tarball (windows-latest)" and .conclusion == "success")] | length) == 1 and
             ([.[] | .jobs[] | select(.name == "Create protected Electric GitHub Release" and .conclusion == "failure")] | length) == 1
           ' /tmp/electric-recovery-reverify-jobs.json >/dev/null
           gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/approvals" \

--- a/.github/workflows/electric-release.yml
+++ b/.github/workflows/electric-release.yml
@@ -200,7 +200,7 @@ jobs:
       - uses: ./.github/actions/setup-gitnexus
         with:
           build: 'true'
-      - name: Pack and install isolated CLI
+      - name: Pack release tarball
         shell: bash
         working-directory: gitnexus
         env:
@@ -208,8 +208,7 @@ jobs:
         run: |
           set -euo pipefail
           ASSET_DIR="$RUNNER_TEMP/electric-release-assets"
-          PREFIX="$RUNNER_TEMP/electric-release-prefix"
-          mkdir -p "$ASSET_DIR" "$PREFIX"
+          mkdir -p "$ASSET_DIR"
 
           npm pack --dry-run > "$RUNNER_TEMP/npm-pack-dry-run.log"
           npm pack --pack-destination "$ASSET_DIR" > "$RUNNER_TEMP/npm-pack.log"
@@ -219,15 +218,6 @@ jobs:
             echo "::error::npm pack did not create $ASSET_PATH"
             exit 1
           fi
-
-          npm install --global --prefix "$PREFIX" "$ASSET_PATH"
-          VERSION_OUTPUT="$("$PREFIX/bin/gitnexus" --version)"
-          if [ "$VERSION_OUTPUT" != "$EXPECTED_VERSION" ]; then
-            echo "::error::Packaged CLI version '$VERSION_OUTPUT' does not equal $EXPECTED_VERSION"
-            exit 1
-          fi
-          "$PREFIX/bin/gitnexus" --help >/dev/null
-          "$PREFIX/bin/gitnexus" mcp --help >/dev/null
 
           (
             cd "$ASSET_DIR"
@@ -244,9 +234,49 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  package_proof:
+    name: Prove release tarball (${{ matrix.os }})
+    needs: [inspect, package]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.inspect.outputs.head_sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Download release tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: electric-release-${{ needs.inspect.outputs.version }}
+          path: ${{ runner.temp }}/electric-release-assets
+      - name: Install and verify release tarball
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ needs.inspect.outputs.version }}
+        run: |
+          set -euo pipefail
+          ASSET_DIR="$RUNNER_TEMP/electric-release-assets"
+          ASSET_PATH="$ASSET_DIR/gitnexus-$EXPECTED_VERSION.tgz"
+          PREFIX="$RUNNER_TEMP/electric-release-prefix"
+          npm install --global --prefix "$PREFIX" "$ASSET_PATH" --no-audit --no-fund
+          node .github/scripts/verify-electric-package.mjs \
+            --asset "$ASSET_PATH" \
+            --checksums "$ASSET_DIR/SHA256SUMS" \
+            --prefix "$PREFIX" \
+            --expected-version "$EXPECTED_VERSION"
+
   release:
     name: Create protected Electric GitHub Release
-    needs: [inspect, package]
+    needs: [inspect, package, package_proof]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment:

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
-        "@ladybugdb/core": "^0.18.0",
+        "@ladybugdb/core": "0.18.1",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@scarf/scarf": "^1.4.0",
         "busboy": "^1.6.0",
@@ -1261,9 +1261,9 @@
       }
     },
     "node_modules/@ladybugdb/core": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core/-/core-0.18.0.tgz",
-      "integrity": "sha512-3X1NCsZZn2oPF/KtvrbQtRu9NvRw9z6BvNSW3lO9xe/I89HSnAsXXFaMDIirLnm3hgGb8ocnVhuMAyfS4DXnhA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core/-/core-0.18.1.tgz",
+      "integrity": "sha512-0c1kXDpdv7z/GB0oyFYnLEjLsXFwPHz1YD4wxtrk9hav8zJX5T1PHQMr+XRfdDI1NQjx4iNdbPQGGT7Bx/X2aw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1272,17 +1272,17 @@
         "node-addon-api": "^6.0.0"
       },
       "optionalDependencies": {
-        "@ladybugdb/core-darwin-arm64": "0.18.0",
-        "@ladybugdb/core-darwin-x64": "0.18.0",
-        "@ladybugdb/core-linux-arm64": "0.18.0",
-        "@ladybugdb/core-linux-x64": "0.18.0",
-        "@ladybugdb/core-win32-x64": "0.18.0"
+        "@ladybugdb/core-darwin-arm64": "0.18.1",
+        "@ladybugdb/core-darwin-x64": "0.18.1",
+        "@ladybugdb/core-linux-arm64": "0.18.1",
+        "@ladybugdb/core-linux-x64": "0.18.1",
+        "@ladybugdb/core-win32-x64": "0.18.1"
       }
     },
     "node_modules/@ladybugdb/core-darwin-arm64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-arm64/-/core-darwin-arm64-0.18.0.tgz",
-      "integrity": "sha512-HlJswkjSdPyXDp+krZBnU5jHQYK/1G4jTBj9Y5cUkm7ze+qR7mj9bkstUldEC3t2N7W6Os7wzTIUUORpHDRGvA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-arm64/-/core-darwin-arm64-0.18.1.tgz",
+      "integrity": "sha512-M5YZuAONRAv3awkr+cfaibn9Da+3pgDzRiek/JabWQuz48xgzW3Vh9yQH4s8Dq/bfQo6YTsaLIBRcUCCUzCtcg==",
       "cpu": [
         "arm64"
       ],
@@ -1293,9 +1293,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-darwin-x64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-x64/-/core-darwin-x64-0.18.0.tgz",
-      "integrity": "sha512-NUqnxnnGPs3XR86/4fLWsn+Cz9/sykVIaNOw3BsYccpiGWKvnGnDcpKID1HVHRcSa84N+CrXPkuzUvkRD36s3Q==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-darwin-x64/-/core-darwin-x64-0.18.1.tgz",
+      "integrity": "sha512-kq+pyTskfCx++Mrbk7QssE/f/CpSuU50T8lhRtv4PaOKhC2Jf8/wAUOA17UxI594wAru3ERpqVBFUBWGcPk2ag==",
       "cpu": [
         "x64"
       ],
@@ -1306,9 +1306,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-linux-arm64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-arm64/-/core-linux-arm64-0.18.0.tgz",
-      "integrity": "sha512-/wHoqsPOna+lZZbeAOFRiTHHpaiuA+07H5FUQqZI/qrEfjjN38xznmnLVCE5YZcFCzNxAS4aK40rXaUFZLj+Ow==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-arm64/-/core-linux-arm64-0.18.1.tgz",
+      "integrity": "sha512-fu7ke1haa5rPINcQn0+kxQijZ0A8ZDWP9e+X8xcDH94RagDbPWwG8yFC890cGSdc/j7mTV+xkA/y/kVHpmVI6w==",
       "cpu": [
         "arm64"
       ],
@@ -1319,9 +1319,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-linux-x64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-x64/-/core-linux-x64-0.18.0.tgz",
-      "integrity": "sha512-ge9pGnU94jVBOYxAuUq3d9BYSS3ProtwIKse9ZKXxeL9Hh8Qmwcz9Ey++BJMm+lSN8dE0lUBQTGXCTd1jrMnpA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-linux-x64/-/core-linux-x64-0.18.1.tgz",
+      "integrity": "sha512-qp5HilHzDGuArfOyD+VyA7lVJ7IwQDKd81NZKKTmUwIAOJtdwqniYx6JZICPnlr36zFJBx/lGYoSsEzbC+TVdw==",
       "cpu": [
         "x64"
       ],
@@ -1332,9 +1332,9 @@
       ]
     },
     "node_modules/@ladybugdb/core-win32-x64": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@ladybugdb/core-win32-x64/-/core-win32-x64-0.18.0.tgz",
-      "integrity": "sha512-RLW9m9BJ4LdFjKsTOZdg43FjmdboZ1gvhmnP494JPfVsmNt+7lMJOmhtvuePj3uAhOEd9qOpGN8hqGiPDywbOA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@ladybugdb/core-win32-x64/-/core-win32-x64-0.18.1.tgz",
+      "integrity": "sha512-vHcXr7Df2X1dbb5ORK+SBmNstd/3tApGFImbAnaWiTuLDFlAdfY8lbiSBSp3OgFjc0BB7F3GYUUdvgDRJjK3zA==",
       "cpu": [
         "x64"
       ],

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -55,7 +55,7 @@
     "prepack": "node scripts/assert-publish-grammar-coverage.cjs && node scripts/build.js"
   },
   "dependencies": {
-    "@ladybugdb/core": "^0.18.0",
+    "@ladybugdb/core": "0.18.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@scarf/scarf": "^1.4.0",
     "busboy": "^1.6.0",


### PR DESCRIPTION
## Summary

- pin `@ladybugdb/core` to exact `0.18.1` without unrelated lockfile churn
- build one deterministic release tarball and prove that same artifact on Linux, macOS, and Windows
- fail closed on checksum, package identity, dependency version, direct native import, CLI, or MCP help drift
- require all three original platform proofs before recovery publication

Closes #120

## Focused proof

- `node --test .github/scripts/check-electric-release-policy.test.mjs .github/scripts/verify-electric-package.test.mjs` (58 passed)
- `node .github/scripts/check-electric-release-policy.mjs`
- `actionlint .github/workflows/electric-release.yml .github/workflows/electric-release-resume.yml`
- Prettier and `git diff --check`
- rebuilt `@ladybugdb/core` direct import: `0.18.1`, `Database` and `Connection` available
- real tarball clean-prefix verifier: checksum, package identity, exact Ladybug version, native import, CLI, and MCP help passed

## Safety boundary

No npm/container publication, live index access, embeddings, OpenClaw canary, gateway restart, or local wrapper mutation. Cross-platform native proof remains a required exact-head GitHub Actions gate.

Coordinates with upstream GitNexus #2441 and LadybugDB #681; no duplicate issue is opened.