### PR TITLE
fix(mcp): keep policy failures agent-visible

### DIFF
--- a/GUARDRAILS.md
+++ b/GUARDRAILS.md
@@ -57,6 +57,12 @@ Format: **Trigger → Instruction → Reason**. Append new Signs when the same m
 - **Do:** Call `list_repos`, then pass `repo` on subsequent tools.
 - **Why:** Default target is ambiguous when multiple repos are registered.
 
+### MCP repository policy is blocked
+
+- **Trigger:** Stdio MCP tools are present but their descriptions or calls report `MCP repository policy is blocked`.
+- **Do:** Repair the named environment key. For an ambiguous allowlist entry, replace the bare repository name with its unique absolute indexed path, then restart the MCP client. Do not remove the allowlist or choose a worktree arbitrarily.
+- **Why:** Stdio MCP stays protocol-visible so agents receive the sanitized configuration error, but every repository tool and resource remains fail-closed until restart. Standalone HTTP still refuses to bind when its repository policy is invalid.
+
 ### LadybugDB lock / "database busy"
 
 - **Trigger:** Errors opening `.gitnexus/lbug` while MCP and analyze both run.

--- a/gitnexus/src/cli/mcp.ts
+++ b/gitnexus/src/cli/mcp.ts
@@ -53,13 +53,15 @@ export const mcpCommand = async (options?: {
   // stdout at module init, but transitive deps (pino, pino-pretty, the
   // worker-thread transport) could in theory, and the import-closure
   // regression test enforces the leaf invariant.
-  const [{ startMCPServer }, { LocalBackend }, { logger }, { createMcpRepositoryPolicy }] =
+  const [{ startMCPServer }, { LocalBackend }, { logger }, repositoryPolicyModule] =
     await Promise.all([
       import('../mcp/server.js'),
       import('../mcp/local/local-backend.js'),
       import('../core/logger.js'),
       import('../mcp/repository-policy.js'),
     ]);
+  const { createMcpRepositoryPolicy, McpRepositoryPolicy, McpRepositoryPolicyConfigurationError } =
+    repositoryPolicyModule;
 
   // Missing-optional-grammar warnings are intentionally NOT emitted here.
   // `gitnexus analyze` already warns at index time, filtered by the repo's
@@ -73,19 +75,34 @@ export const mcpCommand = async (options?: {
   const backend = new LocalBackend();
   await backend.init();
 
-  const repositoryPolicy = await createMcpRepositoryPolicy(backend);
-  const repos = await repositoryPolicy.scopeBackend(backend).listRepos();
-  if (repos.length === 0) {
-    // Operator-actionable but the server still starts and serves; warn-level,
-    // not error. Tools will discover newly-analyzed repos via lazy refresh.
-    logger.warn(
-      'GitNexus: No indexed repos yet. Run `gitnexus analyze` in a git repo — the server will pick it up automatically.',
+  const repositoryPolicy = await createMcpRepositoryPolicy(backend).catch((error: unknown) => {
+    if (options?.http || !(error instanceof McpRepositoryPolicyConfigurationError)) throw error;
+    logger.error(
+      {
+        configurationKey: error.key,
+        failureReason: error.reason,
+        entryPosition: error.entryPosition,
+        mode: 'blocked',
+      },
+      error.message,
     );
-  } else {
-    logger.info(
-      { repoCount: repos.length, repos: repos.map((r) => r.name) },
-      'GitNexus: MCP server starting',
-    );
+    return McpRepositoryPolicy.blocked(error);
+  });
+
+  if (!repositoryPolicy.configurationError) {
+    const repos = await repositoryPolicy.scopeBackend(backend).listRepos();
+    if (repos.length === 0) {
+      // Operator-actionable but the server still starts and serves; warn-level,
+      // not error. Tools will discover newly-analyzed repos via lazy refresh.
+      logger.warn(
+        'GitNexus: No indexed repos yet. Run `gitnexus analyze` in a git repo — the server will pick it up automatically.',
+      );
+    } else {
+      logger.info(
+        { repoCount: repos.length, repos: repos.map((r) => r.name) },
+        'GitNexus: MCP server starting',
+      );
+    }
   }
 
   // Start HTTP server or fall back to stdio (default).

--- a/gitnexus/src/mcp/repository-policy.ts
+++ b/gitnexus/src/mcp/repository-policy.ts
@@ -13,13 +13,44 @@ const OPENCLAW_DEFAULT = 'OPENCLAW_CODE_INDEX_DEFAULT_REPO';
 
 interface RawRepositoryPolicy {
   allowed?: string[];
+  allowedKey?: string;
   defaultRepo?: string;
+  defaultKey?: string;
 }
 
 interface ResolvedRepository {
   name: string;
   path: string;
   pathKey: string;
+}
+
+export type McpRepositoryPolicyFailureReason =
+  | 'invalid'
+  | 'ambiguous'
+  | 'blank'
+  | 'default_outside_allowlist';
+
+export class McpRepositoryPolicyConfigurationError extends Error {
+  readonly key: string;
+  readonly reason: McpRepositoryPolicyFailureReason;
+  readonly entryPosition?: number;
+
+  constructor(key: string, reason: McpRepositoryPolicyFailureReason, entryPosition?: number) {
+    const location = entryPosition === undefined ? key : `${key} entry ${entryPosition}`;
+    const message =
+      reason === 'ambiguous'
+        ? `MCP repository policy is blocked: MCP repository configuration contains an ambiguous repository selection at ${location}. Use an absolute indexed repository path when names are duplicated, then restart GitNexus MCP.`
+        : reason === 'invalid'
+          ? `MCP repository policy is blocked: MCP repository configuration contains an invalid repository selection at ${location}. Update or remove the entry, then restart GitNexus MCP.`
+          : reason === 'blank'
+            ? `MCP repository policy is blocked: ${location} must not be blank. Set a repository name or absolute path, or unset the variable, then restart GitNexus MCP.`
+            : `MCP repository policy is blocked: ${location} default repository is not in the configured allowlist. Update the default or allowlist, then restart GitNexus MCP.`;
+    super(message);
+    this.name = 'McpRepositoryPolicyConfigurationError';
+    this.key = key;
+    this.reason = reason;
+    this.entryPosition = entryPosition;
+  }
 }
 
 function configuredValue(
@@ -45,16 +76,25 @@ function parseRepositoryPolicy(env: NodeJS.ProcessEnv): RawRepositoryPolicy {
       .split(',')
       .map((entry) => entry.trim())
       .filter(Boolean);
-    if (allowed.length === 0) throw new Error(`${allowedRaw.key} must not be blank.`);
+    if (allowed.length === 0) {
+      throw new McpRepositoryPolicyConfigurationError(allowedRaw.key, 'blank');
+    }
   }
 
   let defaultRepo: string | undefined;
   if (defaultRaw) {
     defaultRepo = defaultRaw.value.trim();
-    if (!defaultRepo) throw new Error(`${defaultRaw.key} must not be blank.`);
+    if (!defaultRepo) {
+      throw new McpRepositoryPolicyConfigurationError(defaultRaw.key, 'blank');
+    }
   }
 
-  return { allowed, defaultRepo };
+  return {
+    allowed,
+    allowedKey: allowedRaw?.key,
+    defaultRepo,
+    defaultKey: defaultRaw?.key,
+  };
 }
 
 function normalizedPath(value: string): string {
@@ -80,14 +120,6 @@ function resolveSpecifier(
   return { repo: matches[0] };
 }
 
-function startupResolutionError(reason: 'invalid' | 'ambiguous'): Error {
-  return new Error(
-    reason === 'ambiguous'
-      ? 'MCP repository configuration contains an ambiguous repository selection.'
-      : 'MCP repository configuration contains an invalid repository selection.',
-  );
-}
-
 function unavailableRepositoryError(): Error {
   return new Error('Repository is not available through this MCP server.');
 }
@@ -95,6 +127,7 @@ function unavailableRepositoryError(): Error {
 export class McpRepositoryPolicy {
   readonly restricted: boolean;
   readonly configured: boolean;
+  readonly configurationError?: McpRepositoryPolicyConfigurationError;
 
   private readonly registry: readonly ResolvedRepository[];
   private readonly allowed: readonly ResolvedRepository[];
@@ -106,10 +139,15 @@ export class McpRepositoryPolicy {
     return new McpRepositoryPolicy([], undefined, undefined);
   }
 
+  static blocked(error: McpRepositoryPolicyConfigurationError): McpRepositoryPolicy {
+    return new McpRepositoryPolicy([], [], undefined, error);
+  }
+
   constructor(
     registry: readonly ResolvedRepository[],
     allowed: readonly ResolvedRepository[] | undefined,
     defaultRepo: ResolvedRepository | undefined,
+    configurationError?: McpRepositoryPolicyConfigurationError,
   ) {
     this.registry = registry;
     this.restricted = allowed !== undefined;
@@ -117,6 +155,7 @@ export class McpRepositoryPolicy {
     this.allowed = allowed ?? registry;
     this.allowedPathKeys = new Set(this.allowed.map((repo) => repo.pathKey));
     this.defaultRepo = defaultRepo;
+    this.configurationError = configurationError;
 
     const registryNameCounts = new Map<string, number>();
     for (const repo of registry) {
@@ -170,6 +209,7 @@ export class McpRepositoryPolicy {
   }
 
   private async listAllowedRepos(backend: LocalBackend): Promise<RepoListing[]> {
+    if (this.configurationError) throw this.configurationError;
     const current = await backend.listRepos();
     if (!this.restricted) return current;
     return current
@@ -223,6 +263,7 @@ export class McpRepositoryPolicy {
     method: string,
     params: Record<string, unknown> | undefined,
   ): Promise<unknown> {
+    if (this.configurationError) throw this.configurationError;
     if (!this.configured) return backend.callTool(method, params);
     if (method === 'list_repos') return this.listReposPage(backend, params);
     if (this.restricted && method.startsWith('group_')) {
@@ -236,6 +277,7 @@ export class McpRepositoryPolicy {
     repo?: string,
     branch?: string,
   ): Promise<Awaited<ReturnType<LocalBackend['resolveRepo']>>> {
+    if (this.configurationError) throw this.configurationError;
     if (!this.configured) return backend.resolveRepo(repo, branch);
     if (!this.restricted) return backend.resolveRepo(repo ?? this.defaultRepo?.path, branch);
     const selected = this.repoForArgs(repo === undefined ? undefined : { repo });
@@ -243,6 +285,7 @@ export class McpRepositoryPolicy {
   }
 
   assertResourceUri(uri: string): void {
+    if (this.configurationError) throw this.configurationError;
     if (!this.restricted) return;
     let parsed: URL;
     try {
@@ -284,13 +327,25 @@ export class McpRepositoryPolicy {
       .replace(/\nGROUP MODE:[\s\S]*?(?=\n\n[A-Z][A-Z ()-]*:|$)/gu, '')
       .replace(/\nCROSS-REPO \(experimental\):[\s\S]*?(?=\n\n[A-Z][A-Z ()-]*:|$)/gu, '')
       .replace(/\nDESTINATION TRACE \(cross-repo\):[\s\S]*?(?=\n\n[A-Z][A-Z ()-]*:|$)/gu, '');
-    return { ...tool, description, inputSchema: { ...tool.inputSchema, properties } };
+    return {
+      ...tool,
+      description: this.configurationError
+        ? `BLOCKED: ${this.configurationError.message}\n\n${description}`
+        : description,
+      inputSchema: { ...tool.inputSchema, properties },
+    };
   }
 
   scopeBackend(backend: LocalBackend): LocalBackend {
     const policy = this;
     return new Proxy(backend, {
       get(target, property, receiver) {
+        const value = Reflect.get(target, property, receiver);
+        if (policy.configurationError && typeof value === 'function') {
+          return () => {
+            throw policy.configurationError;
+          };
+        }
         if (property === 'callTool') {
           return (method: string, params: Record<string, unknown> | undefined) =>
             policy.callTool(target, method, params);
@@ -315,7 +370,6 @@ export class McpRepositoryPolicy {
             );
           };
         }
-        const value = Reflect.get(target, property, receiver);
         return typeof value === 'function' ? value.bind(target) : value;
       },
     });
@@ -345,9 +399,15 @@ export async function createMcpRepositoryPolicy(
   let allowed: ResolvedRepository[] | undefined;
   if (raw.allowed) {
     const byPath = new Map<string, ResolvedRepository>();
-    for (const specifier of raw.allowed) {
+    for (const [index, specifier] of raw.allowed.entries()) {
       const result = resolveSpecifier(specifier, registry);
-      if (!result.repo) throw startupResolutionError(result.reason ?? 'invalid');
+      if (!result.repo) {
+        throw new McpRepositoryPolicyConfigurationError(
+          raw.allowedKey ?? CANONICAL_ALLOWED,
+          result.reason ?? 'invalid',
+          index + 1,
+        );
+      }
       byPath.set(result.repo.pathKey, result.repo);
     }
     allowed = [...byPath.values()];
@@ -356,13 +416,21 @@ export async function createMcpRepositoryPolicy(
   let defaultRepo: ResolvedRepository | undefined;
   if (raw.defaultRepo) {
     const result = resolveSpecifier(raw.defaultRepo, registry);
-    if (!result.repo) throw startupResolutionError(result.reason ?? 'invalid');
+    if (!result.repo) {
+      throw new McpRepositoryPolicyConfigurationError(
+        raw.defaultKey ?? CANONICAL_DEFAULT,
+        result.reason ?? 'invalid',
+      );
+    }
     defaultRepo = result.repo;
   }
 
   const defaultPathKey = defaultRepo?.pathKey;
   if (defaultPathKey && allowed && !allowed.some((repo) => repo.pathKey === defaultPathKey)) {
-    throw new Error('The MCP default repository is not in the configured allowlist.');
+    throw new McpRepositoryPolicyConfigurationError(
+      raw.defaultKey ?? CANONICAL_DEFAULT,
+      'default_outside_allowlist',
+    );
   }
 
   return new McpRepositoryPolicy(registry, allowed, defaultRepo);

--- a/gitnexus/test/integration/mcp/server-startup.test.ts
+++ b/gitnexus/test/integration/mcp/server-startup.test.ts
@@ -51,13 +51,14 @@ interface SpawnedServer {
  * a valid header→body window is captured as "stray" so the test can
  * assert the stream is clean.
  */
-function spawnMcpServer(): SpawnedServer {
+function spawnMcpServer(envOverrides: NodeJS.ProcessEnv = {}): SpawnedServer {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     // Avoid adding indexed repos noise to the test.
     GITNEXUS_HOME: path.join(REPO_ROOT, 'test', 'integration', 'mcp', '.tmp-home'),
     // Be deterministic across machines.
     NODE_OPTIONS: '',
+    ...envOverrides,
   };
 
   const proc = spawn(process.execPath, [DIST_CLI, 'mcp'], {
@@ -315,6 +316,77 @@ describe('MCP server end-to-end startup', () => {
           `Stdout contained ${stray.length} bytes outside JSON-RPC framing — protocol corruption regression.\nStray bytes (utf8): ${JSON.stringify(stray.toString('utf8'))}\nStderr from server:\n${stderr}`,
         );
       }
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+
+  it('keeps stdio alive and reports a sanitized blocked mode when repository policy is invalid', async () => {
+    if (!fs.existsSync(DIST_CLI)) {
+      throw new Error(
+        `dist/cli/index.js missing — run \`npm run build\` first (or use \`npm run test:integration\` which builds via pretest:integration).`,
+      );
+    }
+
+    const configuredValue = 'sensitive-missing-repository';
+    const server = spawnMcpServer({
+      GITNEXUS_MCP_ALLOWED_REPOS: configuredValue,
+      GITNEXUS_MCP_DEFAULT_REPO: undefined,
+      OPENCLAW_CODE_INDEX_ALLOWED_REPOS: undefined,
+      OPENCLAW_CODE_INDEX_DEFAULT_REPO: undefined,
+    });
+
+    try {
+      server.send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'gitnexus-blocked-policy-test', version: '0.0.0' },
+        },
+      });
+      const initResponse = (await server.nextMessage()) as {
+        id: number;
+        result?: { serverInfo: { name: string } };
+        error?: unknown;
+      };
+      expect(initResponse.id).toBe(1);
+      expect(initResponse.error).toBeUndefined();
+      expect(initResponse.result?.serverInfo.name).toMatch(/gitnexus/i);
+
+      server.send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+      server.send({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+      const toolsResponse = (await server.nextMessage()) as {
+        id: number;
+        result?: { tools: Array<{ name: string; description?: string }> };
+      };
+      expect(toolsResponse.id).toBe(2);
+      expect(toolsResponse.result?.tools.length).toBeGreaterThan(0);
+      for (const tool of toolsResponse.result?.tools ?? []) {
+        expect(tool.description).toMatch(/BLOCKED.*invalid.*GITNEXUS_MCP_ALLOWED_REPOS entry 1/is);
+        expect(tool.description).not.toContain(configuredValue);
+      }
+
+      server.send({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'list_repos', arguments: {} },
+      });
+      const callResponse = (await server.nextMessage()) as {
+        id: number;
+        result?: { content?: Array<{ type: string; text: string }>; isError?: boolean };
+      };
+      expect(callResponse.id).toBe(3);
+      expect(callResponse.result?.isError).toBe(true);
+      expect(callResponse.result?.content?.[0]?.text).toMatch(
+        /invalid.*GITNEXUS_MCP_ALLOWED_REPOS entry 1/is,
+      );
+      expect(callResponse.result?.content?.[0]?.text).not.toContain(configuredValue);
+      expect(server.proc.exitCode).toBeNull();
+      expect(server.strayStdoutBytes()).toHaveLength(0);
     } finally {
       await server.close();
     }

--- a/gitnexus/test/unit/mcp-repository-policy.test.ts
+++ b/gitnexus/test/unit/mcp-repository-policy.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import type { LocalBackend, RepoListing } from '../../src/mcp/local/local-backend.js';
-import { createMcpRepositoryPolicy } from '../../src/mcp/repository-policy.js';
+import {
+  createMcpRepositoryPolicy,
+  McpRepositoryPolicy,
+  McpRepositoryPolicyConfigurationError,
+} from '../../src/mcp/repository-policy.js';
 import { createMCPServer } from '../../src/mcp/server.js';
 import { createStreamableHttpHandler, startMcpHttpServer } from '../../src/mcp/http-transport.js';
 
@@ -150,6 +154,7 @@ describe('MCP repository policy', () => {
   it.each([
     [{ GITNEXUS_MCP_ALLOWED_REPOS: 'Missing' }, 'invalid'],
     [{ GITNEXUS_MCP_ALLOWED_REPOS: 'Duplicate' }, 'ambiguous'],
+    [{ GITNEXUS_MCP_DEFAULT_REPO: 'Missing' }, 'invalid'],
     [{ GITNEXUS_MCP_DEFAULT_REPO: 'Duplicate' }, 'ambiguous'],
   ])('fails startup with a sanitized %s configuration error', async (env, reason) => {
     const backend = createBackend();
@@ -163,6 +168,64 @@ describe('MCP repository policy', () => {
     expect(message).not.toContain('/repos/');
     expect(message).not.toContain('Alpha');
     expect(message).not.toContain('Beta');
+  });
+
+  it('keeps MCP discovery agent-visible while a failed policy remains fail-closed', async () => {
+    const backend = createBackend();
+    let configurationError: McpRepositoryPolicyConfigurationError | undefined;
+    try {
+      await createMcpRepositoryPolicy(backend, {
+        GITNEXUS_MCP_ALLOWED_REPOS: 'Alpha,Duplicate',
+      });
+    } catch (error) {
+      if (error instanceof McpRepositoryPolicyConfigurationError) configurationError = error;
+    }
+
+    expect(configurationError).toMatchObject({
+      key: 'GITNEXUS_MCP_ALLOWED_REPOS',
+      reason: 'ambiguous',
+      entryPosition: 2,
+    });
+    vi.clearAllMocks();
+
+    const policy = McpRepositoryPolicy.blocked(configurationError!);
+    const server = createMCPServer(backend, { repositoryPolicy: policy });
+    const client = new Client({ name: 'blocked-policy-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+      const tools = await client.listTools();
+      expect(tools.tools.length).toBeGreaterThan(0);
+      for (const tool of tools.tools) {
+        expect(tool.description).toMatch(
+          /BLOCKED.*ambiguous.*GITNEXUS_MCP_ALLOWED_REPOS entry 2/is,
+        );
+        expect(tool.description).not.toContain('/repos/');
+        expect(tool.description).not.toContain('Duplicate');
+      }
+
+      const call = await client.callTool({ name: 'list_repos', arguments: {} });
+      expect(call.isError).toBe(true);
+      const callText = (call.content[0] as { text: string }).text;
+      expect(callText).toMatch(/ambiguous.*GITNEXUS_MCP_ALLOWED_REPOS entry 2/is);
+      expect(callText).not.toContain('/repos/');
+      expect(callText).not.toContain('Duplicate');
+
+      const resource = await client.readResource({ uri: 'gitnexus://repos' });
+      const resourceText = (resource.contents[0] as { text: string }).text;
+      expect(resourceText).toMatch(/ambiguous.*GITNEXUS_MCP_ALLOWED_REPOS entry 2/is);
+      expect(resourceText).not.toContain('/repos/');
+      expect(resourceText).not.toContain('Duplicate');
+
+      expect(backend.listRepos).not.toHaveBeenCalled();
+      expect(backend.callTool).not.toHaveBeenCalled();
+      expect(backend.resolveRepo).not.toHaveBeenCalled();
+    } finally {
+      await client.close();
+      await server.close();
+    }
   });
 
   it('allows a duplicate-name repository when configured by its unique path', async () => {


### PR DESCRIPTION
## Summary

- keep stdio MCP protocol-visible when repository policy configuration is invalid;
- preserve fail-closed authorization with a blocked policy that rejects every repository backend call and resource read;
- expose sanitized, actionable failure class, environment key, and one-based entry position in tool descriptions and calls;
- preserve standalone HTTP fail-fast startup and existing error phrases;
- document the blocked-mode recovery path.

## Why

One ambiguous bare repository name currently terminates stdio MCP before initialization. Agents see a missing or closed tool surface and cannot receive the configuration error. This change keeps discovery alive without selecting a repository, dropping an allowlist entry, falling back to unrestricted access, or revealing configured values and registry paths.

Closes #128. Related operator preflight: #127.

## Validation

From `gitnexus/`:

```text
node_modules/.bin/tsc --noEmit
node_modules/.bin/vitest run test/unit/mcp-repository-policy.test.ts
node_modules/.bin/vitest run test/integration/mcp/import-closure.test.ts test/integration/mcp/server-startup.test.ts
```

Results:

- TypeScript: passed.
- Repository-policy unit tests: 23/23 passed.
- MCP import/startup integration tests: 4/4 passed.
- Direct built-CLI smoke: emitted a sanitized blocked-mode error without the configured repository value.
- `git diff --check`: passed.

`detect_changes` was attempted as required, but this short-lived worktree is intentionally not registered as another GitNexus index. It returned `Repository not found`; creating another duplicate-name index would recreate the failure class being repaired. Current-source diff and focused protocol tests are the proof surface.

## Risk and rollback

- Only typed repository-policy configuration errors degrade stdio; unexpected registry/backend failures still fail normally.
- HTTP behavior remains fail-fast.
- Blocked mode grants zero repository access and does not call the backend.
- Rollback is a normal revert of this PR.

## Proof boundary

This proves the focused source and built stdio paths locally. It does not prove merge, npm publication, release, installed-package promotion, or Codex/Claude runtime rollout.
