### PR TITLE
chore(release): prepare 1.6.10-electric.2

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.1",
+      "version": "1.6.10-electric.2",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.1",
+      "version": "1.6.10-electric.2",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.2.md
+++ b/Documentation/releases/1.6.10-electric.2.md
@@ -1,0 +1,63 @@
+# GitNexus 1.6.10-electric.2
+
+`1.6.10-electric.2` is a focused Electric Sheep maintenance release for more
+reliable MCP discovery and reproducible native packaging. It is distributed as
+a GitHub Release tarball with a SHA-256 checksum and does not publish to npm or
+a container registry.
+
+## Highlights
+
+- MCP context resources now see fresh repository metadata after analysis by a
+  separate process; restarting the MCP server is no longer required.
+- Tool schemas avoid root combinators rejected by strict providers while
+  keeping the existing property and alias surface intact.
+- LadybugDB is pinned exactly to `0.18.1`, and one release tarball is proved in
+  clean Linux, macOS, and Windows installations before publication.
+
+## Changes
+
+- Allowed context-resource requests read current `meta.json` data and fall back
+  to cached registry metadata when the file is absent or corrupt.
+- `impact` and `api_impact` selector requirements are enforced by runtime
+  normalization before repository resolution, including canonical, alias,
+  agreeing, conflicting, grouped, read-only, allowlisted, stdio, and HTTP paths.
+- Release recovery requires the three original platform package proofs, and
+  the shared verifier is reused by normal CI and protected release jobs.
+
+## Fixes
+
+- Denied repositories cannot trigger metadata reads through the context
+  resource path.
+- Strict MCP providers no longer reject advertised tools because of top-level
+  `anyOf`, `oneOf`, or `allOf` schemas.
+- Package proof now fails closed on checksum or package drift, native-load
+  failure, broken launcher targets, hung CLI probes, vendor build debris, and
+  links in the five shipped native grammar directories.
+
+## Known Boundaries
+
+- This patch builds on the existing Electric `1.6.10-electric.1` lineage and
+  does not claim convergence with a nonexistent upstream stable `v1.6.10` tag.
+- Distribution is GitHub-only. Public npm dist-tags and container registries
+  remain unchanged.
+- Publication does not analyze a repository, mutate an index, build
+  embeddings, restart OpenClaw, or change a running OpenClaw process. Existing
+  processes adopt the new local default only after a later natural or
+  separately approved restart.
+- Cross-platform package proof covers supported GitHub runners; it does not
+  establish customer runtime or indexing-quality behavior.
+
+## Release Verification
+
+- Capability PRs: #122, #123, and #124; tracker: #117; release gate: #121.
+- Package, lockfile, Claude/Codex plugin manifests, both marketplaces, and this
+  release note agree on `1.6.10-electric.2`.
+- Required proof includes focused resource/schema/package tests, complete
+  current-head CI, protected publication approval, and one-tarball native-load
+  verification on Linux, macOS, and Windows.
+- Post-release verification downloads both assets, checks `SHA256SUMS`, installs
+  beside `1.6.10-electric.1`, smokes the isolated CLI and MCP `tools/list`, and
+  retains `.1` as the rollback target.
+
+Evidence: `gitnexus-electric2-release-gate/v1` under the Electric Sheep sprint
+packet for 2026-07-14.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.1",
+  "version": "1.6.10-electric.2",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.1",
+  "version": "1.6.10-electric.2",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.2] - 2026-07-15
+
+### Added
+
+- **Fresh MCP context metadata after out-of-process analysis** by reading allowed repositories' current `meta.json` on each context-resource request, with cached registry fallback for missing or corrupt metadata and no metadata reads for denied repositories (#118, #122)
+- **Provider-compatible MCP tool schemas** without root `anyOf`, `oneOf`, or `allOf`, while preserving canonical and alias property names and enforcing required selectors before repository resolution (#119, #123)
+
+### Changed
+
+- **LadybugDB is pinned exactly to `0.18.1`** and the GitHub-only release gate now installs one tarball into clean Linux, macOS, and Windows prefixes before publication (#120, #124)
+- Package proof fails closed on checksum, package identity, exact dependency version, direct native import, launcher identity, CLI/MCP smoke, vendor build debris, or shipped native-grammar link drift.
+- Distribution remains a downloadable GitHub Release tarball plus `SHA256SUMS`; npm, container, index, embedding, and OpenClaw runtime operations are unchanged.
+
 ## [1.6.10-electric.1] - 2026-07-14
 
 ### Added

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.1",
+  "version": "1.6.10-electric.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-electric.1",
+      "version": "1.6.10-electric.2",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.1",
+  "version": "1.6.10-electric.2",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Summary

- set the package, lockfile, Claude/Codex plugin manifests, and both marketplaces to `1.6.10-electric.2`
- add the focused Electric.2 changelog and human-readable GitHub release notes
- preserve GitHub-only distribution and the `.1` rollback boundary

Refs #121

## Focused proof

- `node --test .github/scripts/check-electric-release-policy.test.mjs .github/scripts/verify-electric-package.test.mjs` (58 passed)
- `node .github/scripts/check-electric-release-policy.mjs`
- exact version consistency across package, lockfile, plugin manifests, and marketplaces
- Prettier and `git diff --check`
- exactly the established eight release files changed

## Release boundary

This PR prepares source metadata only. It does not create a tag or release, publish npm/container artifacts, analyze a repository, mutate indexes, build embeddings, restart OpenClaw, or switch the local wrapper. Protected publication and local activation remain gated by issue #121 after this PR merges.