### PR TITLE
fix: make pooled vector retrieval truthful

### DIFF
--- a/gitnexus/src/cli/doctor.ts
+++ b/gitnexus/src/cli/doctor.ts
@@ -200,6 +200,50 @@ export function repoVectorDoctorStatus(meta: RepoMeta | null | undefined): {
   };
 }
 
+export interface DoctorPoolProbe {
+  fts: boolean;
+  vector: boolean;
+  exercisedConnections: number;
+  connectionCount: number;
+  reason: string | null;
+}
+
+/**
+ * Probe the actual indexed read pool without invoking any recovery path.
+ * Optional extensions are aggregated across every pre-warmed connection.
+ */
+export async function probeDoctorPool(dbPath: string): Promise<DoctorPoolProbe> {
+  const repoId = `doctor:${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  let closePool: ((repoId?: string) => Promise<void>) | undefined;
+  try {
+    // Keep the native pool out of doctor.ts's static import graph so `doctor`
+    // can still report a missing/broken lbugjs.node via checkLbugNative().
+    const pool = await import('../core/lbug/pool-adapter.js');
+    closePool = pool.closeLbug;
+    await pool.initLbugNonRecovering(repoId, dbPath);
+    const capabilities = pool.getPoolCapabilities(repoId);
+    if (!capabilities) throw new Error('read pool did not publish capability state');
+    const exercisedConnections = await pool.probePoolConnections(repoId);
+    return {
+      fts: capabilities.fts,
+      vector: capabilities.vector,
+      exercisedConnections,
+      connectionCount: capabilities.connectionCount,
+      reason: null,
+    };
+  } catch (err) {
+    return {
+      fts: false,
+      vector: false,
+      exercisedConnections: 0,
+      connectionCount: 0,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (closePool) await closePool(repoId).catch(() => {});
+  }
+}
+
 export const doctorCommand = async (
   inputPath?: string,
   options: { recoveryPlan?: boolean } = {},
@@ -215,6 +259,10 @@ export const doctorCommand = async (
   const fingerprint = getRuntimeFingerprint();
   const capabilities = getRuntimeCapabilities();
   const embeddingConfig = resolveEmbeddingConfig();
+  const requestedPath = inputPath ? path.resolve(inputPath) : process.cwd();
+  const repoRoot = getGitRoot(requestedPath) ?? requestedPath;
+  const storagePaths = getStoragePaths(repoRoot);
+  const repoMeta = await loadMeta(storagePaths.storagePath).catch(() => null);
 
   console.log(t('doctor.title') + '\n');
   console.log(t('doctor.runtime'));
@@ -242,8 +290,16 @@ export const doctorCommand = async (
   console.log(`  ${label('doctor.labels.graphStore', 18)}${capabilities.graph}`);
   // Live LOAD probe, not the static platform capability — the static value
   // said "available" while analyze failed to load the extension (#2374).
+  const poolProbe = nativeCheck.ok && repoMeta ? await probeDoctorPool(storagePaths.lbugPath) : null;
   const ftsProbe = nativeCheck.ok
-    ? await probeFtsExtensionLoad()
+    ? poolProbe
+      ? {
+          loaded: poolProbe.fts,
+          reason: poolProbe.fts
+            ? undefined
+            : (poolProbe.reason ?? 'FTS did not load on every read-pool connection'),
+        }
+      : await probeFtsExtensionLoad()
     : { loaded: false, reason: 'LadybugDB native module (lbugjs.node) failed to load' };
   console.log(
     `  ${label('doctor.labels.fullTextSearch', 18)}${ftsProbe.loaded ? 'available' : 'unavailable'}`,
@@ -261,13 +317,28 @@ export const doctorCommand = async (
     }
   }
   const vectorProbe = nativeCheck.ok
-    ? await probeVectorExtensionLoad()
+    ? poolProbe
+      ? {
+          loaded: poolProbe.vector,
+          reason: poolProbe.vector
+            ? undefined
+            : (poolProbe.reason ?? 'VECTOR did not load on every read-pool connection'),
+        }
+      : await probeVectorExtensionLoad()
     : { loaded: false, reason: 'LadybugDB native module (lbugjs.node) failed to load' };
   console.log(
     `  ${label('doctor.labels.vectorIndex', 18)}${vectorProbe.loaded ? 'available' : 'unavailable'}`,
   );
   if (!vectorProbe.loaded && vectorProbe.reason) {
     console.log(`  ${padDisplayEnd('', 18)}${vectorProbe.reason}`);
+  }
+  if (poolProbe) {
+    console.log(
+      `  ${padDisplayEnd('Pool connections:', 18)}` +
+        (poolProbe.connectionCount > 0
+          ? `${poolProbe.exercisedConnections}/${poolProbe.connectionCount} exercised`
+          : 'unavailable'),
+    );
   }
   console.log(`  ${label('doctor.labels.semanticMode', 18)}${capabilities.semanticMode}`);
   // Surface the optional-extension install policy so offline users can see
@@ -286,9 +357,6 @@ export const doctorCommand = async (
   );
   if (capabilities.reason)
     console.log(`  ${label('doctor.labels.note', 18)}${capabilities.reason}`);
-  const requestedPath = inputPath ? path.resolve(inputPath) : process.cwd();
-  const repoRoot = getGitRoot(requestedPath) ?? requestedPath;
-  const repoMeta = await loadMeta(getStoragePaths(repoRoot).storagePath).catch(() => null);
   const repoVector = repoVectorDoctorStatus(repoMeta);
   console.log(`  ${padDisplayEnd('Repo VECTOR:', 18)}${repoVector.status}`);
   if (repoVector.detail) {

--- a/gitnexus/src/cli/doctor.ts
+++ b/gitnexus/src/cli/doctor.ts
@@ -290,7 +290,8 @@ export const doctorCommand = async (
   console.log(`  ${label('doctor.labels.graphStore', 18)}${capabilities.graph}`);
   // Live LOAD probe, not the static platform capability — the static value
   // said "available" while analyze failed to load the extension (#2374).
-  const poolProbe = nativeCheck.ok && repoMeta ? await probeDoctorPool(storagePaths.lbugPath) : null;
+  const poolProbe =
+    nativeCheck.ok && repoMeta ? await probeDoctorPool(storagePaths.lbugPath) : null;
   const ftsProbe = nativeCheck.ok
     ? poolProbe
       ? {

--- a/gitnexus/src/cli/doctor.ts
+++ b/gitnexus/src/cli/doctor.ts
@@ -292,13 +292,19 @@ export const doctorCommand = async (
   // said "available" while analyze failed to load the extension (#2374).
   const poolProbe =
     nativeCheck.ok && repoMeta ? await probeDoctorPool(storagePaths.lbugPath) : null;
+  // The aggregate pool verdict is authoritative, but its booleans intentionally
+  // contain no native error text. On failure, run the same bounded, offline LOAD
+  // diagnostic doctor historically used so remediation remains specific.
+  const ftsFailureProbe = poolProbe && !poolProbe.fts ? await probeFtsExtensionLoad() : null;
   const ftsProbe = nativeCheck.ok
     ? poolProbe
       ? {
           loaded: poolProbe.fts,
           reason: poolProbe.fts
             ? undefined
-            : (poolProbe.reason ?? 'FTS did not load on every read-pool connection'),
+            : ((!ftsFailureProbe?.loaded ? ftsFailureProbe?.reason : undefined) ??
+              poolProbe.reason ??
+              'FTS did not load on every read-pool connection'),
         }
       : await probeFtsExtensionLoad()
     : { loaded: false, reason: 'LadybugDB native module (lbugjs.node) failed to load' };
@@ -317,13 +323,17 @@ export const doctorCommand = async (
       console.log(`  ${padDisplayEnd('', 18)}${remedy}`);
     }
   }
+  const vectorFailureProbe =
+    poolProbe && !poolProbe.vector ? await probeVectorExtensionLoad() : null;
   const vectorProbe = nativeCheck.ok
     ? poolProbe
       ? {
           loaded: poolProbe.vector,
           reason: poolProbe.vector
             ? undefined
-            : (poolProbe.reason ?? 'VECTOR did not load on every read-pool connection'),
+            : ((!vectorFailureProbe?.loaded ? vectorFailureProbe?.reason : undefined) ??
+              poolProbe.reason ??
+              'VECTOR did not load on every read-pool connection'),
         }
       : await probeVectorExtensionLoad()
     : { loaded: false, reason: 'LadybugDB native module (lbugjs.node) failed to load' };

--- a/gitnexus/src/core/lbug/extension-loader.ts
+++ b/gitnexus/src/core/lbug/extension-loader.ts
@@ -43,6 +43,8 @@ export interface ExtensionCapability {
 export interface ExtensionEnsureOptions {
   policy?: ExtensionInstallPolicy;
   installTimeoutMs?: number;
+  /** Per-call diagnostic sink. Pool callers use plain stderr so CLI JSON stays machine-readable. */
+  warn?: (message: string) => void;
 }
 
 export interface ExtensionManagerOptions {
@@ -229,7 +231,7 @@ export class ExtensionManager {
     const policy = opts.policy ?? this.options.policy ?? resolvePolicyFromEnv();
     const timeoutMs =
       opts.installTimeoutMs ?? this.options.installTimeoutMs ?? getExtensionInstallTimeoutMs();
-    const warn = this.options.warn ?? ((msg: string) => logger.warn(msg));
+    const warn = opts.warn ?? this.options.warn ?? ((msg: string) => logger.warn(msg));
 
     if (policy === 'never') {
       this.markUnavailable(name, label, 'extension install policy is "never"', warn);

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -17,7 +17,11 @@
 
 import fs from 'fs/promises';
 import lbug from '@ladybugdb/core';
-import { isReadOnlyDbError, loadFTSExtension } from './lbug-adapter.js';
+import {
+  isReadOnlyDbError,
+  loadFTSExtension,
+  loadVectorExtension,
+} from './lbug-adapter.js';
 import { closeQueryResults } from './query-result-utils.js';
 import {
   createLbugDatabase,
@@ -55,6 +59,17 @@ interface PoolEntry {
   dbPath: string;
   /** Set to true when the pool entry is closed — checkin will close orphaned connections */
   closed: boolean;
+  /** Optional search capabilities available on every connection in this pool. */
+  capabilities: PoolCapabilities;
+}
+
+export interface PoolCapabilities {
+  /** True only when FTS loaded successfully on every pre-warmed connection. */
+  fts: boolean;
+  /** True only when VECTOR loaded successfully on every pre-warmed connection. */
+  vector: boolean;
+  /** Number of connections prepared before the pool was published. */
+  connectionCount: number;
 }
 
 const pool = new Map<string, PoolEntry>();
@@ -562,6 +577,35 @@ async function openReadOnlyDatabase(dbPath: string): Promise<lbug.Database> {
 }
 
 /**
+ * Open a read-only Database without any sidecar quarantine or writable replay.
+ * Used by `doctor`, whose capability probe must observe the real index without
+ * repairing or otherwise mutating it.
+ */
+async function openReadOnlyDatabaseNonRecovering(dbPath: string): Promise<lbug.Database> {
+  let db: lbug.Database | undefined;
+  silenceStdout();
+  try {
+    await preflightLbugSidecars(dbPath, {
+      mode: 'read-only',
+      logger: poolSidecarLogger,
+      allowQuarantine: false,
+    });
+    db = createLbugDatabase(lbug, toNativeSafePath(dbPath), {
+      readOnly: true,
+      throwOnWalReplayFailure: false,
+    });
+    await db.init();
+    await probeDatabaseForShadowReplay(db);
+    return db;
+  } catch (err) {
+    if (db) await db.close().catch(() => {});
+    throw err;
+  } finally {
+    restoreStdout();
+  }
+}
+
+/**
  * Quarantine the .wal file and retry opening the database.
  * Used when the initial open fails with a WAL corruption error.
  */
@@ -616,11 +660,68 @@ export const initLbug = async (repoId: string, dbPath: string): Promise<void> =>
 };
 
 /**
- * Internal init — creates DB, pre-warms connections, loads FTS, then registers pool.
+ * Initialize the real read pool without invoking WAL quarantine or writable
+ * shadow replay. This is deliberately separate from normal MCP initialization:
+ * diagnostic callers may inspect capability but must never repair the index.
+ */
+export const initLbugNonRecovering = async (repoId: string, dbPath: string): Promise<void> => {
+  const existing = pool.get(repoId);
+  if (existing) {
+    existing.lastUsed = Date.now();
+    return;
+  }
+
+  const pending = initPromises.get(repoId);
+  if (pending) return pending;
+
+  const promise = doInitLbug(repoId, dbPath, { allowRecovery: false });
+  initPromises.set(repoId, promise);
+  try {
+    await promise;
+  } finally {
+    initPromises.delete(repoId);
+  }
+};
+
+/**
+ * Prepare optional extensions on every connection before publishing the pool.
+ * A partial load disables that capability for the whole pool while preserving
+ * graph queries; callers must never assume a capability from one lucky slot.
+ */
+async function preparePoolConnections(
+  connections: lbug.Connection[],
+): Promise<PoolCapabilities> {
+  let fts = true;
+  let vector = true;
+
+  // Keep native LOAD calls sequential. They target independent connections,
+  // but some LadybugDB builds are not safe to initialize extensions in parallel.
+  for (const connection of connections) {
+    try {
+      if (!(await loadFTSExtension(connection, { policy: 'load-only' }))) fts = false;
+    } catch {
+      fts = false;
+    }
+    try {
+      if (!(await loadVectorExtension(connection, { policy: 'load-only' }))) vector = false;
+    } catch {
+      vector = false;
+    }
+  }
+
+  return { fts, vector, connectionCount: connections.length };
+}
+
+/**
+ * Internal init — creates DB, pre-warms connections, loads optional extensions, then registers pool.
  * Pool entry is registered LAST so concurrent executeQuery calls see either
  * "not initialized" (and throw) or a fully ready pool — never a half-built one.
  */
-async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
+async function doInitLbug(
+  repoId: string,
+  dbPath: string,
+  options: { allowRecovery?: boolean } = {},
+): Promise<void> {
   // Check if database exists
   try {
     await fs.stat(dbPath);
@@ -640,7 +741,9 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
     let lastError: Error | null = null;
     for (let attempt = 1; attempt <= LOCK_RETRY_ATTEMPTS; attempt++) {
       try {
-        const db = await openReadOnlyDatabase(dbPath);
+        const db = options.allowRecovery === false
+          ? await openReadOnlyDatabaseNonRecovering(dbPath)
+          : await openReadOnlyDatabase(dbPath);
         shared = { db, refCount: 0, ftsLoaded: false };
         dbCache.set(dbPath, shared);
         break;
@@ -648,6 +751,7 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
         lastError = err instanceof Error ? err : new Error(String(err));
 
         if (isWalCorruptionError(lastError)) {
+          if (options.allowRecovery === false) throw lastError;
           try {
             const db = await tryQuarantineAndReopen(dbPath, repoId);
             shared = { db, refCount: 0, ftsLoaded: false };
@@ -702,18 +806,11 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
     preWarmActive = false;
   }
 
-  // Load FTS extension once per shared Database.
-  // Done BEFORE pool registration so no concurrent checkout can grab
-  // the connection while the async FTS load is in progress.
-  // policy: 'load-only' — the read pool must never trigger a network
-  // install; analyze owns extension installation. If LOAD fails, search
-  // features degrade gracefully and the user-facing query path proceeds.
-  if (!shared.ftsLoaded) {
-    shared.ftsLoaded = await loadFTSExtension(available[0], { policy: 'load-only' });
-  }
+  const capabilities = await preparePoolConnections(available);
+  shared.ftsLoaded = capabilities.fts;
 
-  // Register pool entry only after all connections are pre-warmed and FTS is
-  // loaded.  Concurrent executeQuery calls see either "not initialized"
+  // Register pool entry only after all connections are pre-warmed and optional
+  // extensions are prepared. Concurrent executeQuery calls see either "not initialized"
   // (and throw cleanly) or a fully ready pool — never a half-built one.
   pool.set(repoId, {
     db,
@@ -723,6 +820,7 @@ async function doInitLbug(repoId: string, dbPath: string): Promise<void> {
     lastUsed: Date.now(),
     dbPath,
     closed: false,
+    capabilities,
   });
   ensureIdleTimer();
   traceRss('init', repoId);
@@ -771,12 +869,8 @@ export async function initLbugWithDb(
     preWarmActive = false;
   }
 
-  // Load FTS extension if not already loaded on this Database.
-  // policy: 'load-only' — same contract as initLbug above; the read pool
-  // must not block on a network install during query execution.
-  if (!shared.ftsLoaded) {
-    shared.ftsLoaded = await loadFTSExtension(available[0], { policy: 'load-only' });
-  }
+  const capabilities = await preparePoolConnections(available);
+  shared.ftsLoaded = capabilities.fts;
 
   pool.set(repoId, {
     db: existingDb,
@@ -786,6 +880,7 @@ export async function initLbugWithDb(
     lastUsed: Date.now(),
     dbPath,
     closed: false,
+    capabilities,
   });
   ensureIdleTimer();
   traceRss('init', repoId);
@@ -878,6 +973,34 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
 
 export const executeQuery = async (repoId: string, cypher: string): Promise<any[]> => {
   return await executeParameterized(repoId, cypher, {});
+};
+
+/** Return the aggregate, all-connections capability state for a ready pool. */
+export const getPoolCapabilities = (repoId: string): PoolCapabilities | null => {
+  const capabilities = pool.get(repoId)?.capabilities;
+  return capabilities ? { ...capabilities } : null;
+};
+
+/**
+ * Exercise every pre-warmed connection concurrently. Since checkout occurs
+ * before each query yields, the fan-out reserves all eight distinct pool
+ * connections before any can be returned.
+ */
+export const probePoolConnections = async (repoId: string): Promise<number> => {
+  const entry = pool.get(repoId);
+  if (!entry) {
+    throw new Error(`LadybugDB not initialized for repo "${repoId}". Call initLbug first.`);
+  }
+
+  const probes = await Promise.all(
+    Array.from({ length: entry.capabilities.connectionCount }, () =>
+      executeQuery(repoId, 'RETURN 1 AS ok'),
+    ),
+  );
+  if (probes.some((rows) => rows.length === 0)) {
+    throw new Error('LadybugDB pool probe returned no rows.');
+  }
+  return probes.length;
 };
 
 /**

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -692,12 +692,24 @@ async function preparePoolConnections(connections: lbug.Connection[]): Promise<P
   // but some LadybugDB builds are not safe to initialize extensions in parallel.
   for (const connection of connections) {
     try {
-      if (!(await loadFTSExtension(connection, { policy: 'load-only' }))) fts = false;
+      if (
+        !(await loadFTSExtension(connection, {
+          policy: 'load-only',
+          warn: poolSidecarLogger.warn,
+        }))
+      )
+        fts = false;
     } catch {
       fts = false;
     }
     try {
-      if (!(await loadVectorExtension(connection, { policy: 'load-only' }))) vector = false;
+      if (
+        !(await loadVectorExtension(connection, {
+          policy: 'load-only',
+          warn: poolSidecarLogger.warn,
+        }))
+      )
+        vector = false;
     } catch {
       vector = false;
     }

--- a/gitnexus/src/core/lbug/pool-adapter.ts
+++ b/gitnexus/src/core/lbug/pool-adapter.ts
@@ -17,11 +17,7 @@
 
 import fs from 'fs/promises';
 import lbug from '@ladybugdb/core';
-import {
-  isReadOnlyDbError,
-  loadFTSExtension,
-  loadVectorExtension,
-} from './lbug-adapter.js';
+import { isReadOnlyDbError, loadFTSExtension, loadVectorExtension } from './lbug-adapter.js';
 import { closeQueryResults } from './query-result-utils.js';
 import {
   createLbugDatabase,
@@ -688,9 +684,7 @@ export const initLbugNonRecovering = async (repoId: string, dbPath: string): Pro
  * A partial load disables that capability for the whole pool while preserving
  * graph queries; callers must never assume a capability from one lucky slot.
  */
-async function preparePoolConnections(
-  connections: lbug.Connection[],
-): Promise<PoolCapabilities> {
+async function preparePoolConnections(connections: lbug.Connection[]): Promise<PoolCapabilities> {
   let fts = true;
   let vector = true;
 
@@ -741,9 +735,10 @@ async function doInitLbug(
     let lastError: Error | null = null;
     for (let attempt = 1; attempt <= LOCK_RETRY_ATTEMPTS; attempt++) {
       try {
-        const db = options.allowRecovery === false
-          ? await openReadOnlyDatabaseNonRecovering(dbPath)
-          : await openReadOnlyDatabase(dbPath);
+        const db =
+          options.allowRecovery === false
+            ? await openReadOnlyDatabaseNonRecovering(dbPath)
+            : await openReadOnlyDatabase(dbPath);
         shared = { db, refCount: 0, ftsLoaded: false };
         dbCache.set(dbPath, shared);
         break;

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1933,12 +1933,7 @@ export class LocalBackend {
       ),
       timer.time(
         'vector',
-        this.semanticSearch(
-          repo,
-          searchQuery,
-          searchLimit,
-          poolCapabilities?.vector !== false,
-        ),
+        this.semanticSearch(repo, searchQuery, searchLimit, poolCapabilities?.vector !== false),
       ),
     ]);
 

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -428,7 +428,7 @@ interface SemanticSearchOutcome {
   results: any[];
   mode: SemanticRetrievalMode;
   embeddingCount: number | null;
-  reason: string;
+  reason: string | null;
   exactScanLimit: number;
   /** True when semantic matches may exist but could not safely be returned. */
   omitted: boolean;
@@ -2337,7 +2337,7 @@ export class LocalBackend {
       definitions: definitions.slice(0, 20), // cap standalone definitions
       timing,
       retrieval: {
-        keyword_mode: ftsUsed ? 'bm25' : 'unavailable',
+        keyword_mode: ftsUsed ? 'fts' : 'unavailable',
         semantic_mode: semanticSearchResult.mode,
         embedding_count: semanticSearchResult.embeddingCount,
         semantic_reason: semanticSearchResult.reason,
@@ -2661,7 +2661,7 @@ export class LocalBackend {
         });
         vectorIndexSucceeded = true;
         semanticMode = 'vector-index';
-        semanticReason = 'vector-index-query-succeeded';
+        semanticReason = null;
       } catch (error) {
         if (!this.warnedVectorQueryFailure) {
           this.warnedVectorQueryFailure = true;

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -15,6 +15,7 @@ import {
   executeParameterized,
   closeLbug,
   isLbugReady,
+  getPoolCapabilities,
 } from '../../core/lbug/pool-adapter.js';
 import { isValidQueryParams } from '../../core/lbug/query-params.js';
 import { toDisplayLine } from './line-display.js';
@@ -419,6 +420,18 @@ function isBenignMissingTableError(err: unknown): boolean {
   return /does not exist|no such (table|label|rel)|unknown (table|label)|(table|label|rel|column|property)[^\n]*\bnot (defined|found)\b/i.test(
     msg,
   );
+}
+
+type SemanticRetrievalMode = 'vector-index' | 'exact-scan' | 'not-indexed' | 'unavailable';
+
+interface SemanticSearchOutcome {
+  results: any[];
+  mode: SemanticRetrievalMode;
+  embeddingCount: number | null;
+  reason: string;
+  exactScanLimit: number;
+  /** True when semantic matches may exist but could not safely be returned. */
+  omitted: boolean;
 }
 
 const isReadOnlyDbError = (err: unknown): boolean => {
@@ -1910,9 +1923,23 @@ export class LocalBackend {
     // each so both get independent wall-time records without fighting
     // over a single `current` phase slot.
     const searchLimit = processLimit * maxSymbolsPerProcess; // fetch enough raw results
-    const [bm25SearchResult, semanticResults] = await Promise.all([
-      timer.time('bm25', this.bm25Search(repo, searchQuery, searchLimit)),
-      timer.time('vector', this.semanticSearch(repo, searchQuery, searchLimit)),
+    const poolCapabilities = getPoolCapabilities(repo.lbugPath);
+    const [bm25SearchResult, semanticSearchResult] = await Promise.all([
+      timer.time(
+        'bm25',
+        poolCapabilities?.fts === false
+          ? Promise.resolve({ results: [], ftsUsed: false })
+          : this.bm25Search(repo, searchQuery, searchLimit),
+      ),
+      timer.time(
+        'vector',
+        this.semanticSearch(
+          repo,
+          searchQuery,
+          searchLimit,
+          poolCapabilities?.vector !== false,
+        ),
+      ),
     ]);
 
     // Guard against undefined results (#1489) — when FTS is entirely
@@ -1936,7 +1963,7 @@ export class LocalBackend {
       }
     }
 
-    const safeSemanticResults = semanticResults ?? [];
+    const safeSemanticResults = semanticSearchResult.results;
     for (let i = 0; i < safeSemanticResults.length; i++) {
       const result = safeSemanticResults[i];
       const key = result.nodeId || result.filePath;
@@ -2295,6 +2322,13 @@ export class LocalBackend {
         'Symbol enrichment partially failed — some process/cohesion/content data may be missing from these results (see server logs).',
       );
     }
+    if (semanticSearchResult.omitted) {
+      warnings.push(
+        ftsUsed
+          ? `Semantic results were omitted; this response is BM25-only (semantic_reason: ${semanticSearchResult.reason}).`
+          : `Semantic results were omitted and BM25 is unavailable (semantic_reason: ${semanticSearchResult.reason}).`,
+      );
+    }
     if (rerankWarning) warnings.push(rerankWarning);
 
     return {
@@ -2302,8 +2336,15 @@ export class LocalBackend {
       process_symbols: dedupedSymbols,
       definitions: definitions.slice(0, 20), // cap standalone definitions
       timing,
+      retrieval: {
+        keyword_mode: ftsUsed ? 'bm25' : 'unavailable',
+        semantic_mode: semanticSearchResult.mode,
+        embedding_count: semanticSearchResult.embeddingCount,
+        semantic_reason: semanticSearchResult.reason,
+        exact_scan_limit: semanticSearchResult.exactScanLimit,
+      },
       ...(warnings.length > 0 && { warning: warnings.join(' ') }),
-      ...(enrichmentDegraded && { partial: true }),
+      ...((enrichmentDegraded || semanticSearchResult.omitted) && { partial: true }),
     };
   }
 
@@ -2506,29 +2547,99 @@ export class LocalBackend {
   /**
    * Semantic vector search helper
    */
-  private async semanticSearch(repo: RepoHandle, query: string, limit: number): Promise<any[]> {
+  private async semanticSearch(
+    repo: RepoHandle,
+    query: string,
+    limit: number,
+    vectorPoolAvailable = true,
+  ): Promise<SemanticSearchOutcome> {
+    const exactScanLimit = getExactScanLimit();
+    let embeddingCount: number;
+
     try {
       // Check if embedding table exists before loading the model (avoids heavy model init when embeddings are off)
       const tableCheck = await executeQuery(
         repo.lbugPath,
         `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN COUNT(*) AS cnt LIMIT 1`,
       );
-      if (!tableCheck.length || (tableCheck[0].cnt ?? tableCheck[0][0]) === 0) return [];
+      embeddingCount = Number(tableCheck?.[0]?.cnt ?? tableCheck?.[0]?.[0] ?? 0);
+      if (!Number.isFinite(embeddingCount) || embeddingCount <= 0) {
+        return {
+          results: [],
+          mode: 'not-indexed',
+          embeddingCount: 0,
+          reason: 'no-embeddings-indexed',
+          exactScanLimit,
+          omitted: false,
+        };
+      }
+    } catch (err) {
+      if (isBenignMissingTableError(err)) {
+        return {
+          results: [],
+          mode: 'not-indexed',
+          embeddingCount: 0,
+          reason: 'no-embeddings-indexed',
+          exactScanLimit,
+          omitted: false,
+        };
+      }
+      logQueryError('query:embedding-index-check', err);
+      return {
+        results: [],
+        mode: 'unavailable',
+        embeddingCount: null,
+        reason: 'embedding-index-check-failed',
+        exactScanLimit,
+        omitted: true,
+      };
+    }
 
+    let queryVec: number[];
+    let dims: number;
+    try {
       const { embedQuery, getEmbeddingDims } = await import('../core/embedder.js');
-      const queryVec = await embedQuery(query);
-      const dims = getEmbeddingDims();
-      const queryVecStr = `[${queryVec.join(',')}]`;
-      const maxDistance = getVectorMaxDistance(DEFAULT_MCP_VECTOR_MAX_DISTANCE);
+      queryVec = await embedQuery(query);
+      dims = getEmbeddingDims();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '';
+      if (
+        !this.warnedMissingEmbeddingStack &&
+        (isMissingLocalEmbeddingStackMessage(message) ||
+          isLocalEmbeddingRuntimeBlockerMessage(message))
+      ) {
+        this.warnedMissingEmbeddingStack = true;
+        logger.warn(`GitNexus [query:vector]: ${message}`);
+      } else {
+        logQueryError('query:embedding-query', err);
+      }
+      return {
+        results: [],
+        mode: 'unavailable',
+        embeddingCount,
+        reason: 'embedding-query-failed',
+        exactScanLimit,
+        omitted: true,
+      };
+    }
 
-      let bestChunks = new Map<
-        string,
-        { distance: number; chunkIndex: number; startLine: number; endLine: number }
-      >();
-      if (isVectorExtensionSupportedByPlatform()) {
-        try {
-          bestChunks = await collectBestChunks(limit, async (fetchLimit) => {
-            const vectorQuery = `
+    const queryVecStr = `[${queryVec.join(',')}]`;
+    const maxDistance = getVectorMaxDistance(DEFAULT_MCP_VECTOR_MAX_DISTANCE);
+
+    let bestChunks = new Map<
+      string,
+      { distance: number; chunkIndex: number; startLine: number; endLine: number }
+    >();
+    let semanticMode: SemanticRetrievalMode = 'unavailable';
+    let semanticReason = vectorPoolAvailable
+      ? 'vector-extension-unsupported'
+      : 'vector-extension-unavailable';
+    let vectorIndexSucceeded = false;
+
+    if (vectorPoolAvailable && isVectorExtensionSupportedByPlatform()) {
+      try {
+        bestChunks = await collectBestChunks(limit, async (fetchLimit) => {
+          const vectorQuery = `
             CALL QUERY_VECTOR_INDEX('${EMBEDDING_TABLE_NAME}', '${EMBEDDING_INDEX_NAME}',
               CAST(${queryVecStr} AS FLOAT[${dims}]), ${fetchLimit})
             YIELD node AS emb, distance
@@ -2539,49 +2650,61 @@ export class LocalBackend {
             ORDER BY distance
           `;
 
-            const embResults = await executeQuery(repo.lbugPath, vectorQuery);
-            return embResults.map((row) => ({
-              nodeId: row.nodeId ?? row[0],
-              chunkIndex: row.chunkIndex ?? row[1] ?? 0,
-              startLine: row.startLine ?? row[2] ?? 0,
-              endLine: row.endLine ?? row[3] ?? 0,
-              distance: row.distance ?? row[4],
-            }));
-          });
-        } catch (error) {
-          bestChunks = new Map();
-          if (!this.warnedVectorQueryFailure) {
-            this.warnedVectorQueryFailure = true;
-            logger.warn(
-              { err: error },
-              'GitNexus [query:vector]: VECTOR index query failed; using exact scan fallback',
-            );
-          }
+          const embResults = await executeQuery(repo.lbugPath, vectorQuery);
+          return embResults.map((row) => ({
+            nodeId: row.nodeId ?? row[0],
+            chunkIndex: row.chunkIndex ?? row[1] ?? 0,
+            startLine: row.startLine ?? row[2] ?? 0,
+            endLine: row.endLine ?? row[3] ?? 0,
+            distance: row.distance ?? row[4],
+          }));
+        });
+        vectorIndexSucceeded = true;
+        semanticMode = 'vector-index';
+        semanticReason = 'vector-index-query-succeeded';
+      } catch (error) {
+        if (!this.warnedVectorQueryFailure) {
+          this.warnedVectorQueryFailure = true;
+          logger.warn(
+            { err: error },
+            'GitNexus [query:vector]: VECTOR index query failed; using exact scan fallback',
+          );
         }
-      } else if (!this.warnedVectorUnsupported) {
-        // Rare diagnostic: surface why we fell back to the exact scan path so
-        // operators can see at a glance that VECTOR is disabled by platform
-        // policy. Emitted once per `LocalBackend` instance lifetime to avoid
-        // noisy stderr on hot semantic-search paths (DoD §2.8).
-        this.warnedVectorUnsupported = true;
-        logger.warn(
-          'GitNexus [query:vector]: VECTOR extension not supported on this platform; using exact scan fallback',
-        );
+        semanticReason = 'vector-index-query-failed';
+      }
+    } else if (!this.warnedVectorUnsupported) {
+      // Emit the connection/platform diagnosis once to stderr. MCP receives
+      // only the stable reason code below, never the native LOAD error.
+      this.warnedVectorUnsupported = true;
+      logger.warn(
+        vectorPoolAvailable
+          ? 'GitNexus [query:vector]: VECTOR extension not supported on this platform; using exact scan fallback'
+          : 'GitNexus [query:vector]: VECTOR extension unavailable across the read pool; using exact scan fallback',
+      );
+    }
+
+    // A successful HNSW query with zero matches is authoritative: it must not
+    // trigger an exact scan. Fallback is reserved for an unavailable/failed
+    // vector path, and remains bounded by the existing safety limit.
+    if (!vectorIndexSucceeded) {
+      if (embeddingCount > exactScanLimit) {
+        if (!this.warnedExactScanLimit) {
+          this.warnedExactScanLimit = true;
+          logger.warn(
+            `GitNexus [query:vector]: exact scan refused; ${embeddingCount} chunks exceed the configured safety limit of ${exactScanLimit}. Restore the VECTOR index or deliberately raise GITNEXUS_SEMANTIC_EXACT_SCAN_LIMIT after reviewing memory cost.`,
+          );
+        }
+        return {
+          results: [],
+          mode: 'unavailable',
+          embeddingCount,
+          reason: 'exact-scan-limit-exceeded',
+          exactScanLimit,
+          omitted: true,
+        };
       }
 
-      if (bestChunks.size === 0) {
-        const embeddingCount = Number(tableCheck[0].cnt ?? tableCheck[0][0] ?? 0);
-        const exactLimit = getExactScanLimit();
-        if (embeddingCount > exactLimit) {
-          if (!this.warnedExactScanLimit) {
-            this.warnedExactScanLimit = true;
-            logger.warn(
-              `GitNexus [query:vector]: exact scan refused; ${embeddingCount} chunks exceed the configured safety limit of ${exactLimit}. Restore the VECTOR index or deliberately raise GITNEXUS_SEMANTIC_EXACT_SCAN_LIMIT after reviewing memory cost.`,
-            );
-          }
-          return [];
-        }
-
+      try {
         const rows = await executeQuery(
           repo.lbugPath,
           `
@@ -2608,60 +2731,70 @@ export class LocalBackend {
             },
           ]),
         );
+        semanticMode = 'exact-scan';
+      } catch (err) {
+        logQueryError('query:vector-exact-scan', err);
+        return {
+          results: [],
+          mode: 'unavailable',
+          embeddingCount,
+          reason: 'exact-scan-query-failed',
+          exactScanLimit,
+          omitted: true,
+        };
       }
-
-      if (bestChunks.size === 0) return [];
-
-      const results: any[] = [];
-
-      for (const [nodeId, chunk] of Array.from(bestChunks.entries()).slice(0, limit)) {
-        const labelEndIdx = nodeId.indexOf(':');
-        const label = labelEndIdx > 0 ? nodeId.substring(0, labelEndIdx) : 'Unknown';
-
-        // Validate label against known node types to prevent Cypher injection
-        if (!VALID_NODE_LABELS.has(label)) continue;
-
-        try {
-          const nodeQuery =
-            label === 'File'
-              ? `MATCH (n:File {id: $nodeId}) RETURN n.name AS name, n.filePath AS filePath`
-              : `MATCH (n:\`${label}\` {id: $nodeId}) RETURN n.name AS name, n.filePath AS filePath`;
-
-          const nodeRows = await executeParameterized(repo.lbugPath, nodeQuery, { nodeId });
-          if (nodeRows.length > 0) {
-            const nodeRow = nodeRows[0];
-            results.push({
-              nodeId,
-              name: nodeRow.name ?? nodeRow[0] ?? '',
-              type: label,
-              filePath: nodeRow.filePath ?? nodeRow[1] ?? '',
-              distance: chunk.distance,
-              startLine: chunk.startLine,
-              endLine: chunk.endLine,
-            });
-          }
-        } catch {}
-      }
-
-      return results;
-    } catch (err) {
-      // Embeddings disabled is the common, silent case. But a pruned or
-      // Node-unloadable optional stack (#2370/#2372) also lands here — surface it
-      // once so semantic search doesn't silently degrade to BM25 with no hint
-      // (the exact silent-degradation mode #2370 exists to fix). Emitted once per
-      // LocalBackend instance to keep stderr quiet on hot paths (like the VECTOR
-      // fallback above). All other errors stay silent, as before.
-      const message = err instanceof Error ? err.message : '';
-      if (
-        !this.warnedMissingEmbeddingStack &&
-        (isMissingLocalEmbeddingStackMessage(message) ||
-          isLocalEmbeddingRuntimeBlockerMessage(message))
-      ) {
-        this.warnedMissingEmbeddingStack = true;
-        logger.warn(`GitNexus [query:vector]: ${message}`);
-      }
-      return [];
     }
+
+    if (bestChunks.size === 0) {
+      return {
+        results: [],
+        mode: semanticMode,
+        embeddingCount,
+        reason: semanticReason,
+        exactScanLimit,
+        omitted: false,
+      };
+    }
+
+    const results: any[] = [];
+
+    for (const [nodeId, chunk] of Array.from(bestChunks.entries()).slice(0, limit)) {
+      const labelEndIdx = nodeId.indexOf(':');
+      const label = labelEndIdx > 0 ? nodeId.substring(0, labelEndIdx) : 'Unknown';
+
+      // Validate label against known node types to prevent Cypher injection
+      if (!VALID_NODE_LABELS.has(label)) continue;
+
+      try {
+        const nodeQuery =
+          label === 'File'
+            ? `MATCH (n:File {id: $nodeId}) RETURN n.name AS name, n.filePath AS filePath`
+            : `MATCH (n:\`${label}\` {id: $nodeId}) RETURN n.name AS name, n.filePath AS filePath`;
+
+        const nodeRows = await executeParameterized(repo.lbugPath, nodeQuery, { nodeId });
+        if (nodeRows.length > 0) {
+          const nodeRow = nodeRows[0];
+          results.push({
+            nodeId,
+            name: nodeRow.name ?? nodeRow[0] ?? '',
+            type: label,
+            filePath: nodeRow.filePath ?? nodeRow[1] ?? '',
+            distance: chunk.distance,
+            startLine: chunk.startLine,
+            endLine: chunk.endLine,
+          });
+        }
+      } catch {}
+    }
+
+    return {
+      results,
+      mode: semanticMode,
+      embeddingCount,
+      reason: semanticReason,
+      exactScanLimit,
+      omitted: false,
+    };
   }
 
   async executeCypher(

--- a/gitnexus/test/integration/lbug-vector-extension.test.ts
+++ b/gitnexus/test/integration/lbug-vector-extension.test.ts
@@ -87,9 +87,8 @@ withTestLbugDB(
       'runs a real HNSW query successfully on all eight pooled connections',
       async () => {
         const poolAdapter = await import('../../src/core/lbug/pool-adapter.js');
-        const { EMBEDDING_DIMS, EMBEDDING_INDEX_NAME, EMBEDDING_TABLE_NAME } = await import(
-          '../../src/core/lbug/schema.js'
-        );
+        const { EMBEDDING_DIMS, EMBEDDING_INDEX_NAME, EMBEDDING_TABLE_NAME } =
+          await import('../../src/core/lbug/schema.js');
         const queryVector = [1, ...new Array(EMBEDDING_DIMS - 1).fill(0)];
         const query = `
           CALL QUERY_VECTOR_INDEX('${EMBEDDING_TABLE_NAME}', '${EMBEDDING_INDEX_NAME}',
@@ -134,12 +133,10 @@ withTestLbugDB(
       if (process.platform === 'win32') return;
 
       const adapter = await import('../../src/core/lbug/lbug-adapter.js');
-      const { batchInsertEmbeddings } = await import(
-        '../../src/core/embeddings/embedding-pipeline.js'
-      );
-      const { resolveAnalyzeInstallPolicy } = await import(
-        '../../src/core/lbug/extension-loader.js'
-      );
+      const { batchInsertEmbeddings } =
+        await import('../../src/core/embeddings/embedding-pipeline.js');
+      const { resolveAnalyzeInstallPolicy } =
+        await import('../../src/core/lbug/extension-loader.js');
       const { EMBEDDING_DIMS } = await import('../../src/core/lbug/schema.js');
       const loaded = await adapter.loadVectorExtension(undefined, {
         policy: resolveAnalyzeInstallPolicy(),

--- a/gitnexus/test/integration/lbug-vector-extension.test.ts
+++ b/gitnexus/test/integration/lbug-vector-extension.test.ts
@@ -75,6 +75,102 @@ withTestLbugDB('vector-extension', (handle) => {
 });
 
 /**
+ * Regression for #131: extension LOAD is connection-local. The read pool must
+ * prepare VECTOR on all eight slots before publication, otherwise concurrent
+ * HNSW queries fail depending on which connection is checked out.
+ */
+const poolVectorNodeId = 'Function:src/vector-pool.ts:target:1';
+withTestLbugDB(
+  'vector-pool-all-connections',
+  (handle) => {
+    it.skipIf(process.platform === 'win32')(
+      'runs a real HNSW query successfully on all eight pooled connections',
+      async () => {
+        const poolAdapter = await import('../../src/core/lbug/pool-adapter.js');
+        const { EMBEDDING_DIMS, EMBEDDING_INDEX_NAME, EMBEDDING_TABLE_NAME } = await import(
+          '../../src/core/lbug/schema.js'
+        );
+        const queryVector = [1, ...new Array(EMBEDDING_DIMS - 1).fill(0)];
+        const query = `
+          CALL QUERY_VECTOR_INDEX('${EMBEDDING_TABLE_NAME}', '${EMBEDDING_INDEX_NAME}',
+            CAST([${queryVector.join(',')}] AS FLOAT[${EMBEDDING_DIMS}]), 1)
+          YIELD node AS emb, distance
+          RETURN emb.nodeId AS nodeId, distance
+        `;
+
+        expect(poolAdapter.getPoolCapabilities(handle.repoId)).toEqual({
+          fts: expect.any(Boolean),
+          vector: true,
+          connectionCount: 8,
+        });
+        const results = await Promise.all(
+          Array.from({ length: 8 }, () => poolAdapter.executeQuery(handle.repoId, query)),
+        );
+
+        expect(results).toHaveLength(8);
+        for (const rows of results) {
+          expect(rows[0]?.nodeId ?? rows[0]?.[0]).toBe(poolVectorNodeId);
+        }
+      },
+    );
+
+    it.skipIf(process.platform !== 'win32')(
+      'keeps graph queries available while VECTOR is disabled on Windows',
+      async () => {
+        const poolAdapter = await import('../../src/core/lbug/pool-adapter.js');
+
+        expect(poolAdapter.getPoolCapabilities(handle.repoId)).toEqual({
+          fts: expect.any(Boolean),
+          vector: false,
+          connectionCount: 8,
+        });
+        await expect(poolAdapter.probePoolConnections(handle.repoId)).resolves.toBe(8);
+      },
+    );
+  },
+  {
+    poolAdapter: true,
+    beforeFTS: async () => {
+      if (process.platform === 'win32') return;
+
+      const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+      const { batchInsertEmbeddings } = await import(
+        '../../src/core/embeddings/embedding-pipeline.js'
+      );
+      const { resolveAnalyzeInstallPolicy } = await import(
+        '../../src/core/lbug/extension-loader.js'
+      );
+      const { EMBEDDING_DIMS } = await import('../../src/core/lbug/schema.js');
+      const loaded = await adapter.loadVectorExtension(undefined, {
+        policy: resolveAnalyzeInstallPolicy(),
+      });
+      if (!loaded) {
+        throw new Error(
+          'VECTOR is required for the non-Windows eight-connection pool regression test',
+        );
+      }
+
+      await adapter.executeQuery(
+        `CREATE (:Function {id: '${poolVectorNodeId}', name: 'target', filePath: 'src/vector-pool.ts', startLine: 1, endLine: 3, isExported: true, content: '', description: ''})`,
+      );
+      await batchInsertEmbeddings(adapter.executeWithReusedStatement, [
+        {
+          nodeId: poolVectorNodeId,
+          chunkIndex: 0,
+          startLine: 1,
+          endLine: 3,
+          embedding: [1, ...new Array(EMBEDDING_DIMS - 1).fill(0)],
+        },
+      ]);
+      if (!(await adapter.createVectorIndex())) {
+        throw new Error('Failed to create the HNSW index for the eight-connection pool test');
+      }
+    },
+    timeout: 120_000,
+  },
+);
+
+/**
  * Regression: VECTOR/HNSW index creation during analyze (#2114).
  *
  * `CALL CREATE_VECTOR_INDEX(...)` compiles to multiple statements, which

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -24,6 +24,11 @@ const { lbugMocks, platformMocks } = vi.hoisted(() => ({
     executeParameterized: vi.fn().mockResolvedValue([]),
     closeLbug: vi.fn().mockResolvedValue(undefined),
     isLbugReady: vi.fn().mockReturnValue(true),
+    getPoolCapabilities: vi.fn().mockReturnValue({
+      fts: true,
+      vector: true,
+      connectionCount: 8,
+    }),
   },
   platformMocks: {
     isVectorExtensionSupportedByPlatform: vi.fn().mockReturnValue(true),
@@ -302,6 +307,11 @@ describe('LocalBackend.callTool', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     platformMocks.isVectorExtensionSupportedByPlatform.mockReturnValue(true);
+    lbugMocks.getPoolCapabilities.mockReturnValue({
+      fts: true,
+      vector: true,
+      connectionCount: 8,
+    });
     backend = new LocalBackend();
     setupSingleRepo();
     await backend.init();
@@ -649,6 +659,27 @@ describe('LocalBackend.callTool', () => {
     expect(result).not.toHaveProperty('warning');
   });
 
+  it('does not enter BM25 when FTS failed on one pool connection', async () => {
+    const { searchFTSFromLbug } = await import('../../src/core/search/bm25-index.js');
+    vi.mocked(searchFTSFromLbug).mockClear();
+    lbugMocks.getPoolCapabilities.mockReturnValue({
+      fts: false,
+      vector: true,
+      connectionCount: 8,
+    });
+    vi.mocked(executeQuery).mockResolvedValue([]);
+    vi.mocked(executeParameterized).mockResolvedValue([]);
+
+    const result = await backend.callTool('query', { query: 'auth' });
+
+    expect(searchFTSFromLbug).not.toHaveBeenCalled();
+    expect(result.retrieval).toMatchObject({
+      keyword_mode: 'unavailable',
+      semantic_mode: 'not-indexed',
+    });
+    expect(result.warning).toMatch(/repair-fts/i);
+  });
+
   it('does not crash when searchFTSFromLbug throws (#1489)', async () => {
     const { searchFTSFromLbug } = await import('../../src/core/search/bm25-index.js');
     vi.mocked(searchFTSFromLbug).mockRejectedValueOnce(new Error('bm25Results is not iterable'));
@@ -684,7 +715,7 @@ describe('LocalBackend.callTool', () => {
     (executeParameterized as any).mockResolvedValue([]);
 
     try {
-      await backend.callTool('query', { query: 'auth' });
+      const result = await backend.callTool('query', { query: 'auth' });
 
       const queries = (executeQuery as any).mock.calls.map(
         ([, cypher]: [string, string]) => cypher,
@@ -706,6 +737,12 @@ describe('LocalBackend.callTool', () => {
             ),
           ),
       ).toBe(true);
+      expect(result.retrieval).toMatchObject({
+        keyword_mode: 'bm25',
+        semantic_mode: 'exact-scan',
+        embedding_count: 1,
+        semantic_reason: 'vector-extension-unsupported',
+      });
     } finally {
       cap.restore();
     }
@@ -719,13 +756,48 @@ describe('LocalBackend.callTool', () => {
     });
     (executeParameterized as any).mockResolvedValue([]);
 
-    await backend.callTool('query', { query: 'auth' });
+    const result = await backend.callTool('query', { query: 'auth' });
 
     const queries = (executeQuery as any).mock.calls.map(([, cypher]: [string, string]) => cypher);
     expect(queries.some((cypher: string) => cypher.includes('QUERY_VECTOR_INDEX'))).toBe(true);
+    expect(
+      queries.some(
+        (cypher: string) =>
+          cypher.includes('RETURN e.nodeId AS nodeId') &&
+          cypher.includes('e.embedding AS embedding'),
+      ),
+    ).toBe(false);
     // The configured threshold must reach the WHERE clause (MCP default 0.6), guarding
     // against a regression that drops the filter or re-hardcodes a different value.
     expect(queries.some((cypher: string) => cypher.includes('distance < 0.6'))).toBe(true);
+    expect(result.retrieval).toMatchObject({
+      semantic_mode: 'vector-index',
+      embedding_count: 1,
+      semantic_reason: 'vector-index-query-succeeded',
+    });
+    expect(result).not.toHaveProperty('partial');
+  });
+
+  it('skips HNSW when VECTOR did not load on every pool connection', async () => {
+    lbugMocks.getPoolCapabilities.mockReturnValue({
+      fts: true,
+      vector: false,
+      connectionCount: 8,
+    });
+    (executeQuery as any).mockImplementation(async (_repoId: string, cypher: string) => {
+      if (cypher.includes('COUNT(*) AS cnt')) return [{ cnt: 1 }];
+      return [];
+    });
+    (executeParameterized as any).mockResolvedValue([]);
+
+    const result = await backend.callTool('query', { query: 'auth' });
+    const queries = (executeQuery as any).mock.calls.map(([, cypher]: [string, string]) => cypher);
+
+    expect(queries.some((cypher: string) => cypher.includes('QUERY_VECTOR_INDEX'))).toBe(false);
+    expect(result.retrieval).toMatchObject({
+      semantic_mode: 'exact-scan',
+      semantic_reason: 'vector-extension-unavailable',
+    });
   });
 
   it('warns once when VECTOR query failure falls back to exact scan', async () => {
@@ -739,13 +811,20 @@ describe('LocalBackend.callTool', () => {
     const cap = _captureLogger();
 
     try {
-      await backend.callTool('query', { query: 'auth' });
+      const first = await backend.callTool('query', { query: 'auth' });
       await backend.callTool('query', { query: 'auth' });
 
       const warnings = cap
         .records()
         .filter((record) => String(record.msg).includes('using exact scan fallback'));
       expect(warnings).toHaveLength(1);
+      expect(first.retrieval).toMatchObject({
+        semantic_mode: 'exact-scan',
+        embedding_count: 1,
+        semantic_reason: 'vector-index-query-failed',
+      });
+      expect(first).not.toHaveProperty('partial');
+      expect(JSON.stringify(first)).not.toContain('HNSW index unavailable');
     } finally {
       cap.restore();
     }
@@ -764,7 +843,7 @@ describe('LocalBackend.callTool', () => {
     const cap = _captureLogger();
 
     try {
-      await backend.callTool('query', { query: 'auth' });
+      const result = await backend.callTool('query', { query: 'auth' });
 
       expect(
         cap
@@ -779,6 +858,17 @@ describe('LocalBackend.callTool', () => {
       expect(queries.some((cypher: string) => cypher.includes('e.embedding AS embedding'))).toBe(
         false,
       );
+      expect(result).toMatchObject({
+        partial: true,
+        retrieval: {
+          semantic_mode: 'unavailable',
+          embedding_count: 2,
+          semantic_reason: 'exact-scan-limit-exceeded',
+          exact_scan_limit: 1,
+        },
+      });
+      expect(result.warning).toMatch(/BM25-only/);
+      expect(JSON.stringify(result)).not.toContain('HNSW index unavailable');
     } finally {
       cap.restore();
       if (previous === undefined) delete process.env.GITNEXUS_SEMANTIC_EXACT_SCAN_LIMIT;

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -738,7 +738,7 @@ describe('LocalBackend.callTool', () => {
           ),
       ).toBe(true);
       expect(result.retrieval).toMatchObject({
-        keyword_mode: 'bm25',
+        keyword_mode: 'fts',
         semantic_mode: 'exact-scan',
         embedding_count: 1,
         semantic_reason: 'vector-extension-unsupported',
@@ -773,7 +773,7 @@ describe('LocalBackend.callTool', () => {
     expect(result.retrieval).toMatchObject({
       semantic_mode: 'vector-index',
       embedding_count: 1,
-      semantic_reason: 'vector-index-query-succeeded',
+      semantic_reason: null,
     });
     expect(result).not.toHaveProperty('partial');
   });

--- a/gitnexus/test/unit/doctor-pool-probe.test.ts
+++ b/gitnexus/test/unit/doctor-pool-probe.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const poolMocks = vi.hoisted(() => ({
+  closeLbug: vi.fn().mockResolvedValue(undefined),
+  getPoolCapabilities: vi.fn(),
+  initLbugNonRecovering: vi.fn().mockResolvedValue(undefined),
+  probePoolConnections: vi.fn().mockResolvedValue(8),
+}));
+
+vi.mock('../../src/core/lbug/pool-adapter.js', () => poolMocks);
+
+const { probeDoctorPool } = await import('../../src/cli/doctor.js');
+
+describe('doctor real read-pool probe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    poolMocks.initLbugNonRecovering.mockResolvedValue(undefined);
+    poolMocks.probePoolConnections.mockResolvedValue(8);
+    poolMocks.getPoolCapabilities.mockReturnValue({
+      fts: true,
+      vector: true,
+      connectionCount: 8,
+    });
+  });
+
+  it('uses non-recovering initialization and exercises all eight connections', async () => {
+    const result = await probeDoctorPool('/repo/.gitnexus/lbug');
+
+    expect(poolMocks.initLbugNonRecovering).toHaveBeenCalledWith(
+      expect.stringMatching(/^doctor:/),
+      '/repo/.gitnexus/lbug',
+    );
+    expect(poolMocks.probePoolConnections).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      fts: true,
+      vector: true,
+      exercisedConnections: 8,
+      connectionCount: 8,
+      reason: null,
+    });
+    expect(poolMocks.closeLbug).toHaveBeenCalledOnce();
+  });
+
+  it('reports aggregate optional-extension failure without losing graph-pool evidence', async () => {
+    poolMocks.getPoolCapabilities.mockReturnValue({
+      fts: true,
+      vector: false,
+      connectionCount: 8,
+    });
+
+    await expect(probeDoctorPool('/repo/.gitnexus/lbug')).resolves.toMatchObject({
+      fts: true,
+      vector: false,
+      exercisedConnections: 8,
+      connectionCount: 8,
+    });
+  });
+
+  it('closes the diagnostic pool when non-recovering initialization fails', async () => {
+    poolMocks.initLbugNonRecovering.mockRejectedValue(new Error('WAL requires recovery'));
+
+    await expect(probeDoctorPool('/repo/.gitnexus/lbug')).resolves.toMatchObject({
+      fts: false,
+      vector: false,
+      exercisedConnections: 0,
+      reason: 'WAL requires recovery',
+    });
+    expect(poolMocks.probePoolConnections).not.toHaveBeenCalled();
+    expect(poolMocks.closeLbug).toHaveBeenCalledOnce();
+  });
+});

--- a/gitnexus/test/unit/group/sync-windowed-resolution.test.ts
+++ b/gitnexus/test/unit/group/sync-windowed-resolution.test.ts
@@ -122,6 +122,7 @@ vi.mock('@ladybugdb/core', () => ({
 vi.mock('../../../src/core/lbug/lbug-adapter.js', () => ({
   isReadOnlyDbError: vi.fn(() => false),
   loadFTSExtension: loadFTSExtensionMock,
+  loadVectorExtension: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('../../../src/core/lbug/lbug-config.js', () => ({

--- a/gitnexus/test/unit/lbug-pool-fts-load.test.ts
+++ b/gitnexus/test/unit/lbug-pool-fts-load.test.ts
@@ -37,13 +37,8 @@ vi.mock('../../src/core/lbug/lbug-config.js', () => ({
   WAL_RECOVERY_SUGGESTION: '',
 }));
 
-const {
-  closeLbug,
-  getPoolCapabilities,
-  initLbugWithDb,
-  isLbugReady,
-  probePoolConnections,
-} = await import('../../src/core/lbug/pool-adapter.js');
+const { closeLbug, getPoolCapabilities, initLbugWithDb, isLbugReady, probePoolConnections } =
+  await import('../../src/core/lbug/pool-adapter.js');
 
 describe('read-pool optional extension loading', () => {
   afterEach(async () => {

--- a/gitnexus/test/unit/lbug-pool-fts-load.test.ts
+++ b/gitnexus/test/unit/lbug-pool-fts-load.test.ts
@@ -63,9 +63,13 @@ describe('read-pool optional extension loading', () => {
 
     expect(loadFTSExtensionMock).toHaveBeenCalledTimes(8);
     expect(loadVectorExtensionMock).toHaveBeenCalledTimes(8);
-    expect(loadFTSExtensionMock).toHaveBeenCalledWith(expect.anything(), { policy: 'load-only' });
+    expect(loadFTSExtensionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ policy: 'load-only', warn: expect.any(Function) }),
+    );
     expect(loadVectorExtensionMock).toHaveBeenCalledWith(expect.anything(), {
       policy: 'load-only',
+      warn: expect.any(Function),
     });
     expect(getPoolCapabilities('repo-a')).toEqual({
       fts: true,

--- a/gitnexus/test/unit/lbug-pool-fts-load.test.ts
+++ b/gitnexus/test/unit/lbug-pool-fts-load.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { loadFTSExtensionMock } = vi.hoisted(() => ({
+const { connections, loadFTSExtensionMock, loadVectorExtensionMock } = vi.hoisted(() => ({
+  connections: [] as any[],
   loadFTSExtensionMock: vi.fn(),
+  loadVectorExtensionMock: vi.fn(),
 }));
 
 vi.mock('@ladybugdb/core', () => ({
@@ -9,6 +11,15 @@ vi.mock('@ladybugdb/core', () => ({
     Database: vi.fn(),
     Connection: vi.fn(function (this: any) {
       this.close = vi.fn().mockResolvedValue(undefined);
+      this.prepare = vi.fn().mockResolvedValue({
+        isSuccess: () => true,
+        getErrorMessage: vi.fn().mockResolvedValue(''),
+      });
+      this.execute = vi.fn().mockResolvedValue({
+        getAll: vi.fn().mockResolvedValue([{ ok: 1 }]),
+        close: vi.fn(),
+      });
+      connections.push(this);
     }),
   },
 }));
@@ -16,6 +27,7 @@ vi.mock('@ladybugdb/core', () => ({
 vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
   isReadOnlyDbError: vi.fn(() => false),
   loadFTSExtension: loadFTSExtensionMock,
+  loadVectorExtension: loadVectorExtensionMock,
 }));
 
 vi.mock('../../src/core/lbug/lbug-config.js', () => ({
@@ -25,38 +37,102 @@ vi.mock('../../src/core/lbug/lbug-config.js', () => ({
   WAL_RECOVERY_SUGGESTION: '',
 }));
 
-const { closeLbug, initLbugWithDb } = await import('../../src/core/lbug/pool-adapter.js');
+const {
+  closeLbug,
+  getPoolCapabilities,
+  initLbugWithDb,
+  isLbugReady,
+  probePoolConnections,
+} = await import('../../src/core/lbug/pool-adapter.js');
 
-describe('read-pool FTS loading', () => {
+describe('read-pool optional extension loading', () => {
   afterEach(async () => {
     await closeLbug().catch(() => {});
     loadFTSExtensionMock.mockReset();
+    loadVectorExtensionMock.mockReset();
+    connections.length = 0;
   });
 
-  it('loads FTS with load-only policy and caches a successful load', async () => {
-    loadFTSExtensionMock.mockResolvedValue(true);
+  it('loads FTS and VECTOR with load-only policy on all eight connections', async () => {
+    loadFTSExtensionMock.mockImplementation(async () => {
+      expect(isLbugReady('repo-a')).toBe(false);
+      return true;
+    });
+    loadVectorExtensionMock.mockImplementation(async () => {
+      expect(isLbugReady('repo-a')).toBe(false);
+      return true;
+    });
     const db = {} as any;
 
-    await initLbugWithDb('repo-a', db, '/tmp/shared-fts-db');
-    await initLbugWithDb('repo-b', db, '/tmp/shared-fts-db');
+    await initLbugWithDb('repo-a', db, '/tmp/pool-extension-success-db');
 
-    expect(loadFTSExtensionMock).toHaveBeenCalledTimes(1);
+    expect(loadFTSExtensionMock).toHaveBeenCalledTimes(8);
+    expect(loadVectorExtensionMock).toHaveBeenCalledTimes(8);
     expect(loadFTSExtensionMock).toHaveBeenCalledWith(expect.anything(), { policy: 'load-only' });
-  });
-
-  it('does not fake a successful load when FTS is unavailable', async () => {
-    loadFTSExtensionMock.mockResolvedValue(false);
-    const db = {} as any;
-
-    await initLbugWithDb('repo-a', db, '/tmp/shared-fts-db');
-    await initLbugWithDb('repo-b', db, '/tmp/shared-fts-db');
-
-    expect(loadFTSExtensionMock).toHaveBeenCalledTimes(2);
-    expect(loadFTSExtensionMock).toHaveBeenNthCalledWith(1, expect.anything(), {
+    expect(loadVectorExtensionMock).toHaveBeenCalledWith(expect.anything(), {
       policy: 'load-only',
     });
-    expect(loadFTSExtensionMock).toHaveBeenNthCalledWith(2, expect.anything(), {
-      policy: 'load-only',
+    expect(getPoolCapabilities('repo-a')).toEqual({
+      fts: true,
+      vector: true,
+      connectionCount: 8,
+    });
+    await expect(probePoolConnections('repo-a')).resolves.toBe(8);
+    expect(connections).toHaveLength(8);
+    expect(connections.every((connection) => connection.prepare.mock.calls.length === 1)).toBe(
+      true,
+    );
+  });
+
+  it('keeps graph ready but disables a capability when one connection fails to load it', async () => {
+    loadFTSExtensionMock.mockResolvedValue(true);
+    loadFTSExtensionMock.mockResolvedValueOnce(false);
+    loadVectorExtensionMock.mockResolvedValue(true);
+    const db = {} as any;
+
+    await initLbugWithDb('repo-partial', db, '/tmp/pool-extension-partial-db');
+
+    expect(loadFTSExtensionMock).toHaveBeenCalledTimes(8);
+    expect(loadVectorExtensionMock).toHaveBeenCalledTimes(8);
+    expect(isLbugReady('repo-partial')).toBe(true);
+    expect(getPoolCapabilities('repo-partial')).toEqual({
+      fts: false,
+      vector: true,
+      connectionCount: 8,
+    });
+  });
+
+  it('disables VECTOR for the pool when only one connection lacks it', async () => {
+    loadFTSExtensionMock.mockResolvedValue(true);
+    loadVectorExtensionMock.mockResolvedValue(true);
+    loadVectorExtensionMock.mockResolvedValueOnce(false);
+
+    await initLbugWithDb('repo-vector-partial', {} as any, '/tmp/pool-vector-partial-db');
+
+    expect(loadFTSExtensionMock).toHaveBeenCalledTimes(8);
+    expect(loadVectorExtensionMock).toHaveBeenCalledTimes(8);
+    expect(isLbugReady('repo-vector-partial')).toBe(true);
+    expect(getPoolCapabilities('repo-vector-partial')).toEqual({
+      fts: true,
+      vector: false,
+      connectionCount: 8,
+    });
+  });
+
+  it('prepares every connection for each alias sharing a Database', async () => {
+    loadFTSExtensionMock.mockResolvedValue(true);
+    loadVectorExtensionMock.mockResolvedValue(true);
+    const db = {} as any;
+
+    await initLbugWithDb('repo-alias-a', db, '/tmp/pool-extension-alias-db');
+    await initLbugWithDb('repo-alias-b', db, '/tmp/pool-extension-alias-db');
+
+    expect(loadFTSExtensionMock).toHaveBeenCalledTimes(16);
+    expect(loadVectorExtensionMock).toHaveBeenCalledTimes(16);
+    expect(getPoolCapabilities('repo-alias-a')).toMatchObject({ fts: true, vector: true });
+    expect(getPoolCapabilities('repo-alias-b')).toMatchObject({
+      fts: true,
+      vector: true,
     });
   });
 });

--- a/gitnexus/test/unit/lbug-pool-pinning.test.ts
+++ b/gitnexus/test/unit/lbug-pool-pinning.test.ts
@@ -36,6 +36,7 @@ vi.mock('@ladybugdb/core', () => ({
 vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
   isReadOnlyDbError: vi.fn(() => false),
   loadFTSExtension: loadFTSExtensionMock,
+  loadVectorExtension: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('../../src/core/lbug/lbug-config.js', () => ({

--- a/gitnexus/test/unit/local-backend-semantic-warn.test.ts
+++ b/gitnexus/test/unit/local-backend-semantic-warn.test.ts
@@ -47,6 +47,7 @@ const unavailableEmbeddingQuery = {
   mode: 'unavailable',
   embeddingCount: 5,
   reason: 'embedding-query-failed',
+  exactScanLimit: expect.any(Number),
   omitted: true,
 };
 

--- a/gitnexus/test/unit/local-backend-semantic-warn.test.ts
+++ b/gitnexus/test/unit/local-backend-semantic-warn.test.ts
@@ -23,11 +23,32 @@ vi.mock('../../src/mcp/core/embedder.js', () => ({
 
 import { LocalBackend } from '../../src/mcp/local/local-backend.js';
 
-interface SemanticSearchable {
-  semanticSearch(repo: { lbugPath: string }, query: string, limit: number): Promise<unknown[]>;
+interface SemanticSearchOutcome {
+  results: unknown[];
+  mode: string;
+  embeddingCount: number | null;
+  reason: string | null;
+  exactScanLimit: number;
+  omitted: boolean;
 }
-const callSemanticSearch = (b: LocalBackend): Promise<unknown[]> =>
+
+interface SemanticSearchable {
+  semanticSearch(
+    repo: { lbugPath: string },
+    query: string,
+    limit: number,
+  ): Promise<SemanticSearchOutcome>;
+}
+const callSemanticSearch = (b: LocalBackend): Promise<SemanticSearchOutcome> =>
   (b as unknown as SemanticSearchable).semanticSearch({ lbugPath: '/tmp/x' }, 'q', 5);
+
+const unavailableEmbeddingQuery = {
+  results: [],
+  mode: 'unavailable',
+  embeddingCount: 5,
+  reason: 'embedding-query-failed',
+  omitted: true,
+};
 
 const stackWarns = (cap: LoggerCapture): number =>
   cap
@@ -45,13 +66,13 @@ describe('LocalBackend.semanticSearch — missing-stack warning (#2372)', () => 
     embedQueryMock.mockReset();
   });
 
-  it('warns once with the actionable message and returns [] on a pruned stack', async () => {
+  it('warns once with the actionable message and reports omission on a pruned stack', async () => {
     embedQueryMock.mockRejectedValue(new Error(localEmbeddingStackMissingMessage()));
     const backend = new LocalBackend();
     const cap = _captureLogger();
     try {
-      expect(await callSemanticSearch(backend)).toEqual([]);
-      expect(await callSemanticSearch(backend)).toEqual([]);
+      expect(await callSemanticSearch(backend)).toMatchObject(unavailableEmbeddingQuery);
+      expect(await callSemanticSearch(backend)).toMatchObject(unavailableEmbeddingQuery);
       expect(stackWarns(cap)).toBe(1); // once per LocalBackend instance
     } finally {
       cap.restore();
@@ -63,7 +84,7 @@ describe('LocalBackend.semanticSearch — missing-stack warning (#2372)', () => 
     const backend = new LocalBackend();
     const cap = _captureLogger();
     try {
-      expect(await callSemanticSearch(backend)).toEqual([]);
+      expect(await callSemanticSearch(backend)).toMatchObject(unavailableEmbeddingQuery);
       expect(stackWarns(cap)).toBe(0);
     } finally {
       cap.restore();

--- a/gitnexus/test/unit/pool-wal-recovery.test.ts
+++ b/gitnexus/test/unit/pool-wal-recovery.test.ts
@@ -31,6 +31,7 @@ vi.mock('@ladybugdb/core', () => ({
 
 vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
   loadFTSExtension: vi.fn().mockResolvedValue(true),
+  loadVectorExtension: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('../../src/core/lbug/lbug-config.js', () => ({
@@ -135,6 +136,43 @@ describe('WAL corruption recovery in doInitLbug (#1402)', () => {
     expect(stderrWriteMock).toHaveBeenCalledWith(
       expect.stringContaining('WAL quarantined for test-repo-init'),
     );
+  });
+
+  it('does not quarantine or retry WAL corruption during a diagnostic init', async () => {
+    const { initLbugNonRecovering } = await import('../../src/core/lbug/pool-adapter.js');
+    const badDb = makeMockDb();
+    badDb.init = vi.fn().mockRejectedValueOnce(new Error('Corrupted wal file'));
+    (createLbugDatabase as any).mockReturnValueOnce(badDb);
+
+    await expect(
+      initLbugNonRecovering('doctor-nonrecovering', '/tmp/test-wal-recovery/doctor-lbug'),
+    ).rejects.toThrow(/corrupted wal/i);
+
+    expect(createLbugDatabase).toHaveBeenCalledTimes(1);
+    expect(fs.rename).not.toHaveBeenCalled();
+  });
+
+  it('does not open writable to replay shadow pages during a diagnostic init', async () => {
+    const { initLbugNonRecovering } = await import('../../src/core/lbug/pool-adapter.js');
+    const readOnlyDb = makeMockDb();
+    connectionQueryMock.mockRejectedValueOnce(
+      new Error(
+        "Runtime exception: Couldn't replay shadow pages under read-only mode. Please re-open the database with read-write mode to replay shadow pages.",
+      ),
+    );
+    (createLbugDatabase as any).mockReturnValueOnce(readOnlyDb);
+
+    await expect(
+      initLbugNonRecovering('doctor-no-replay', '/tmp/test-shadow-replay/doctor-lbug'),
+    ).rejects.toThrow(/replay shadow pages/i);
+
+    expect(createLbugDatabase).toHaveBeenCalledTimes(1);
+    expect(createLbugDatabase).toHaveBeenCalledWith(
+      expect.anything(),
+      '/tmp/test-shadow-replay/doctor-lbug',
+      expect.objectContaining({ readOnly: true }),
+    );
+    expect(fs.rename).not.toHaveBeenCalled();
   });
 
   it('replays shadow pages with a temporary writable open before pooling read-only DBs', async () => {

--- a/gitnexus/test/unit/query-degraded-signal.test.ts
+++ b/gitnexus/test/unit/query-degraded-signal.test.ts
@@ -69,7 +69,14 @@ function makeBackend(ftsUsed = true): LocalBackend {
     endLine: 2,
   };
   (backend as any).bm25Search = vi.fn().mockResolvedValue({ results: [sym], ftsUsed });
-  (backend as any).semanticSearch = vi.fn().mockResolvedValue([]);
+  (backend as any).semanticSearch = vi.fn().mockResolvedValue({
+    results: [],
+    mode: 'not-indexed',
+    embeddingCount: 0,
+    reason: 'no-embeddings-indexed',
+    exactScanLimit: 10_000,
+    omitted: false,
+  });
   return { backend, repoHandle } as any;
 }
 


### PR DESCRIPTION
## Outcome

Make semantic retrieval truthful and reliable across GitNexus's full eight-connection LadybugDB pool.

Closes #131. Part of #130 and a release dependency for #137.

## Changes

- Prewarm all eight pooled connections and load FTS and VECTOR with `load-only` before publishing the pool.
- Track aggregate live pool capability instead of trusting metadata or a single connection.
- Keep graph/keyword access available when extension loading is partial, while marking semantic retrieval unavailable with stable reason codes.
- Distinguish a successful zero-result HNSW query from a failed vector query.
- Add the additive retrieval response (`keyword_mode`, `semantic_mode`, `embedding_count`, `semantic_reason`, `exact_scan_limit`) and set `partial: true` plus a sanitized BM25-only warning whenever the semantic channel is omitted.
- Probe VECTOR through a non-recovering eight-connection diagnostic pool in `doctor`; metadata cannot override a failed live probe.

## Safety and proof boundaries

- The 20,000-row installed exact-scan gate remains bounded; this PR does not raise it.
- Raw native errors remain server-side. Agent-facing responses expose stable sanitized reason codes.
- This PR proves source behavior only. Release artifact, installed runtime, 85k/125k soak, fleet repair, and Codex/Claude proof remain separate gates.

## Validation

- TypeScript typecheck passed.
- 231 focused call-tool tests passed.
- 66 pool/VECTOR tests passed; one Windows-only case skipped as expected.
- Real LadybugDB HNSW smoke completed across eight concurrent pooled connections.
- Live doctor probe reported VECTOR on all eight connections.
- GitNexus `detect_changes`: low risk, two files in the acceptance delta, zero affected processes.
- Independent initial review and two delta-only passes found no P0/P1 or supported-path P2 blockers. The final delta proved the CI formatter commit behavior-equivalent.

## Rollback

Revert this PR before the `.3` release. The change does not mutate repository indexes or the local registry.

Closes #131
