### PR TITLE
feat(analyze): stage bounded resumable large-repo indexing

### DIFF
--- a/gitnexus/src/cli/analyze-resource-log.ts
+++ b/gitnexus/src/cli/analyze-resource-log.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { constants as fsConstants } from 'fs';
 import fs from 'fs/promises';
 import os from 'os';
 
@@ -44,7 +45,33 @@ export const createAnalyzeResourceLogger = async (
 
   const resolvedPath = path.resolve(filePath.trim());
   await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
-  const handle = await fs.open(resolvedPath, 'a', 0o600);
+  try {
+    const target = await fs.lstat(resolvedPath);
+    if (target.isSymbolicLink() || !target.isFile()) {
+      throw new Error('Analyze resource log target must be a regular, non-symlink file');
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+
+  const openFlags =
+    fsConstants.O_APPEND |
+    fsConstants.O_CREAT |
+    fsConstants.O_WRONLY |
+    fsConstants.O_NOFOLLOW |
+    fsConstants.O_NONBLOCK;
+  const handle = await fs.open(resolvedPath, openFlags, 0o600);
+  try {
+    const openedTarget = await handle.stat();
+    if (!openedTarget.isFile()) {
+      throw new Error('Analyze resource log target must be a regular file');
+    }
+    // The mode argument only applies on create; tighten pre-existing files too.
+    await handle.chmod(0o600);
+  } catch (error) {
+    await handle.close().catch(() => {});
+    throw error;
+  }
   let pending = Promise.resolve();
   let closed = false;
   let closing = false;

--- a/gitnexus/src/cli/analyze-resource-log.ts
+++ b/gitnexus/src/cli/analyze-resource-log.ts
@@ -1,0 +1,99 @@
+import path from 'path';
+import fs from 'fs/promises';
+import os from 'os';
+
+const RESOURCE_LOG_SCHEMA = 'gitnexus.analyze-resource/v1';
+const BYTES_PER_MIB = 1024 * 1024;
+const MAX_PHASE_LENGTH = 64;
+const PHASE_PATTERN = /^[a-z0-9._-]+$/u;
+
+export type AnalyzeResourceEvent = 'start' | 'progress' | 'signal' | 'complete' | 'error';
+
+export interface AnalyzeResourceLogger {
+  emit(event: AnalyzeResourceEvent, phase?: string, percent?: number): Promise<void>;
+  flush(): Promise<void>;
+  close(): Promise<void>;
+}
+
+const sanitizePhase = (phase: string | undefined): string | undefined => {
+  if (!phase) return undefined;
+  const normalized = phase.trim().toLowerCase();
+  if (!PHASE_PATTERN.test(normalized) || normalized.length > MAX_PHASE_LENGTH) return undefined;
+  return normalized;
+};
+
+const normalizePercent = (percent: number | undefined): number | undefined => {
+  if (percent === undefined || !Number.isFinite(percent)) return undefined;
+  return Math.max(0, Math.min(100, Math.round(percent)));
+};
+
+const mib = (bytes: number): number => Math.round((bytes / BYTES_PER_MIB) * 10) / 10;
+
+/**
+ * Create an append-only resource-event sink for analyze.
+ *
+ * The schema deliberately accepts only an enum event, a restricted phase token,
+ * numeric progress, and process/system counters. Free-form messages, repository
+ * paths, endpoint URLs, source text, environment values, and errors can never
+ * enter the JSONL payload.
+ */
+export const createAnalyzeResourceLogger = async (
+  filePath = process.env.GITNEXUS_ANALYZE_RESOURCE_LOG,
+): Promise<AnalyzeResourceLogger | undefined> => {
+  if (!filePath?.trim()) return undefined;
+
+  const resolvedPath = path.resolve(filePath.trim());
+  await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+  const handle = await fs.open(resolvedPath, 'a', 0o600);
+  let pending = Promise.resolve();
+  let closed = false;
+  let closing = false;
+
+  const emit = async (
+    event: AnalyzeResourceEvent,
+    phase?: string,
+    percent?: number,
+  ): Promise<void> => {
+    if (closing || closed) return;
+    const memory = process.memoryUsage();
+    const record = {
+      schema: RESOURCE_LOG_SCHEMA,
+      at: new Date().toISOString(),
+      pid: process.pid,
+      event,
+      phase: sanitizePhase(phase),
+      percent: normalizePercent(percent),
+      rssMiB: mib(memory.rss),
+      heapUsedMiB: mib(memory.heapUsed),
+      heapTotalMiB: mib(memory.heapTotal),
+      externalMiB: mib(memory.external),
+      arrayBuffersMiB: mib(memory.arrayBuffers),
+      systemFreeMiB: mib(os.freemem()),
+      systemTotalMiB: mib(os.totalmem()),
+    };
+    pending = pending.then(async () => {
+      await handle.appendFile(`${JSON.stringify(record)}\n`, 'utf8');
+    });
+    await pending;
+  };
+
+  const flush = async (): Promise<void> => {
+    await pending;
+    if (closed) return;
+    await handle.sync();
+  };
+
+  const close = async (): Promise<void> => {
+    if (closed || closing) return;
+    closing = true;
+    try {
+      await pending;
+      await handle.sync();
+    } finally {
+      closed = true;
+      await handle.close();
+    }
+  };
+
+  return { emit, flush, close };
+};

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -70,6 +70,7 @@ import {
   resolveEmbeddingRuntime,
 } from '../core/embeddings/runtime-install.js';
 import { warnIfNpm11NpxRisk } from './resolve-invocation.js';
+import { createAnalyzeResourceLogger } from './analyze-resource-log.js';
 
 // Capture stderr.write at module load BEFORE anything (LadybugDB native
 // init, progress bar, console redirection) can monkey-patch it. The
@@ -126,17 +127,17 @@ const installFatalHandlers = (): void => {
   });
 };
 
-/** Historical floor for the re-exec heap cap — the auto-sizer never goes below
- *  this, so small boxes / CI never regress. */
-const DEFAULT_HEAP_MB = 16384;
+const MIN_HEAP_MB = 2048;
+const MAX_HEAP_MB = 6144;
 
 /**
- * RAM-aware re-exec heap cap (MB): `0.75 × effective RAM`, clamped to
- * `>= DEFAULT_HEAP_MB`. Kept BELOW physical RAM on purpose — a cap `>=` RAM makes
- * V8 collect lazily and inflate the heap into swap-thrash (observed analyzing the
- * Linux kernel at a 30GB cap on a 31GB box). `constrainedBytes` is the cgroup
- * limit or `null`; it is honored only as a real, smaller-than-physical cap, because
- * `process.constrainedMemory()` returns a huge sentinel when UNCONSTRAINED.
+ * RAM-aware re-exec heap cap (MB): `0.5 × effective RAM`, clamped to
+ * `[2048, 6144]`. Keeping the cap materially below physical RAM leaves room for
+ * LadybugDB, worker processes, native embedding buffers, and the OS instead of
+ * allowing V8 to turn a large analysis into swap-thrash. `constrainedBytes` is
+ * the cgroup limit or `null`; it is honored only as a real, smaller-than-physical
+ * cap because `process.constrainedMemory()` returns a huge sentinel when
+ * unconstrained.
  */
 export function computeHeapCapMb(totalBytes: number, constrainedBytes: number | null): number {
   const effectiveBytes =
@@ -144,7 +145,7 @@ export function computeHeapCapMb(totalBytes: number, constrainedBytes: number | 
       ? constrainedBytes
       : totalBytes;
   const effectiveMb = Math.floor(effectiveBytes / (1024 * 1024));
-  return Math.max(DEFAULT_HEAP_MB, Math.floor(0.75 * effectiveMb));
+  return Math.max(MIN_HEAP_MB, Math.min(MAX_HEAP_MB, Math.floor(0.5 * effectiveMb)));
 }
 
 function readConstrainedBytes(): number | null {
@@ -518,7 +519,7 @@ const RECOMMENDED_WAL_CHECKPOINT_THRESHOLD = 64 * 1024 * 1024;
  *  if we're currently below that. A user-supplied NODE_OPTIONS heap wins (no re-exec). */
 async function ensureHeap(): Promise<boolean> {
   const nodeOpts = process.env.NODE_OPTIONS || '';
-  if (nodeOpts.includes('--max-old-space-size')) return false;
+  if (/--max[-_]old[-_]space[-_]size(?:=|\s|$)/u.test(nodeOpts)) return false;
 
   const v8Heap = v8.getHeapStatistics().heap_size_limit;
   if (v8Heap >= HEAP_MB * 1024 * 1024 * 0.9) return false;
@@ -538,7 +539,7 @@ async function ensureHeap(): Promise<boolean> {
   if (childExit.status !== 0 || childExit.signal) {
     if (childProcessLikelyOom(childExit)) {
       cliError(
-        `  Analysis likely ran out of memory (heap cap auto-sized to ${RESPAWN_HEAP_MB}MB ≈ 0.75x RAM).\n` +
+        `  Analysis likely ran out of memory (heap cap auto-sized to ${RESPAWN_HEAP_MB}MB; 50% of effective RAM, clamped to 2048–6144MB).\n` +
           `  This repository's working set exceeds available RAM. Use a machine with more RAM,\n` +
           `  or override the cap (a cap above physical RAM causes swap-thrash — use with care):\n` +
           `    NODE_OPTIONS="--max-old-space-size=<MB>" gitnexus analyze [your-args]\n` +
@@ -609,6 +610,8 @@ const restoreAnalyzeEnv = (snap: AnalyzeEnvSnapshot): void => {
 
 export interface AnalyzeOptions {
   force?: boolean;
+  /** Build an isolated generation and journal its promotion into the canonical slot. */
+  staged?: boolean;
   /** Refuse any analyze path that would require a full DB rebuild. */
   incrementalOnly?: boolean;
   repairFts?: boolean;
@@ -1258,29 +1261,65 @@ const analyzeCommandImpl = async (
 
   bar.start(100, 0, { phase: 'Initializing...' });
 
-  // Graceful SIGINT handling. Pino's default destination is `sync: false`
+  const resourceLog = await createAnalyzeResourceLogger();
+  let resourceLogFailureReported = false;
+  const reportResourceLogFailure = (): void => {
+    if (resourceLogFailureReported) return;
+    resourceLogFailureReported = true;
+    realStderrWrite('\n  Warning: analyze resource logging failed; analysis will continue.\n');
+  };
+  const emitResourceEvent = async (
+    event: Parameters<NonNullable<typeof resourceLog>['emit']>[0],
+    phase?: string,
+    percent?: number,
+  ): Promise<void> => {
+    try {
+      await resourceLog?.emit(event, phase, percent);
+    } catch {
+      reportResourceLogFailure();
+    }
+  };
+  const closeResourceLog = async (): Promise<void> => {
+    try {
+      await resourceLog?.close();
+    } catch {
+      reportResourceLogFailure();
+    }
+  };
+  await emitResourceEvent('start', 'initializing', 0);
+
+  // Graceful SIGINT/SIGTERM handling. Pino's default destination is `sync: false`
   // (buffered) — flush before exit so in-flight records reach stderr.
   // See `gitnexus/src/core/logger.ts:flushLoggerSync`.
   let aborted = false;
-  const sigintHandler = () => {
+  const signalHandler = (signal: 'SIGINT' | 'SIGTERM') => {
     if (aborted) process.exit(1);
     aborted = true;
     bar.stop();
-    console.log('\n  Interrupted — cleaning up...');
+    console.log(
+      signal === 'SIGINT'
+        ? '\n  Interrupted — checkpointing before exit...'
+        : '\n  Termination requested — checkpointing before exit...',
+    );
     // Bounded CHECKPOINT-then-exit (#2264 review P3): skip the native close (the
     // LadybugDB destructor can double-free after --pdg writes), but don't hang
     // behind a long --pdg COPY holding the connection lock — bound it so a single
     // Ctrl-C stays responsive; the WAL replays on the next analyze. A second
     // Ctrl-C (`if (aborted) process.exit(1)` above) remains the escape hatch.
     void boundedCheckpointBeforeExit({
-      exitCode: 130,
+      exitCode: signal === 'SIGINT' ? 130 : 143,
       beforeExit: async () => {
+        await emitResourceEvent('signal', signal.toLowerCase(), undefined);
+        await closeResourceLog();
         const { flushLoggerSync } = await import('../core/logger.js');
         flushLoggerSync();
       },
     });
   };
+  const sigintHandler = () => signalHandler('SIGINT');
+  const sigtermHandler = () => signalHandler('SIGTERM');
   process.on('SIGINT', sigintHandler);
+  process.on('SIGTERM', sigtermHandler);
 
   // Route console output through bar.log() to prevent progress bar corruption.
   // This is a deliberate UI pattern (not a logging concern): analyze runs a
@@ -1341,6 +1380,7 @@ const analyzeCommandImpl = async (
         // needs a fresh pipelineResult. Has no bearing on the registry
         // collision guard (see allowDuplicateName below).
         force: options.force || options.skills,
+        staged: options.staged,
         incrementalOnly: options.incrementalOnly,
         repairFts: options.repairFts,
         embeddings: embeddingsEnabled,
@@ -1388,6 +1428,7 @@ const analyzeCommandImpl = async (
       {
         onProgress: (_phase, percent, message) => {
           updateBar(percent, message);
+          void emitResourceEvent('progress', _phase, percent);
         },
         onLog: barLog,
       },
@@ -1423,6 +1464,9 @@ const analyzeCommandImpl = async (
       }
       clearInterval(elapsedTimer);
       process.removeListener('SIGINT', sigintHandler);
+      process.removeListener('SIGTERM', sigtermHandler);
+      await emitResourceEvent('complete', 'already-up-to-date', 100);
+      await closeResourceLog();
       console.log = origLog;
       // eslint-disable-next-line no-console -- restoring after intentional progress-bar routing
       console.warn = origWarn;
@@ -1443,6 +1487,9 @@ const analyzeCommandImpl = async (
     if (result.ftsRepairedOnly) {
       clearInterval(elapsedTimer);
       process.removeListener('SIGINT', sigintHandler);
+      process.removeListener('SIGTERM', sigtermHandler);
+      await emitResourceEvent('complete', 'fts-repair', 100);
+      await closeResourceLog();
       console.log = origLog;
       // eslint-disable-next-line no-console -- restoring after intentional progress-bar routing
       console.warn = origWarn;
@@ -1528,6 +1575,9 @@ const analyzeCommandImpl = async (
 
     clearInterval(elapsedTimer);
     process.removeListener('SIGINT', sigintHandler);
+    process.removeListener('SIGTERM', sigtermHandler);
+    await emitResourceEvent('complete', 'done', 100);
+    await closeResourceLog();
 
     console.log = origLog;
     // eslint-disable-next-line no-console -- restoring after intentional progress-bar routing
@@ -1567,6 +1617,9 @@ const analyzeCommandImpl = async (
   } catch (err: unknown) {
     clearInterval(elapsedTimer);
     process.removeListener('SIGINT', sigintHandler);
+    process.removeListener('SIGTERM', sigtermHandler);
+    await emitResourceEvent('error', 'failed', undefined);
+    await closeResourceLog();
     console.log = origLog;
     // eslint-disable-next-line no-console -- restoring after intentional progress-bar routing
     console.warn = origWarn;

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -1261,13 +1261,20 @@ const analyzeCommandImpl = async (
 
   bar.start(100, 0, { phase: 'Initializing...' });
 
-  const resourceLog = await createAnalyzeResourceLogger();
   let resourceLogFailureReported = false;
   const reportResourceLogFailure = (): void => {
     if (resourceLogFailureReported) return;
     resourceLogFailureReported = true;
     realStderrWrite('\n  Warning: analyze resource logging failed; analysis will continue.\n');
   };
+  let resourceLog: Awaited<ReturnType<typeof createAnalyzeResourceLogger>> = undefined;
+  try {
+    resourceLog = await createAnalyzeResourceLogger();
+  } catch {
+    // Observability is optional. An invalid/unwritable target must not prevent
+    // the analyzer from preserving or updating its canonical generation.
+    reportResourceLogFailure();
+  }
   const emitResourceEvent = async (
     event: Parameters<NonNullable<typeof resourceLog>['emit']>[0],
     phase?: string,

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -55,6 +55,10 @@ program
   .description('Index a repository (full analysis)')
   .option('-f, --force', 'Force full re-index even if up to date')
   .option(
+    '--staged',
+    'Build and validate an isolated DB, then promote it with a crash-safe journal',
+  )
+  .option(
     '--incremental-only',
     'Refuse recovery, migration, or scale escalation that would require a full rebuild',
   )

--- a/gitnexus/src/core/embeddings/cache-snapshot.ts
+++ b/gitnexus/src/core/embeddings/cache-snapshot.ts
@@ -1,0 +1,237 @@
+import { createHash } from 'crypto';
+import { createReadStream } from 'fs';
+import fs from 'fs/promises';
+import { createInterface } from 'readline';
+import type { CachedEmbedding } from './types.js';
+
+export const EMBEDDING_PRESERVATION_BATCH_SIZE = 256;
+export const EMBEDDING_SNAPSHOT_FILE = 'embedding-preservation.jsonl';
+
+const SNAPSHOT_SCHEMA = 'gitnexus.embedding-preservation/v1';
+
+interface SnapshotRow {
+  type: 'embedding';
+  nodeId: string;
+  chunkIndex: number;
+  startLine: number;
+  endLine: number;
+  embeddingBase64: string;
+  contentHash?: string;
+}
+
+interface SnapshotFooter {
+  type: 'complete';
+  schema: typeof SNAPSHOT_SCHEMA;
+  count: number;
+  dimensions: number;
+  sha256: string;
+  sourceLastCommit?: string;
+  sourceIndexedAt?: string;
+}
+
+export interface EmbeddingSnapshotSource {
+  lastCommit?: string;
+  indexedAt?: string;
+}
+
+export interface EmbeddingSnapshotInfo {
+  count: number;
+  dimensions: number;
+}
+
+const encodeEmbedding = (embedding: number[]): string => {
+  const vector = Float32Array.from(embedding);
+  return Buffer.from(vector.buffer, vector.byteOffset, vector.byteLength).toString('base64');
+};
+
+const decodeEmbedding = (encoded: string, dimensions: number): number[] => {
+  const bytes = Buffer.from(encoded, 'base64');
+  if (bytes.byteLength !== dimensions * Float32Array.BYTES_PER_ELEMENT) {
+    throw new Error('Embedding preservation snapshot contains a malformed vector');
+  }
+  const copy = Uint8Array.from(bytes).buffer;
+  return Array.from(new Float32Array(copy));
+};
+
+const toSnapshotRow = (embedding: CachedEmbedding): SnapshotRow => ({
+  type: 'embedding',
+  nodeId: embedding.nodeId,
+  chunkIndex: embedding.chunkIndex,
+  startLine: embedding.startLine,
+  endLine: embedding.endLine,
+  embeddingBase64: encodeEmbedding(embedding.embedding),
+  contentHash: embedding.contentHash,
+});
+
+/**
+ * Write an atomic, checksummed embedding snapshot without retaining more than
+ * 256 vectors. The producer may stream batches through `emit`; returning a
+ * small legacy array is supported for existing test doubles.
+ */
+export const createEmbeddingSnapshot = async (
+  snapshotPath: string,
+  source: EmbeddingSnapshotSource,
+  producer: (
+    emit: (batch: readonly CachedEmbedding[]) => Promise<void>,
+  ) => Promise<readonly CachedEmbedding[] | void>,
+): Promise<EmbeddingSnapshotInfo> => {
+  const tempPath = `${snapshotPath}.tmp-${process.pid}`;
+  const handle = await fs.open(tempPath, 'w', 0o600);
+  const digest = createHash('sha256');
+  let count = 0;
+  let dimensions = 0;
+
+  const emit = async (batch: readonly CachedEmbedding[]): Promise<void> => {
+    if (batch.length > EMBEDDING_PRESERVATION_BATCH_SIZE) {
+      throw new Error(
+        `Embedding preservation batch exceeds ${EMBEDDING_PRESERVATION_BATCH_SIZE} vectors`,
+      );
+    }
+    let payload = '';
+    for (const embedding of batch) {
+      const rowDimensions = embedding.embedding.length;
+      if (dimensions === 0) dimensions = rowDimensions;
+      if (rowDimensions !== dimensions) {
+        throw new Error('Embedding preservation snapshot mixes vector dimensions');
+      }
+      const line = `${JSON.stringify(toSnapshotRow(embedding))}\n`;
+      digest.update(line);
+      payload += line;
+      count++;
+    }
+    if (payload) await handle.writeFile(payload, 'utf8');
+  };
+
+  try {
+    const legacyRows = await producer(emit);
+    if (legacyRows && legacyRows.length > 0) {
+      for (let i = 0; i < legacyRows.length; i += EMBEDDING_PRESERVATION_BATCH_SIZE) {
+        await emit(legacyRows.slice(i, i + EMBEDDING_PRESERVATION_BATCH_SIZE));
+      }
+    }
+    const footer: SnapshotFooter = {
+      type: 'complete',
+      schema: SNAPSHOT_SCHEMA,
+      count,
+      dimensions,
+      sha256: digest.digest('hex'),
+      sourceLastCommit: source.lastCommit,
+      sourceIndexedAt: source.indexedAt,
+    };
+    await handle.writeFile(`${JSON.stringify(footer)}\n`, 'utf8');
+    await handle.sync();
+    await handle.close();
+    await fs.rename(tempPath, snapshotPath);
+    return { count, dimensions };
+  } catch (error) {
+    await handle.close().catch(() => {});
+    await fs.rm(tempPath, { force: true }).catch(() => {});
+    throw error;
+  }
+};
+
+/** Validate the entire snapshot before any restored row is written. */
+export const validateEmbeddingSnapshot = async (
+  snapshotPath: string,
+  source: EmbeddingSnapshotSource,
+  expectedCount?: number,
+): Promise<EmbeddingSnapshotInfo | undefined> => {
+  let input: ReturnType<typeof createReadStream>;
+  try {
+    input = createReadStream(snapshotPath, { encoding: 'utf8' });
+  } catch {
+    return undefined;
+  }
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  const digest = createHash('sha256');
+  let count = 0;
+  let dimensions = 0;
+  let footer: SnapshotFooter | undefined;
+
+  try {
+    for await (const line of lines) {
+      if (!line) continue;
+      const value = JSON.parse(line) as SnapshotRow | SnapshotFooter;
+      if (value.type === 'complete') {
+        if (footer) return undefined;
+        footer = value;
+        continue;
+      }
+      if (footer || value.type !== 'embedding' || typeof value.embeddingBase64 !== 'string') {
+        return undefined;
+      }
+      const byteLength = Buffer.byteLength(value.embeddingBase64, 'base64');
+      if (byteLength === 0 || byteLength % Float32Array.BYTES_PER_ELEMENT !== 0) return undefined;
+      const rowDimensions = byteLength / Float32Array.BYTES_PER_ELEMENT;
+      if (dimensions === 0) dimensions = rowDimensions;
+      if (rowDimensions !== dimensions) return undefined;
+      digest.update(`${line}\n`);
+      count++;
+    }
+  } catch {
+    return undefined;
+  } finally {
+    lines.close();
+    input.destroy();
+  }
+
+  if (
+    !footer ||
+    footer.schema !== SNAPSHOT_SCHEMA ||
+    footer.count !== count ||
+    footer.dimensions !== dimensions ||
+    footer.sha256 !== digest.digest('hex') ||
+    footer.sourceLastCommit !== source.lastCommit ||
+    footer.sourceIndexedAt !== source.indexedAt ||
+    (expectedCount !== undefined && count !== expectedCount)
+  ) {
+    return undefined;
+  }
+  return { count, dimensions };
+};
+
+/**
+ * Read a previously validated snapshot in vector batches bounded to 256.
+ * Validation is repeated first so a corrupt file can never be partially restored.
+ */
+export const readEmbeddingSnapshot = async (
+  snapshotPath: string,
+  source: EmbeddingSnapshotSource,
+  onBatch: (batch: readonly CachedEmbedding[]) => Promise<void>,
+  expectedCount?: number,
+): Promise<EmbeddingSnapshotInfo> => {
+  const info = await validateEmbeddingSnapshot(snapshotPath, source, expectedCount);
+  if (!info) throw new Error('Embedding preservation snapshot failed validation');
+
+  const input = createReadStream(snapshotPath, { encoding: 'utf8' });
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  let batch: CachedEmbedding[] = [];
+  try {
+    for await (const line of lines) {
+      if (!line) continue;
+      const value = JSON.parse(line) as SnapshotRow | SnapshotFooter;
+      if (value.type === 'complete') break;
+      batch.push({
+        nodeId: value.nodeId,
+        chunkIndex: value.chunkIndex,
+        startLine: value.startLine,
+        endLine: value.endLine,
+        embedding: decodeEmbedding(value.embeddingBase64, info.dimensions),
+        contentHash: value.contentHash,
+      });
+      if (batch.length === EMBEDDING_PRESERVATION_BATCH_SIZE) {
+        await onBatch(batch);
+        batch = [];
+      }
+    }
+    if (batch.length > 0) await onBatch(batch);
+  } finally {
+    lines.close();
+    input.destroy();
+  }
+  return info;
+};
+
+export const removeEmbeddingSnapshot = async (snapshotPath: string): Promise<void> => {
+  await fs.rm(snapshotPath, { force: true });
+};

--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -42,6 +42,7 @@ import { rankExactEmbeddingRows, type ExactEmbeddingRow } from './exact-search.j
 import { EMBEDDING_TABLE_NAME, EMBEDDING_INDEX_NAME, STALE_HASH_SENTINEL } from '../lbug/schema.js';
 import { loadVectorExtension, createVectorIndex } from '../lbug/lbug-adapter.js';
 import { escapeCypherString } from '../lbug/cypher-escape.js';
+import { isMissingColumnOrTableError } from '../lbug/schema-errors.js';
 import type { ExtensionInstallPolicy } from '../lbug/extension-loader.js';
 import { getExactScanLimit } from '../platform/capabilities.js';
 import { logger } from '../logger.js';
@@ -215,6 +216,8 @@ const queryEmbeddableNodes = async function* (
         yield page;
       }
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error ?? '');
+      if (!isMissingColumnOrTableError(message)) throw error;
       if (isDev) logger.warn({ error }, `Query for ${label} nodes failed:`);
     }
   }
@@ -228,6 +231,8 @@ const queryFallbackFileNodes = async function* (
   try {
     yield* queryLabelNodePages(executeQuery, 'File');
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    if (!isMissingColumnOrTableError(message)) throw error;
     if (isDev) logger.warn({ error }, 'Fallback File-node embedding query failed:');
   }
 };

--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -109,121 +109,159 @@ export const contentHashForNode = (
  */
 export type EmbeddingProgressCallback = (progress: EmbeddingProgress) => void;
 
-/**
- * Query all embeddable nodes from LadybugDB
- * Uses table-specific queries for different label types
- */
-const queryEmbeddableNodes = async (
+export const EMBEDDABLE_NODE_PAGE_SIZE = 512;
+const MAX_EMBEDDING_BATCH_SIZE = 16;
+const MAX_EMBEDDING_SUB_BATCH_SIZE = 8;
+
+interface EmbeddableNodeRef {
+  id: string;
+  label: string;
+}
+
+const mapEmbeddableRow = (row: any, label: string): EmbeddableNode => {
+  const hasExportedColumn = label === LABEL_METHOD || LABELS_WITH_EXPORTED.has(label);
+  const content = row.content ?? row[4] ?? '';
+  return {
+    id: String(row.id ?? row[0] ?? ''),
+    name: String(row.name ?? row[1] ?? ''),
+    label: String(row.label ?? row[2] ?? label),
+    filePath: String(row.filePath ?? row[3] ?? ''),
+    content,
+    startLine: label === 'File' ? 1 : (row.startLine ?? row[5]),
+    endLine: label === 'File' ? Math.max(1, content.split('\n').length) : (row.endLine ?? row[6]),
+    isExported: hasExportedColumn ? (row.isExported ?? row[7]) : undefined,
+    description: row.description ?? (hasExportedColumn ? row[8] : row[7]),
+    ...(label === LABEL_METHOD
+      ? {
+          parameterCount: row.parameterCount ?? row[9],
+          returnType: row.returnType ?? row[10],
+        }
+      : {}),
+  };
+};
+
+const buildEmbeddableNodeQuery = (
+  label: string,
+  selector: { afterId?: string; nodeIds?: readonly string[] },
+): string => {
+  const table = label === 'File' ? 'File' : `\`${label}\``;
+  const where = selector.nodeIds
+    ? `WHERE n.id IN [${selector.nodeIds.map((id) => `'${escapeCypherString(id)}'`).join(', ')}]`
+    : selector.afterId
+      ? `WHERE n.id > '${escapeCypherString(selector.afterId)}'`
+      : '';
+  const projection =
+    label === 'File'
+      ? `n.id AS id, n.name AS name, 'File' AS label, n.filePath AS filePath, n.content AS content`
+      : label === LABEL_METHOD
+        ? `n.id AS id, n.name AS name, 'Method' AS label,
+           n.filePath AS filePath, n.content AS content,
+           n.startLine AS startLine, n.endLine AS endLine,
+           n.isExported AS isExported, n.description AS description,
+           n.parameterCount AS parameterCount, n.returnType AS returnType`
+        : LABELS_WITH_EXPORTED.has(label)
+          ? `n.id AS id, n.name AS name, '${label}' AS label,
+             n.filePath AS filePath, n.content AS content,
+             n.startLine AS startLine, n.endLine AS endLine,
+             n.isExported AS isExported, n.description AS description`
+          : `n.id AS id, n.name AS name, '${label}' AS label,
+             n.filePath AS filePath, n.content AS content,
+             n.startLine AS startLine, n.endLine AS endLine,
+             n.description AS description`;
+  return `MATCH (n:${table}) ${where} RETURN ${projection} ORDER BY n.id LIMIT ${EMBEDDABLE_NODE_PAGE_SIZE}`;
+};
+
+const queryLabelNodePages = async function* (
   executeQuery: (cypher: string) => Promise<any[]>,
-): Promise<EmbeddableNode[]> => {
-  const allNodes: EmbeddableNode[] = [];
-
-  for (const label of EMBEDDABLE_LABELS) {
-    try {
-      let query: string;
-
-      if (label === LABEL_METHOD) {
-        // Method has parameterCount and returnType
-        query = `
-          MATCH (n:Method)
-          RETURN n.id AS id, n.name AS name, 'Method' AS label,
-                 n.filePath AS filePath, n.content AS content,
-                 n.startLine AS startLine, n.endLine AS endLine,
-                 n.isExported AS isExported, n.description AS description,
-                 n.parameterCount AS parameterCount, n.returnType AS returnType
-        `;
-      } else if (LABELS_WITH_EXPORTED.has(label)) {
-        // Function, Class, Interface have isExported and description
-        query = `
-          MATCH (n:\`${label}\`)
-          RETURN n.id AS id, n.name AS name, '${label}' AS label,
-                 n.filePath AS filePath, n.content AS content,
-                 n.startLine AS startLine, n.endLine AS endLine,
-                 n.isExported AS isExported, n.description AS description
-        `;
-      } else {
-        // Multi-language tables (Struct, Enum, etc.) — have description but no isExported
-        query = `
-          MATCH (n:\`${label}\`)
-          RETURN n.id AS id, n.name AS name, '${label}' AS label,
-                 n.filePath AS filePath, n.content AS content,
-                 n.startLine AS startLine, n.endLine AS endLine,
-                 n.description AS description
-        `;
-      }
-
-      const rows = await executeQuery(query);
-      for (const row of rows) {
-        const hasExportedColumn = label === LABEL_METHOD || LABELS_WITH_EXPORTED.has(label);
-        allNodes.push({
-          id: row.id ?? row[0],
-          name: row.name ?? row[1],
-          label: row.label ?? row[2],
-          filePath: row.filePath ?? row[3],
-          content: row.content ?? row[4] ?? '',
-          startLine: row.startLine ?? row[5],
-          endLine: row.endLine ?? row[6],
-          isExported: hasExportedColumn ? (row.isExported ?? row[7]) : undefined,
-          description: row.description ?? (hasExportedColumn ? row[8] : row[7]),
-          ...(label === LABEL_METHOD
-            ? {
-                parameterCount: row.parameterCount ?? row[9],
-                returnType: row.returnType ?? row[10],
-              }
-            : {}),
-        });
-      }
-    } catch (error) {
-      if (isDev) {
-        logger.warn({ error }, `Query for ${label} nodes failed:`);
-      }
-    }
+  label: string,
+): AsyncGenerator<EmbeddableNode[]> {
+  let afterId: string | undefined;
+  for (;;) {
+    const rows = await executeQuery(buildEmbeddableNodeQuery(label, { afterId }));
+    if (!rows || rows.length === 0) return;
+    const rawPage = rows.slice(0, EMBEDDABLE_NODE_PAGE_SIZE);
+    const nextAfterId = String(rawPage.at(-1)?.id ?? rawPage.at(-1)?.[0] ?? '');
+    if (!nextAfterId || (afterId !== undefined && nextAfterId <= afterId)) return;
+    afterId = nextAfterId;
+    const page = rawPage
+      .map((row) => mapEmbeddableRow(row, label))
+      .filter((node) =>
+        label === 'File'
+          ? Boolean(
+              node.id &&
+              node.filePath &&
+              node.content.trim() &&
+              node.content !== '[Binary file - content not stored]',
+            )
+          : Boolean(node.id),
+      );
+    if (page.length > 0) yield page;
+    if (rows.length < EMBEDDABLE_NODE_PAGE_SIZE) return;
   }
-
-  return allNodes.length > 0 ? allNodes : queryFallbackFileNodes(executeQuery);
 };
 
 /**
- * Static and documentation repositories may contain no code symbols while
- * still persisting useful text on File nodes. Keep File embeddings as a
- * zero-symbol fallback so code repositories retain symbol-first selection.
+ * Page code-symbol nodes deterministically. If the repository has no code
+ * symbols, page text-bearing File nodes instead.
  */
-const queryFallbackFileNodes = async (
+const queryEmbeddableNodes = async function* (
   executeQuery: (cypher: string) => Promise<any[]>,
-): Promise<EmbeddableNode[]> => {
-  try {
-    const rows = await executeQuery(`
-      MATCH (n:File)
-      RETURN n.id AS id, n.name AS name, 'File' AS label,
-             n.filePath AS filePath, n.content AS content
-    `);
-
-    return rows
-      .map((row) => {
-        const content = row.content ?? row[4] ?? '';
-        return {
-          id: row.id ?? row[0],
-          name: row.name ?? row[1],
-          label: row.label ?? row[2] ?? 'File',
-          filePath: row.filePath ?? row[3],
-          content,
-          startLine: 1,
-          endLine: Math.max(1, content.split('\n').length),
-        };
-      })
-      .filter(
-        (node) =>
-          node.id &&
-          node.filePath &&
-          node.content.trim() &&
-          node.content !== '[Binary file - content not stored]',
-      );
-  } catch (error) {
-    if (isDev) {
-      logger.warn({ error }, 'Fallback File-node embedding query failed:');
+): AsyncGenerator<EmbeddableNode[]> {
+  let sawCodeSymbol = false;
+  for (const label of EMBEDDABLE_LABELS) {
+    try {
+      for await (const page of queryLabelNodePages(executeQuery, label)) {
+        sawCodeSymbol = true;
+        yield page;
+      }
+    } catch (error) {
+      if (isDev) logger.warn({ error }, `Query for ${label} nodes failed:`);
     }
-    return [];
   }
+  if (!sawCodeSymbol) yield* queryFallbackFileNodes(executeQuery);
+};
+
+/** Static/documentation repository fallback, still bounded to 512 rows. */
+const queryFallbackFileNodes = async function* (
+  executeQuery: (cypher: string) => Promise<any[]>,
+): AsyncGenerator<EmbeddableNode[]> {
+  try {
+    yield* queryLabelNodePages(executeQuery, 'File');
+  } catch (error) {
+    if (isDev) logger.warn({ error }, 'Fallback File-node embedding query failed:');
+  }
+};
+
+const queryNodesByRefs = async (
+  executeQuery: (cypher: string) => Promise<any[]>,
+  refs: readonly EmbeddableNodeRef[],
+): Promise<EmbeddableNode[]> => {
+  if (refs.length > EMBEDDABLE_NODE_PAGE_SIZE) {
+    throw new Error(`Embeddable node page exceeds ${EMBEDDABLE_NODE_PAGE_SIZE}`);
+  }
+  const byLabel = new Map<string, EmbeddableNodeRef[]>();
+  for (const ref of refs) {
+    const labelRefs = byLabel.get(ref.label) ?? [];
+    labelRefs.push(ref);
+    byLabel.set(ref.label, labelRefs);
+  }
+  const byId = new Map<string, EmbeddableNode>();
+  for (const [label, labelRefs] of byLabel) {
+    const ids = labelRefs.map((ref) => ref.id);
+    const wanted = new Set(ids);
+    const rows = await executeQuery(buildEmbeddableNodeQuery(label, { nodeIds: ids }));
+    for (const row of rows.slice(0, EMBEDDABLE_NODE_PAGE_SIZE)) {
+      const node = mapEmbeddableRow(row, label);
+      if (wanted.has(node.id)) byId.set(node.id, node);
+    }
+  }
+  const nodes = refs
+    .map((ref) => byId.get(ref.id))
+    .filter((node): node is EmbeddableNode => !!node);
+  if (nodes.length !== refs.length) {
+    throw new Error('An embeddable node disappeared while its checkpoint window was active');
+  }
+  return nodes;
 };
 
 /**
@@ -319,6 +357,10 @@ export interface EmbeddingPipelineOptions {
   signal?: AbortSignal;
   checkpointEveryNodes?: number;
   forceReembedNodeIds?: ReadonlySet<string>;
+  /** Load cached node identities for one page; callers must return at most the requested IDs. */
+  loadExistingEmbeddingHashes?: (
+    nodeIds: readonly string[],
+  ) => Promise<Map<string, string> | undefined>;
   onCheckpointWindowStart?: (window: EmbeddingPipelineCheckpointWindow) => Promise<void>;
   onCheckpoint?: (checkpoint: EmbeddingPipelineCheckpoint) => Promise<void>;
 }
@@ -428,58 +470,60 @@ export const runEmbeddingPipeline = async (
       logger.info('🔍 Querying embeddable nodes...');
     }
 
-    // Phase 2: Query embeddable nodes
-    let nodes = await queryEmbeddableNodes(executeQuery);
-    throwIfCancelled();
-    const embeddableNodeIds = new Set(nodes.map((node) => node.id));
-
-    // Incremental mode: compare content hashes, delete stale rows, skip fresh ones.
-    // Computed hashes for stale nodes are cached so batchInsertEmbeddings can reuse them
-    // (avoids double computation).
-    const computedStaleHashes = new Map<string, string>();
-    // Stale rows are DELETE'd per-batch (just before each batch's INSERT) rather
-    // than all up front — see U6 / KTD7. `staleNodeIds` is consulted inside the
-    // batch loop; it stays empty in full (non-incremental) mode so no deletes fire.
-    const staleNodeIds = new Set<string>();
+    // Phase 2: scan bounded node pages and stream cached identity lookups. The
+    // first pass computes an exact progress total without retaining node content;
+    // the second pass builds one durable 5,000-node checkpoint window at a time.
     const forceReembedNodeIds = pipelineOptions.forceReembedNodeIds;
-    if (
-      (existingEmbeddings && existingEmbeddings.size > 0) ||
-      (forceReembedNodeIds && forceReembedNodeIds.size > 0)
-    ) {
-      const beforeCount = nodes.length;
-      nodes = nodes.filter((n) => {
-        const existingHash = existingEmbeddings?.get(n.id);
-        if (existingHash === undefined) {
-          // New node — needs embedding
-          return true;
-        }
-        const currentHash = contentHashForNode(n, finalConfig);
-        if (currentHash !== existingHash || forceReembedNodeIds?.has(n.id)) {
-          // Content changed — cache hash for reuse during insert, mark for DELETE + re-embed
-          computedStaleHashes.set(n.id, currentHash);
-          staleNodeIds.add(n.id);
-          return true;
-        }
-        // Hash matches — skip (fresh); no need to cache hash for skipped nodes
-        return false;
-      });
+    const removedPendingNodeIds = new Set(forceReembedNodeIds ?? []);
 
-      if (isDev) {
-        logger.info(
-          `📦 Incremental embeddings: ${beforeCount} total, ${existingEmbeddings.size} cached, ${staleNodeIds.size} stale, ${nodes.length} to embed`,
+    const loadPageHashes = async (
+      nodes: readonly EmbeddableNode[],
+    ): Promise<Map<string, string>> => {
+      if (pipelineOptions.loadExistingEmbeddingHashes) {
+        return (
+          (await pipelineOptions.loadExistingEmbeddingHashes(nodes.map((node) => node.id))) ??
+          new Map()
         );
       }
+      if (!existingEmbeddings || existingEmbeddings.size === 0) return new Map();
+      const page = new Map<string, string>();
+      for (const node of nodes) {
+        const hash = existingEmbeddings.get(node.id);
+        if (hash !== undefined) page.set(node.id, hash);
+      }
+      return page;
+    };
+
+    const selectPageRefs = async (
+      nodes: readonly EmbeddableNode[],
+      trackPendingPresence: boolean,
+    ): Promise<EmbeddableNodeRef[]> => {
+      const existingHashes = await loadPageHashes(nodes);
+      const selected: EmbeddableNodeRef[] = [];
+      for (const node of nodes) {
+        if (trackPendingPresence) removedPendingNodeIds.delete(node.id);
+        const existingHash = existingHashes.get(node.id);
+        if (
+          existingHash === undefined ||
+          existingHash !== contentHashForNode(node, finalConfig) ||
+          forceReembedNodeIds?.has(node.id)
+        ) {
+          selected.push({ id: node.id, label: node.label });
+        }
+      }
+      return selected;
+    };
+
+    let totalNodes = 0;
+    for await (const page of queryEmbeddableNodes(executeQuery)) {
+      throwIfCancelled();
+      totalNodes += (await selectPageRefs(page, true)).length;
     }
 
-    if (forceReembedNodeIds && forceReembedNodeIds.size > 0) {
-      const removedPendingNodeIds = [...forceReembedNodeIds].filter(
-        (nodeId) => !embeddableNodeIds.has(nodeId),
-      );
-      await deleteStaleEmbeddingRows(executeWithReusedStatement, removedPendingNodeIds);
+    if (removedPendingNodeIds.size > 0) {
+      await deleteStaleEmbeddingRows(executeWithReusedStatement, [...removedPendingNodeIds]);
       throwIfCancelled();
     }
-
-    const totalNodes = nodes.length;
 
     if (isDev) {
       logger.info(`📊 Found ${totalNodes} embeddable nodes`);
@@ -507,13 +551,10 @@ export const runEmbeddingPipeline = async (
     }
 
     // Phase 3: Chunk + embed nodes
-    const batchSize = finalConfig.batchSize;
+    const batchSize = Math.min(finalConfig.batchSize, MAX_EMBEDDING_BATCH_SIZE);
     const chunkSize = finalConfig.chunkSize;
     const overlap = finalConfig.overlap;
-    const checkpointWindowNodeCount = Math.max(
-      batchSize,
-      Math.ceil(checkpointEveryNodes / batchSize) * batchSize,
-    );
+    const checkpointWindowNodeCount = checkpointEveryNodes;
     let processedNodes = 0;
 
     onProgress({
@@ -525,147 +566,139 @@ export const runEmbeddingPipeline = async (
       totalBatches: Math.ceil(totalNodes / batchSize),
     });
 
-    // Process in batches of nodes
-    for (let batchIndex = 0; batchIndex < totalNodes; batchIndex += batchSize) {
-      throwIfCancelled();
-      if (pipelineOptions.onCheckpointWindowStart && batchIndex % checkpointWindowNodeCount === 0) {
+    const processNodePage = async (nodes: EmbeddableNode[]): Promise<void> => {
+      const pageHashes = await loadPageHashes(nodes);
+      for (let batchIndex = 0; batchIndex < nodes.length; batchIndex += batchSize) {
+        throwIfCancelled();
+        const batch = nodes.slice(batchIndex, batchIndex + batchSize);
+        const allTexts: string[] = [];
+        const allUpdates: Array<{
+          nodeId: string;
+          chunkIndex: number;
+          startLine: number;
+          endLine: number;
+          contentHash: string;
+        }> = [];
+
+        for (const node of batch) {
+          const isShort = isShortLabel(node.label);
+          const startLine = node.startLine ?? 0;
+          const endLine = node.endLine ?? 0;
+          if (!isShort && STRUCTURAL_LABELS.has(node.label)) {
+            try {
+              const names = await extractStructuralNames(node.content, node.filePath);
+              node.methodNames = names.methodNames;
+              node.fieldNames = names.fieldNames;
+            } catch {
+              // AST extraction failed — names stay undefined, text-generator handles gracefully
+            }
+          }
+
+          const hash = contentHashForNode(node, finalConfig);
+          let chunks: Array<{
+            text: string;
+            chunkIndex: number;
+            startLine: number;
+            endLine: number;
+          }>;
+          if (isShort) {
+            chunks = [{ text: node.content, chunkIndex: 0, startLine, endLine }];
+          } else {
+            try {
+              chunks = await chunkNode(
+                node.label,
+                node.content,
+                node.filePath,
+                startLine,
+                endLine,
+                chunkSize,
+                overlap,
+              );
+            } catch (chunkErr) {
+              if (isDev) {
+                logger.warn(
+                  { chunkErr },
+                  `⚠️ AST chunking failed for ${node.label} "${node.name}" (${node.filePath}), falling back to character-based chunking:`,
+                );
+              }
+              chunks = characterChunk(node.content, startLine, endLine, chunkSize, overlap);
+            }
+          }
+
+          let prevTail = '';
+          for (const chunk of chunks) {
+            allTexts.push(
+              generateEmbeddingText(node, chunk.text, finalConfig, chunk.chunkIndex, prevTail),
+            );
+            allUpdates.push({
+              nodeId: node.id,
+              chunkIndex: chunk.chunkIndex,
+              startLine: chunk.startLine,
+              endLine: chunk.endLine,
+              contentHash: hash,
+            });
+            prevTail = overlap > 0 ? chunk.text.slice(-overlap) : '';
+          }
+        }
+
+        const batchStaleIds = batch
+          .filter((node) => pageHashes.has(node.id))
+          .map((node) => node.id);
+        await deleteStaleEmbeddingRows(executeWithReusedStatement, batchStaleIds);
+        throwIfCancelled();
+
+        const embedSubBatch = Math.min(finalConfig.subBatchSize, MAX_EMBEDDING_SUB_BATCH_SIZE);
+        for (let si = 0; si < allTexts.length; si += embedSubBatch) {
+          const subTexts = allTexts.slice(si, si + embedSubBatch);
+          const subUpdates = allUpdates.slice(si, si + embedSubBatch);
+          let embeddings: Float32Array[];
+          try {
+            embeddings = await embedBatch(subTexts, { signal: pipelineOptions.signal });
+          } catch (embedErr) {
+            logger.error(
+              { embedErr },
+              `❌ embedBatch failed for ${subTexts.length} texts (first: "${subTexts[0]?.substring(0, 80)}..."):`,
+            );
+            throw embedErr;
+          }
+          await batchInsertEmbeddings(
+            executeWithReusedStatement,
+            subUpdates.map((update, index) => ({
+              ...update,
+              embedding: embeddingToArray(embeddings[index]),
+            })),
+          );
+          throwIfCancelled();
+        }
+
+        processedNodes += batch.length;
+        totalChunks += allUpdates.length;
+        onProgress({
+          phase: 'embedding',
+          percent: Math.round(20 + (processedNodes / totalNodes) * 70),
+          nodesProcessed: processedNodes,
+          totalNodes,
+          currentBatch: Math.ceil(processedNodes / batchSize),
+          totalBatches: Math.ceil(totalNodes / batchSize),
+        });
+      }
+    };
+
+    const processCheckpointWindow = async (refs: EmbeddableNodeRef[]): Promise<void> => {
+      if (pipelineOptions.onCheckpointWindowStart) {
         await pipelineOptions.onCheckpointWindowStart({
           nodesProcessed: processedNodes,
           totalNodes,
           chunksProcessed: totalChunks,
-          nodeIds: nodes
-            .slice(batchIndex, batchIndex + checkpointWindowNodeCount)
-            .map((node) => node.id),
+          nodeIds: refs.map((ref) => ref.id),
         });
         throwIfCancelled();
       }
-      const batch = nodes.slice(batchIndex, batchIndex + batchSize);
-
-      // Chunk each node and generate text
-      const allTexts: string[] = [];
-      const allUpdates: Array<{
-        nodeId: string;
-        chunkIndex: number;
-        startLine: number;
-        endLine: number;
-        contentHash: string;
-      }> = [];
-
-      for (const node of batch) {
-        const isShort = isShortLabel(node.label);
-        const startLine = node.startLine ?? 0;
-        const endLine = node.endLine ?? 0;
-
-        // Extract structural names for class-like nodes via AST extractors
-        if (!isShort && STRUCTURAL_LABELS.has(node.label)) {
-          try {
-            const names = await extractStructuralNames(node.content, node.filePath);
-            node.methodNames = names.methodNames;
-            node.fieldNames = names.fieldNames;
-          } catch {
-            // AST extraction failed — names stay undefined, text-generator handles gracefully
-          }
-        }
-
-        // Compute content hash once per node (re-use cached value for stale nodes)
-        const hash = computedStaleHashes.get(node.id) ?? contentHashForNode(node, finalConfig);
-
-        let chunks: Array<{ text: string; chunkIndex: number; startLine: number; endLine: number }>;
-        if (isShort) {
-          chunks = [{ text: node.content, chunkIndex: 0, startLine, endLine }];
-        } else {
-          try {
-            chunks = await chunkNode(
-              node.label,
-              node.content,
-              node.filePath,
-              startLine,
-              endLine,
-              chunkSize,
-              overlap,
-            );
-          } catch (chunkErr) {
-            if (isDev) {
-              logger.warn(
-                { chunkErr },
-                `⚠️ AST chunking failed for ${node.label} "${node.name}" (${node.filePath}), falling back to character-based chunking:`,
-              );
-            }
-            chunks = characterChunk(node.content, startLine, endLine, chunkSize, overlap);
-          }
-        }
-
-        let prevTail = '';
-        for (const chunk of chunks) {
-          const text = generateEmbeddingText(
-            node,
-            chunk.text,
-            finalConfig,
-            chunk.chunkIndex,
-            prevTail,
-          );
-          allTexts.push(text);
-          allUpdates.push({
-            nodeId: node.id,
-            chunkIndex: chunk.chunkIndex,
-            startLine: chunk.startLine,
-            endLine: chunk.endLine,
-            contentHash: hash,
-          });
-          prevTail = overlap > 0 ? chunk.text.slice(-overlap) : '';
-        }
+      for (let i = 0; i < refs.length; i += EMBEDDABLE_NODE_PAGE_SIZE) {
+        const pageRefs = refs.slice(i, i + EMBEDDABLE_NODE_PAGE_SIZE);
+        await processNodePage(await queryNodesByRefs(executeQuery, pageRefs));
       }
-
-      // U6 / KTD7: delete this batch's stale rows immediately before its inserts,
-      // so an interrupted re-embed loses at most one batch (not the whole index).
-      // Preserves Kuzu's required DELETE-before-INSERT for vector-indexed rows.
-      const batchStaleIds = batch.filter((n) => staleNodeIds.has(n.id)).map((n) => n.id);
-      await deleteStaleEmbeddingRows(executeWithReusedStatement, batchStaleIds);
-      throwIfCancelled();
-
-      // Embed chunk texts in sub-batches to control memory
-      const EMBED_SUB_BATCH = finalConfig.subBatchSize;
-      for (let si = 0; si < allTexts.length; si += EMBED_SUB_BATCH) {
-        const subTexts = allTexts.slice(si, si + EMBED_SUB_BATCH);
-        const subUpdates = allUpdates.slice(si, si + EMBED_SUB_BATCH);
-
-        let embeddings: Float32Array[];
-        try {
-          embeddings = await embedBatch(subTexts, { signal: pipelineOptions.signal });
-        } catch (embedErr) {
-          logger.error(
-            { embedErr },
-            `❌ embedBatch failed for ${subTexts.length} texts (first: "${subTexts[0]?.substring(0, 80)}..."):`,
-          );
-          throw embedErr;
-        }
-
-        const dbUpdates = subUpdates.map((u, i) => ({
-          ...u,
-          embedding: embeddingToArray(embeddings[i]),
-        }));
-
-        await batchInsertEmbeddings(executeWithReusedStatement, dbUpdates);
-        throwIfCancelled();
-      }
-
-      processedNodes += batch.length;
-      totalChunks += allUpdates.length;
-
-      const embeddingProgress = 20 + (processedNodes / totalNodes) * 70;
-      onProgress({
-        phase: 'embedding',
-        percent: Math.round(embeddingProgress),
-        nodesProcessed: processedNodes,
-        totalNodes,
-        currentBatch: Math.floor(batchIndex / batchSize) + 1,
-        totalBatches: Math.ceil(totalNodes / batchSize),
-      });
-
-      if (
-        pipelineOptions.onCheckpoint &&
-        (processedNodes % checkpointWindowNodeCount === 0 || processedNodes === totalNodes)
-      ) {
+      if (pipelineOptions.onCheckpoint) {
         await pipelineOptions.onCheckpoint({
           nodesProcessed: processedNodes,
           totalNodes,
@@ -673,7 +706,21 @@ export const runEmbeddingPipeline = async (
         });
         throwIfCancelled();
       }
+    };
+
+    let checkpointRefs: EmbeddableNodeRef[] = [];
+    for await (const page of queryEmbeddableNodes(executeQuery)) {
+      throwIfCancelled();
+      const selected = await selectPageRefs(page, false);
+      for (const ref of selected) {
+        checkpointRefs.push(ref);
+        if (checkpointRefs.length === checkpointWindowNodeCount) {
+          await processCheckpointWindow(checkpointRefs);
+          checkpointRefs = [];
+        }
+      }
     }
+    if (checkpointRefs.length > 0) await processCheckpointWindow(checkpointRefs);
 
     // Phase 4: Create vector index
     throwIfCancelled();

--- a/gitnexus/src/core/embeddings/http-client.ts
+++ b/gitnexus/src/core/embeddings/http-client.ts
@@ -17,7 +17,7 @@ const HTTP_TIMEOUT_MS = 30_000;
 const HTTP_MAX_RETRIES = 2;
 const HTTP_RETRY_BACKOFF_MS = 1_000;
 const HTTP_RETRY_CAP_MS = 5_000;
-const HTTP_BATCH_SIZE = 64;
+const HTTP_BATCH_SIZE = 8;
 const DEFAULT_DIMS = 384;
 const HTTP_BREAKER_KEY = 'embeddings-http';
 

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import lbug from '@ladybugdb/core';
 import { closeQueryResults } from './query-result-utils.js';
 import { escapeCypherString } from './cypher-escape.js';
+import { isMissingColumnOrTableError } from './schema-errors.js';
 import { withConnLock } from './conn-lock.js';
 import { isWalDriverActive } from './wal-driver-state.js';
 import { KnowledgeGraph } from '../graph/types.js';
@@ -225,16 +226,6 @@ let vectorIndexEnsured = false;
 const ensuredFTSIndexes = new Set<string>();
 
 const ftsIndexKey = (tableName: string, indexName: string): string => `${tableName}:${indexName}`;
-
-/**
- * Check if an error indicates a missing column or table (schema-level problem)
- * rather than a transient/connection error. Used for legacy DB fallback logic.
- */
-const isMissingColumnOrTableError = (msg: string): boolean =>
-  msg.includes('does not exist') ||
-  // Kuzu-specific: "(table|column|property) ... not found" — narrow enough to avoid
-  // matching transient errors like "connection not found" or "key not found".
-  /(table|column|property).*not found/i.test(msg);
 
 /** Expose the current Database for pool adapter reuse in tests. */
 export const getDatabase = (): lbug.Database | null => db;

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -1708,13 +1708,27 @@ export const getLbugStats = async (): Promise<{ nodes: number; edges: number }> 
  *
  * Detects old schema (no chunkIndex column) and returns empty cache to trigger rebuild.
  */
-export const loadCachedEmbeddings = async (): Promise<{
+export interface LoadCachedEmbeddingsOptions {
+  /** Stream vectors instead of retaining them in the returned arrays. */
+  onBatch?: (batch: readonly CachedEmbedding[]) => void | Promise<void>;
+  /** Hard-capped at 256 so a 2,048-dimensional index stays bounded. */
+  batchSize?: number;
+}
+
+export const loadCachedEmbeddings = async (
+  options: LoadCachedEmbeddingsOptions = {},
+): Promise<{
   embeddingNodeIds: Set<string>;
   embeddings: CachedEmbedding[];
 }> => {
   const c = conn;
   if (!c) {
     return { embeddingNodeIds: new Set(), embeddings: [] };
+  }
+
+  const batchSize = options.batchSize ?? 256;
+  if (!Number.isSafeInteger(batchSize) || batchSize <= 0 || batchSize > 256) {
+    throw new Error('Cached embedding stream batchSize must be an integer in [1, 256]');
   }
 
   // The whole read runs inside the connection lock (#2264 review P2). It's safe
@@ -1725,6 +1739,55 @@ export const loadCachedEmbeddings = async (): Promise<{
   return withConnLock(async () => {
     const embeddingNodeIds = new Set<string>();
     const embeddings: CachedEmbedding[] = [];
+    let pendingBatch: CachedEmbedding[] = [];
+
+    const acceptRow = async (row: any, hasContentHash: boolean): Promise<void> => {
+      const nodeId = String(row.nodeId ?? row[0] ?? '');
+      if (!nodeId) return;
+      const embedding = row.embedding ?? row[4];
+      if (!embedding) return;
+      const cached: CachedEmbedding = {
+        nodeId,
+        chunkIndex: Number(row.chunkIndex ?? row[1] ?? 0),
+        startLine: Number(row.startLine ?? row[2] ?? 0),
+        endLine: Number(row.endLine ?? row[3] ?? 0),
+        embedding: Array.isArray(embedding)
+          ? embedding.map(Number)
+          : Array.from(embedding as any).map(Number),
+        contentHash: hasContentHash ? (row.contentHash ?? row[5] ?? undefined) : undefined,
+      };
+      if (options.onBatch) {
+        pendingBatch.push(cached);
+        if (pendingBatch.length === batchSize) {
+          await options.onBatch(pendingBatch);
+          pendingBatch = [];
+        }
+      } else {
+        embeddingNodeIds.add(nodeId);
+        embeddings.push(cached);
+      }
+    };
+
+    const streamRows = async (query: string, hasContentHash: boolean): Promise<void> => {
+      const queryResult = await c.query(query);
+      const results = Array.isArray(queryResult) ? queryResult : [queryResult];
+      let streamError: unknown;
+      try {
+        for (const result of results) {
+          while (await result.hasNext()) await acceptRow(await result.getNext(), hasContentHash);
+        }
+      } catch (error) {
+        streamError = error;
+        throw error;
+      } finally {
+        try {
+          await drainQueryResult(results);
+        } catch (error) {
+          if (streamError === undefined) throw error;
+        }
+      }
+    };
+
     try {
       // Schema migration detection: query with new columns to verify schema version.
       // Old schema only had (nodeId, embedding); new schema adds (id, chunkIndex, startLine, endLine, contentHash).
@@ -1739,48 +1802,67 @@ export const loadCachedEmbeddings = async (): Promise<{
       }
 
       // Try to read contentHash alongside chunk columns
-      let rows: any;
-      let hasContentHash = true;
       try {
-        rows = await c.query(
+        await streamRows(
           `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN e.nodeId AS nodeId, e.chunkIndex AS chunkIndex, e.startLine AS startLine, e.endLine AS endLine, e.embedding AS embedding, e.contentHash AS contentHash`,
+          true,
         );
       } catch (err: any) {
         // Fallback for legacy DBs without contentHash column
         const msg = err?.message ?? '';
         if (isMissingColumnOrTableError(msg)) {
-          hasContentHash = false;
-          rows = await c.query(
+          await streamRows(
             `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN e.nodeId AS nodeId, e.chunkIndex AS chunkIndex, e.startLine AS startLine, e.endLine AS endLine, e.embedding AS embedding`,
+            false,
           );
         } else {
           throw err;
         }
       }
-      for (const row of await readQueryRows(rows)) {
-        const nodeId = String(row.nodeId ?? row[0] ?? '');
-        if (!nodeId) continue;
-        embeddingNodeIds.add(nodeId);
-        const embedding = row.embedding ?? row[4];
-        if (embedding) {
-          embeddings.push({
-            nodeId,
-            chunkIndex: Number(row.chunkIndex ?? row[1] ?? 0),
-            startLine: Number(row.startLine ?? row[2] ?? 0),
-            endLine: Number(row.endLine ?? row[3] ?? 0),
-            embedding: Array.isArray(embedding)
-              ? embedding.map(Number)
-              : Array.from(embedding as any).map(Number),
-            contentHash: hasContentHash ? (row.contentHash ?? row[5] ?? undefined) : undefined,
-          });
-        }
-      }
-    } catch {
+      if (options.onBatch && pendingBatch.length > 0) await options.onBatch(pendingBatch);
+    } catch (error: any) {
+      if (!isMissingColumnOrTableError(error?.message ?? '')) throw error;
       /* embedding table may not exist */
     }
 
     return { embeddingNodeIds, embeddings };
   });
+};
+
+/** Fetch only the cached identities needed for one bounded node page. */
+export const fetchExistingEmbeddingHashesForNodeIds = async (
+  execQuery: (cypher: string) => Promise<any[]>,
+  nodeIds: readonly string[],
+): Promise<Map<string, string>> => {
+  if (nodeIds.length === 0) return new Map();
+  if (nodeIds.length > 512) throw new Error('Embedding identity page exceeds 512 node IDs');
+  const ids = `[${nodeIds.map((id) => `'${escapeCypherString(id)}'`).join(', ')}]`;
+  try {
+    const rows = await execQuery(
+      `MATCH (e:${EMBEDDING_TABLE_NAME}) WHERE e.nodeId IN ${ids} RETURN e.nodeId AS nodeId, e.chunkIndex AS chunkIndex, e.startLine AS startLine, e.endLine AS endLine, e.contentHash AS contentHash`,
+    );
+    const hashes = new Map<string, string>();
+    for (const row of rows ?? []) {
+      const nodeId = row.nodeId ?? row[0];
+      if (!nodeId) continue;
+      const chunkIndex = row.chunkIndex ?? row[1];
+      const startLine = row.startLine ?? row[2];
+      const endLine = row.endLine ?? row[3];
+      const hash = row.contentHash ?? row[4] ?? STALE_HASH_SENTINEL;
+      const completeChunkMetadata =
+        chunkIndex !== undefined &&
+        chunkIndex !== null &&
+        startLine !== undefined &&
+        startLine !== null &&
+        endLine !== undefined &&
+        endLine !== null;
+      hashes.set(String(nodeId), completeChunkMetadata && hash ? hash : STALE_HASH_SENTINEL);
+    }
+    return hashes;
+  } catch (error: any) {
+    if (isMissingColumnOrTableError(error?.message ?? '')) return new Map();
+    throw error;
+  }
 };
 
 /**

--- a/gitnexus/src/core/lbug/schema-errors.ts
+++ b/gitnexus/src/core/lbug/schema-errors.ts
@@ -1,0 +1,10 @@
+/**
+ * Check whether a LadybugDB error reports a missing schema table or column.
+ * Callers may recover from these legacy-schema cases, but must propagate
+ * connection, query, and other runtime failures.
+ */
+export const isMissingColumnOrTableError = (message: string): boolean =>
+  message.includes('does not exist') ||
+  // Kuzu-specific: "(table|column|property) ... not found" — narrow enough to avoid
+  // matching transient errors like "connection not found" or "key not found".
+  /(table|column|property).*not found/i.test(message);

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -673,7 +673,7 @@ const runFullAnalysisImpl = async (
   const canonicalPaths = getStoragePaths(repoPath, placement.branch);
   const canonicalMetaDir = path.dirname(canonicalPaths.metaPath);
   const promotionPaths = getStagedAnalyzePaths(canonicalPaths.lbugPath, canonicalMetaDir);
-  let stagedPaths: StagedAnalyzePaths | undefined = options.staged ? promotionPaths : undefined;
+  const stagedPaths: StagedAnalyzePaths | undefined = options.staged ? promotionPaths : undefined;
 
   const commitStagedMetadataAndRegistry = async (meta: RepoMeta): Promise<string> => {
     await saveMeta(canonicalMetaDir, meta);

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -132,7 +132,8 @@ import {
   prepareStagedWorkspace,
   promoteStagedGeneration,
   validateStagedGeneration,
-  withStagedAnalyzeLock,
+  withAnalyzeOwnershipLock,
+  type RepositorySourceIdentity,
   type StagedAnalyzePaths,
 } from './staged-promotion.js';
 
@@ -657,14 +658,22 @@ const runFullAnalysisImpl = async (
   // `~ ^ : ? *`, leading `-`, `..`) becomes `null` → the flat slot, matching
   // that a later `--branch <that-ref>` query would also be rejected. A normal
   // ref passes through unchanged so index-time and query-time labels round-trip.
-  const checkedOutBranch = repoHasGit
-    ? (sanitizeDetectedBranch(getCurrentBranch(repoPath)) ?? null)
-    : null;
+  const rawCheckedOutBranch = repoHasGit ? getCurrentBranch(repoPath) : null;
+  const checkedOutBranch = sanitizeDetectedBranch(rawCheckedOutBranch) ?? null;
+  const repositorySource: RepositorySourceIdentity = {
+    head: currentCommit,
+    branch: rawCheckedOutBranch,
+  };
+  const readRepositoryIdentity = (): RepositorySourceIdentity => ({
+    head: repoHasGit ? getCurrentCommit(repoPath) : '',
+    branch: repoHasGit ? getCurrentBranch(repoPath) : null,
+  });
   const branchLabel = options.branch ?? checkedOutBranch;
   const placement = options.branch ? await resolveBranchPlacement(repoPath, branchLabel) : {};
   const canonicalPaths = getStoragePaths(repoPath, placement.branch);
   const canonicalMetaDir = path.dirname(canonicalPaths.metaPath);
-  let stagedPaths: StagedAnalyzePaths | undefined;
+  const promotionPaths = getStagedAnalyzePaths(canonicalPaths.lbugPath, canonicalMetaDir);
+  let stagedPaths: StagedAnalyzePaths | undefined = options.staged ? promotionPaths : undefined;
 
   const commitStagedMetadataAndRegistry = async (meta: RepoMeta): Promise<string> => {
     await saveMeta(canonicalMetaDir, meta);
@@ -675,10 +684,9 @@ const runFullAnalysisImpl = async (
     });
   };
 
-  const promoteValidatedStage = async (): Promise<string | undefined> => {
-    if (!stagedPaths) throw new Error('Cannot promote without staged-analyze paths');
-    const stagedMeta = await validateStagedGeneration(stagedPaths);
-    const stagedStats = await withLbugDb(stagedPaths.stagedLbugPath, getLbugStats, {
+  const promoteValidatedStage = async (paths: StagedAnalyzePaths): Promise<string | undefined> => {
+    const stagedMeta = await validateStagedGeneration(paths);
+    const stagedStats = await withLbugDb(paths.stagedLbugPath, getLbugStats, {
       readOnly: true,
     });
     if (
@@ -691,17 +699,28 @@ const runFullAnalysisImpl = async (
           `but the readable DB contains ${stagedStats.nodes} nodes/${stagedStats.edges} edges.`,
       );
     }
-    return (await promoteStagedGeneration(stagedPaths, commitStagedMetadataAndRegistry))
-      .projectName;
+    return (
+      await promoteStagedGeneration(paths, commitStagedMetadataAndRegistry, {
+        readRepositoryIdentity,
+      })
+    ).projectName;
   };
 
-  if (options.staged) {
-    stagedPaths = getStagedAnalyzePaths(canonicalPaths.lbugPath, canonicalMetaDir);
-    if (await hasPendingPromotion(stagedPaths)) {
-      progress('lbug', 1, 'Recovering staged promotion...');
-      await promoteStagedGeneration(stagedPaths, commitStagedMetadataAndRegistry);
-      log('Recovered and completed the previous staged promotion.');
+  // Every analyze mode owns the same canonical slot and must resolve its
+  // promotion journal before any fast path can report success. In particular,
+  // a crash at old-backed-up may leave the canonical pathname temporarily
+  // absent even when metadata still looks current.
+  if (await hasPendingPromotion(promotionPaths)) {
+    if (options.incrementalOnly) {
+      throw new Error(
+        'Incremental-only safety stop: a staged-promotion journal requires recovery before this index can be read as current. No recovery mutation was started.',
+      );
     }
+    progress('lbug', 1, 'Recovering staged promotion...');
+    await promoteStagedGeneration(promotionPaths, commitStagedMetadataAndRegistry, {
+      readRepositoryIdentity,
+    });
+    log('Recovered and completed the previous staged promotion.');
   }
 
   // Analyze indexes the working tree, not an arbitrary ref. Recover a pending
@@ -721,7 +740,7 @@ const runFullAnalysisImpl = async (
 
   if (stagedPaths) {
     const canonicalMeta = await loadMeta(canonicalMetaDir);
-    const prepared = await prepareStagedWorkspace(stagedPaths, canonicalMeta);
+    const prepared = await prepareStagedWorkspace(stagedPaths, canonicalMeta, repositorySource);
     log(
       prepared.resumed
         ? 'Resuming the existing staged generation; the canonical index remains untouched.'
@@ -1237,7 +1256,7 @@ const runFullAnalysisImpl = async (
             // this same-commit fast path. Promote that validated generation
             // instead of silently discarding completed work.
             progress('lbug', 99, 'Promoting completed staged generation...');
-            promotedProjectName = await promoteValidatedStage();
+            promotedProjectName = await promoteValidatedStage(stagedPaths);
           } else {
             await discardStagedWorkspace(stagedPaths);
           }
@@ -2459,7 +2478,7 @@ const runFullAnalysisImpl = async (
     if (stagedPaths) {
       progress('lbug', 97, 'Validating staged generation...');
       progress('lbug', 99, 'Promoting staged generation...');
-      const promotedProjectName = await promoteValidatedStage();
+      const promotedProjectName = await promoteValidatedStage(stagedPaths);
       projectName =
         promotedProjectName ??
         options.registryName ??
@@ -2568,9 +2587,8 @@ export async function runFullAnalysis(
   options: AnalyzeOptions,
   callbacks: AnalyzeCallbacks,
 ): Promise<AnalyzeResult> {
-  if (!options.staged) return runFullAnalysisImpl(repoPath, options, callbacks);
   const { storagePath } = getStoragePaths(repoPath);
-  return withStagedAnalyzeLock(storagePath, () =>
+  return withAnalyzeOwnershipLock(storagePath, () =>
     runFullAnalysisImpl(repoPath, options, callbacks),
   );
 }

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -113,11 +113,28 @@ import {
   getInferredRepoName,
   resolveRepoIdentityRoot,
 } from '../storage/git.js';
-import type { CachedEmbedding } from './embeddings/types.js';
+import {
+  createEmbeddingSnapshot,
+  EMBEDDING_PRESERVATION_BATCH_SIZE,
+  EMBEDDING_SNAPSHOT_FILE,
+  readEmbeddingSnapshot,
+  removeEmbeddingSnapshot,
+  validateEmbeddingSnapshot,
+  type EmbeddingSnapshotInfo,
+} from './embeddings/cache-snapshot.js';
 import { generateAIContextFiles } from '../cli/ai-context.js';
 import { sanitizeDetectedBranch } from '../cli/analyze-config.js';
 import { EMBEDDING_TABLE_NAME } from './lbug/schema.js';
-import { STALE_HASH_SENTINEL } from './lbug/schema.js';
+import {
+  discardStagedWorkspace,
+  getStagedAnalyzePaths,
+  hasPendingPromotion,
+  prepareStagedWorkspace,
+  promoteStagedGeneration,
+  validateStagedGeneration,
+  withStagedAnalyzeLock,
+  type StagedAnalyzePaths,
+} from './staged-promotion.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -141,6 +158,8 @@ export interface AnalyzeOptions {
    * bypass. See `allowDuplicateName` below.
    */
   force?: boolean;
+  /** Build and validate a shadow DB, then promote it through a durable journal. */
+  staged?: boolean;
   /**
    * Refuse every path that would require a full DB rebuild. The preflight is
    * intentionally stricter than normal analyze: it runs before migration
@@ -585,11 +604,11 @@ export const pdgModeMismatch = (recorded: RepoMeta['pdg'], options: PdgOptions):
   return false;
 };
 
-export async function runFullAnalysis(
+const runFullAnalysisImpl = async (
   repoPath: string,
   options: AnalyzeOptions,
   callbacks: AnalyzeCallbacks,
-): Promise<AnalyzeResult> {
+): Promise<AnalyzeResult> => {
   const log = (msg: string) => callbacks.onLog?.(msg);
   const progress = (phase: string, percent: number, message: string) =>
     callbacks.onProgress(phase, percent, message);
@@ -641,23 +660,77 @@ export async function runFullAnalysis(
   const checkedOutBranch = repoHasGit
     ? (sanitizeDetectedBranch(getCurrentBranch(repoPath)) ?? null)
     : null;
-  // Analyze indexes the working tree, not an arbitrary ref. An explicit
-  // `--branch X` while a DIFFERENT branch Y is checked out would write Y's
-  // content (and Y's commit) into X's index slot, corrupting X (#2106). Refuse
-  // the mismatch. Detached HEAD / non-git (checkedOutBranch === null) still
-  // allow an explicit label so CI checkouts can name their snapshot.
+  const branchLabel = options.branch ?? checkedOutBranch;
+  const placement = options.branch ? await resolveBranchPlacement(repoPath, branchLabel) : {};
+  const canonicalPaths = getStoragePaths(repoPath, placement.branch);
+  const canonicalMetaDir = path.dirname(canonicalPaths.metaPath);
+  let stagedPaths: StagedAnalyzePaths | undefined;
+
+  const commitStagedMetadataAndRegistry = async (meta: RepoMeta): Promise<string> => {
+    await saveMeta(canonicalMetaDir, meta);
+    return registerRepo(repoPath, meta, {
+      name: options.registryName,
+      allowDuplicateName: options.allowDuplicateName,
+      branch: placement.branch,
+    });
+  };
+
+  const promoteValidatedStage = async (): Promise<string | undefined> => {
+    if (!stagedPaths) throw new Error('Cannot promote without staged-analyze paths');
+    const stagedMeta = await validateStagedGeneration(stagedPaths);
+    const stagedStats = await withLbugDb(stagedPaths.stagedLbugPath, getLbugStats, {
+      readOnly: true,
+    });
+    if (
+      (stagedMeta.stats?.nodes !== undefined && stagedMeta.stats.nodes !== stagedStats.nodes) ||
+      (stagedMeta.stats?.edges !== undefined && stagedMeta.stats.edges !== stagedStats.edges)
+    ) {
+      throw new Error(
+        `Staged DB validation failed: metadata records ` +
+          `${stagedMeta.stats?.nodes ?? '?'} nodes/${stagedMeta.stats?.edges ?? '?'} edges, ` +
+          `but the readable DB contains ${stagedStats.nodes} nodes/${stagedStats.edges} edges.`,
+      );
+    }
+    return (await promoteStagedGeneration(stagedPaths, commitStagedMetadataAndRegistry))
+      .projectName;
+  };
+
+  if (options.staged) {
+    stagedPaths = getStagedAnalyzePaths(canonicalPaths.lbugPath, canonicalMetaDir);
+    if (await hasPendingPromotion(stagedPaths)) {
+      progress('lbug', 1, 'Recovering staged promotion...');
+      await promoteStagedGeneration(stagedPaths, commitStagedMetadataAndRegistry);
+      log('Recovered and completed the previous staged promotion.');
+    }
+  }
+
+  // Analyze indexes the working tree, not an arbitrary ref. Recover a pending
+  // staged promotion first so a crash cannot leave the canonical pathname
+  // absent merely because the user switched branches before retrying. Once
+  // recovery is complete, refuse to start a new build for a mismatched label.
   if (options.branch && checkedOutBranch && options.branch !== checkedOutBranch) {
     throw new Error(
       `--branch "${options.branch}" does not match the checked-out branch "${checkedOutBranch}". ` +
         `Check out "${options.branch}" before indexing it, or omit --branch to index the current branch.`,
     );
   }
-  const branchLabel = options.branch ?? checkedOutBranch;
-  const placement = options.branch ? await resolveBranchPlacement(repoPath, branchLabel) : {};
-  const { lbugPath, metaPath } = getStoragePaths(repoPath, placement.branch);
-  // metaPath now points to the metadata file (gitnexus.json) in a branch-specific directory.
-  // metaDir is the directory containing the metadata file (and branch-specific DBs).
-  const metaDir = path.dirname(metaPath);
+
+  if (stagedPaths && options.repairFts) {
+    throw new Error('`--staged` cannot be combined with `--repair-fts`; repair is in-place only.');
+  }
+
+  if (stagedPaths) {
+    const canonicalMeta = await loadMeta(canonicalMetaDir);
+    const prepared = await prepareStagedWorkspace(stagedPaths, canonicalMeta);
+    log(
+      prepared.resumed
+        ? 'Resuming the existing staged generation; the canonical index remains untouched.'
+        : 'Prepared an isolated staged generation; the canonical index remains readable.',
+    );
+  }
+
+  const lbugPath = stagedPaths?.stagedLbugPath ?? canonicalPaths.lbugPath;
+  const metaDir = stagedPaths?.stagedMetaDir ?? canonicalMetaDir;
 
   if (options.incrementalOnly && (options.force || options.repairFts)) {
     incrementalOnlyStop('it cannot be combined with --force or --repair-fts');
@@ -724,7 +797,9 @@ export async function runFullAnalysis(
     }
   } else {
     // Normal analyze retains its established self-healing behavior.
-    const kuzuResult = await cleanupOldKuzuFiles(storagePath);
+    const kuzuResult = options.staged
+      ? { found: false, needsReindex: false }
+      : await cleanupOldKuzuFiles(storagePath);
     if (kuzuResult.found && kuzuResult.needsReindex) {
       log('Migrating from KuzuDB to LadybugDB — rebuilding index...');
     }
@@ -734,11 +809,13 @@ export async function runFullAnalysis(
     // legacy fallback, so a reconciliation failure (read-only mount, full disk)
     // must never abort the analyze run — a repo that indexed fine read-only
     // before the rename must keep doing so.
-    try {
-      await reconcileMetadataFiles(repoPath);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException)?.code;
-      log(`Metadata reconciliation failed (non-critical${code ? `, ${code}` : ''}); continuing.`);
+    if (!options.staged) {
+      try {
+        await reconcileMetadataFiles(repoPath);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code;
+        log(`Metadata reconciliation failed (non-critical${code ? `, ${code}` : ''}); continuing.`);
+      }
     }
     existingMeta = await loadMeta(metaDir);
   }
@@ -1106,6 +1183,7 @@ export async function runFullAnalysis(
       const healUnregistered =
         options.allowDuplicateName === true && !(await isRepoRegistered(repoPath));
       if (!dirty && !healUnregistered) {
+        let promotedProjectName: string | undefined;
         // ── #2354: restamp the workspace label on a same-commit branch flip ──
         // The flat slot follows the checked-out working tree; a branch switch
         // at the SAME commit with a clean tree changes nothing the pipeline
@@ -1113,7 +1191,12 @@ export async function runFullAnalysis(
         // registry copy that query-side branch scoping reads) would go stale.
         // Detached HEAD / non-git (branchLabel === null) keeps the existing
         // stamp, mirroring the end-of-run meta write.
-        if (!placement.branch && branchLabel && existingMeta.branch !== branchLabel) {
+        if (
+          !stagedPaths &&
+          !placement.branch &&
+          branchLabel &&
+          existingMeta.branch !== branchLabel
+        ) {
           if (options.incrementalOnly) {
             incrementalOnlyStop('the flat index branch label requires a metadata restamp');
           }
@@ -1142,7 +1225,23 @@ export async function runFullAnalysis(
             );
           }
         }
-        if (!options.incrementalOnly) {
+        if (stagedPaths) {
+          const canonicalMeta = await loadMeta(canonicalMetaDir);
+          const stageWasFinalizedAfterItsCanonicalSource =
+            !canonicalMeta ||
+            canonicalMeta.lastCommit !== existingMeta.lastCommit ||
+            canonicalMeta.indexedAt !== existingMeta.indexedAt;
+          if (stageWasFinalizedAfterItsCanonicalSource) {
+            // The prior process can die after finalizing the staged DB/meta but
+            // before writing the promotion journal. A resumed run then reaches
+            // this same-commit fast path. Promote that validated generation
+            // instead of silently discarding completed work.
+            progress('lbug', 99, 'Promoting completed staged generation...');
+            promotedProjectName = await promoteValidatedStage();
+          } else {
+            await discardStagedWorkspace(stagedPaths);
+          }
+        } else if (!options.incrementalOnly) {
           await ensureGitNexusIgnored(repoPath);
         }
         return {
@@ -1150,6 +1249,7 @@ export async function runFullAnalysis(
           // canonical repo basename (#1259) but leaves arbitrary subdirs
           // and `--skip-git` paths unchanged (#1232/#1233 intent preserved).
           repoName:
+            promotedProjectName ??
             options.registryName ??
             getInferredRepoName(repoPath) ??
             path.basename(resolveRepoIdentityRoot(repoPath)),
@@ -1177,8 +1277,13 @@ export async function runFullAnalysis(
   // The default-preserve branch is what makes a routine `analyze` (e.g. a
   // post-commit hook) safe: a multi-minute embedding pass is no longer
   // silently dropped just because the caller omitted `--embeddings`.
-  let cachedEmbeddingNodeIds = new Set<string>();
-  let cachedEmbeddings: CachedEmbedding[] = [];
+  const embeddingSnapshotPath = path.join(metaDir, EMBEDDING_SNAPSHOT_FILE);
+  const embeddingSnapshotSource = {
+    lastCommit: existingMeta?.lastCommit,
+    indexedAt: existingMeta?.indexedAt,
+  };
+  let embeddingSnapshotInfo: EmbeddingSnapshotInfo | undefined;
+  let embeddingSnapshotAvailable = false;
 
   const existingEmbeddingCount = existingMeta?.stats?.embeddings ?? 0;
   const {
@@ -1226,31 +1331,64 @@ export async function runFullAnalysis(
   if (shouldLoadCache && existingMeta) {
     try {
       progress('embeddings', 0, 'Caching embeddings...');
-      const cached = options.incrementalOnly
-        ? await withLbugDb(lbugPath, loadCachedEmbeddings, { readOnly: true })
-        : await (async () => {
-            await initLbug(lbugPath);
-            return loadCachedEmbeddings();
-          })();
-      cachedEmbeddingNodeIds = cached.embeddingNodeIds;
-      cachedEmbeddings = cached.embeddings;
-      await closeLbug();
-    } catch (err: any) {
-      // Surface cache-load failures explicitly: silently swallowing here would
-      // re-introduce the original silent-data-loss symptom (embeddings end up
-      // at 0 in meta.json with no diagnostic) through a different door.
-      log(
-        `Warning: could not load cached embeddings ` +
-          `(${err?.message ?? String(err)}). ` +
-          `Embeddings will not be preserved on this run.`,
+      const expectedSnapshotCount = resumeEmbeddingCheckpoint ? undefined : existingEmbeddingCount;
+      embeddingSnapshotInfo = await validateEmbeddingSnapshot(
+        embeddingSnapshotPath,
+        embeddingSnapshotSource,
+        expectedSnapshotCount,
       );
-      cachedEmbeddingNodeIds = new Set<string>();
-      cachedEmbeddings = [];
+      if (embeddingSnapshotInfo) {
+        embeddingSnapshotAvailable = true;
+        log(
+          `Reusing validated embedding preservation snapshot ` +
+            `(${embeddingSnapshotInfo.count} vectors).`,
+        );
+      } else {
+        embeddingSnapshotInfo = await createEmbeddingSnapshot(
+          embeddingSnapshotPath,
+          embeddingSnapshotSource,
+          async (emit) => {
+            const load = async () =>
+              loadCachedEmbeddings({
+                batchSize: EMBEDDING_PRESERVATION_BATCH_SIZE,
+                onBatch: emit,
+              });
+            const cached = options.incrementalOnly
+              ? await withLbugDb(lbugPath, load, { readOnly: true })
+              : await (async () => {
+                  await initLbug(lbugPath);
+                  return load();
+                })();
+            // Legacy unit doubles return a small array and ignore onBatch. The
+            // snapshot writer consumes that return without weakening production's
+            // streaming path.
+            return cached.embeddings;
+          },
+        );
+        embeddingSnapshotAvailable = true;
+        await closeLbug();
+      }
+      if (
+        !resumeEmbeddingCheckpoint &&
+        existingEmbeddingCount > 0 &&
+        embeddingSnapshotInfo.count !== existingEmbeddingCount
+      ) {
+        throw new Error(
+          `Embedding preservation snapshot contains ${embeddingSnapshotInfo.count} vectors, ` +
+            `but metadata records ${existingEmbeddingCount}; refusing a rebuild that could lose vectors.`,
+        );
+      }
+    } catch (err: any) {
       try {
         await closeLbug();
       } catch {
         /* swallow */
       }
+      throw new Error(
+        `Could not create a bounded embedding preservation snapshot; analysis stopped ` +
+          `before the rebuild could discard vectors (${err?.message ?? String(err)}).`,
+        { cause: err },
+      );
     }
   }
 
@@ -1883,91 +2021,76 @@ export async function runFullAnalysis(
     //      propagates errors (a completed writeback means a deterministic
     //      delete outcome) and this process holds the exclusive DB lock (no
     //      concurrent writer).
-    // The per-batch try/catch stays as a last-resort guard only — it no
-    // longer fires on the happy path.
+    // Restore insertion failures propagate: silently skipping a failed batch
+    // would finalize metadata with fewer vectors than the preserved snapshot.
     let restoredEmbeddingCount = 0;
-    if (cachedEmbeddings.length > 0) {
-      const cachedDims = cachedEmbeddings[0].embedding.length;
+    if (embeddingSnapshotInfo && embeddingSnapshotInfo.count > 0) {
+      const cachedDims = embeddingSnapshotInfo.dimensions;
       const { EMBEDDING_DIMS } = await import('./lbug/schema.js');
       if (cachedDims !== EMBEDDING_DIMS) {
         // Dimensions changed (e.g. switched embedding model) — discard cache and re-embed all
         log(
           `Embedding dimensions changed (${cachedDims}d -> ${EMBEDDING_DIMS}d), discarding cache`,
         );
-        cachedEmbeddings = [];
-        cachedEmbeddingNodeIds = new Set();
       } else {
         const { batchInsertEmbeddings: batchInsert } =
           await import('./embeddings/embedding-pipeline.js');
-        // (1) Live-graph filter — the FULL pipeline graph (always produced),
-        // NOT the incremental subgraph, or unchanged files' rows would be
-        // dropped from the restore set.
-        const liveEmbeddings = cachedEmbeddings.filter(
-          (e) => pipelineResult.graph.getNode(e.nodeId) !== undefined,
+        progress(
+          'embeddings',
+          88,
+          `Restoring ${embeddingSnapshotInfo.count} cached embeddings in bounded batches...`,
         );
-        // (2) Restore-scope filter (see the discipline note above).
-        const rowsToRestore =
-          deletedFilePathsForRestore === null
-            ? liveEmbeddings
-            : liveEmbeddings.filter((e) => {
-                const filePath = pipelineResult.graph.getNode(e.nodeId)?.properties?.filePath;
-                return typeof filePath === 'string' && deletedFilePathsForRestore!.has(filePath);
-              });
-        progress('embeddings', 88, `Restoring ${rowsToRestore.length} cached embeddings...`);
-        const EMBED_BATCH = 200;
-        for (let i = 0; i < rowsToRestore.length; i += EMBED_BATCH) {
-          const batch = rowsToRestore.slice(i, i + EMBED_BATCH);
-
-          try {
-            await batchInsert(executeWithReusedStatement, batch);
-            restoredEmbeddingCount += batch.length;
-          } catch {
-            /* last-resort guard — conflict-free by construction above */
-          }
-        }
-
-        // Legacy-orphan sweep (FIX 3, finder B): the live-graph filter's
-        // REJECTS — cached rows whose owning node no longer exists — are the
-        // rows stranded by the era when the embedding delete was a no-op
-        // (tri-review 4669518496 P2-1; schema version stays 6), plus this
-        // run's just-deleted files' rows (already join-deleted above — the
-        // exact-id DELETE matches nothing for those, so including them is a
-        // harmless no-op rather than worth a fragile nodeId parse to
-        // exclude). On the SURGICAL path the true legacy orphans still sit
-        // in the DB and the node join can never reach them again (no owning
-        // node), so delete them by exact row id. On wiped paths the rejects
-        // were simply not restored — nothing to sweep. Legacy-tolerant: a
-        // sweep failure must never fail a completed writeback, so the whole
-        // sweep warns-and-continues.
-        if (deletedFilePathsForRestore !== null) {
-          const orphanRowIds = cachedEmbeddings
-            .filter((e) => pipelineResult.graph.getNode(e.nodeId) === undefined)
-            .map((e) => `${e.nodeId}:${e.chunkIndex}`);
-          if (orphanRowIds.length > 0) {
-            try {
-              for (let i = 0; i < orphanRowIds.length; i += DELETE_FILES_CHUNK_SIZE) {
-                const chunk = orphanRowIds.slice(i, i + DELETE_FILES_CHUNK_SIZE);
-                const listLiteral = `[${chunk
-                  .map((id) => `'${escapeCypherString(id)}'`)
-                  .join(', ')}]`;
-                await executeQuery(
-                  `MATCH (e:${EMBEDDING_TABLE_NAME}) WHERE e.id IN ${listLiteral} DELETE e`,
+        await readEmbeddingSnapshot(
+          embeddingSnapshotPath,
+          embeddingSnapshotSource,
+          async (snapshotBatch) => {
+            const rowsToRestore = [];
+            const orphanRowIds: string[] = [];
+            for (const embedding of snapshotBatch) {
+              const liveNode = pipelineResult.graph.getNode(embedding.nodeId);
+              if (!liveNode) {
+                if (deletedFilePathsForRestore !== null) {
+                  orphanRowIds.push(`${embedding.nodeId}:${embedding.chunkIndex}`);
+                }
+                continue;
+              }
+              if (deletedFilePathsForRestore !== null) {
+                const filePath = liveNode.properties?.filePath;
+                if (typeof filePath !== 'string' || !deletedFilePathsForRestore.has(filePath)) {
+                  continue;
+                }
+              }
+              rowsToRestore.push(embedding);
+            }
+            if (rowsToRestore.length > 0) {
+              await batchInsert(executeWithReusedStatement, rowsToRestore);
+              restoredEmbeddingCount += rowsToRestore.length;
+            }
+            if (orphanRowIds.length > 0) {
+              try {
+                for (let i = 0; i < orphanRowIds.length; i += DELETE_FILES_CHUNK_SIZE) {
+                  const chunk = orphanRowIds.slice(i, i + DELETE_FILES_CHUNK_SIZE);
+                  const listLiteral = `[${chunk
+                    .map((id) => `'${escapeCypherString(id)}'`)
+                    .join(', ')}]`;
+                  await executeQuery(
+                    `MATCH (e:${EMBEDDING_TABLE_NAME}) WHERE e.id IN ${listLiteral} DELETE e`,
+                  );
+                }
+                log(
+                  `Swept ${orphanRowIds.length} cached embedding row(s) with no live owning node.`,
+                );
+              } catch (err) {
+                log(
+                  `Warning: could not sweep ${orphanRowIds.length} orphaned embedding ` +
+                    `row(s) (${(err as Error).message}); they are unreachable by search ` +
+                    'joins and will be retried next run.',
                 );
               }
-              log(
-                `Swept ${orphanRowIds.length} cached embedding row(s) with no live owning ` +
-                  'node — legacy orphans stranded while the embedding delete was a no-op; ' +
-                  'ids already removed with their files match nothing.',
-              );
-            } catch (err) {
-              log(
-                `Warning: could not sweep ${orphanRowIds.length} orphaned embedding ` +
-                  `row(s) (${(err as Error).message}); they are unreachable by search ` +
-                  'joins and will be retried next run.',
-              );
             }
-          }
-        }
+          },
+          resumeEmbeddingCheckpoint ? undefined : existingEmbeddingCount,
+        );
       }
     }
 
@@ -2045,17 +2168,9 @@ export async function runFullAnalysis(
         httpMode ? 'Connecting to embedding endpoint...' : 'Loading embedding model...',
       );
       const { runEmbeddingPipeline } = await import('./embeddings/embedding-pipeline.js');
+      const { fetchExistingEmbeddingHashesForNodeIds } = await import('./lbug/lbug-adapter.js');
       embeddingIdentityForRun ??= await resolveEmbeddingIdentity();
       const embeddingIdentity = embeddingIdentityForRun;
-      // Build a Map<nodeId, contentHash> from cached embeddings for incremental mode
-      let existingEmbeddings: Map<string, string> | undefined;
-      if (cachedEmbeddingNodeIds.size > 0) {
-        existingEmbeddings = new Map<string, string>();
-        for (const e of cachedEmbeddings) {
-          existingEmbeddings.set(e.nodeId, e.contentHash ?? STALE_HASH_SENTINEL);
-        }
-      }
-
       const saveEmbeddingCheckpoint = async (
         checkpoint: {
           nodesProcessed: number;
@@ -2112,10 +2227,12 @@ export async function runFullAnalysis(
           progress('embeddings', scaled, label);
         },
         {},
-        cachedEmbeddingNodeIds.size > 0 ? cachedEmbeddingNodeIds : undefined,
-        existingEmbeddings,
+        undefined,
+        undefined,
         {
           forceReembedNodeIds: pendingEmbeddingNodeIds,
+          loadExistingEmbeddingHashes: (nodeIds) =>
+            fetchExistingEmbeddingHashesForNodeIds(executeQuery, nodeIds),
           onCheckpointWindowStart: async ({ nodeIds, ...checkpoint }) => {
             await saveEmbeddingCheckpoint(checkpoint, nodeIds, existingMeta?.stats?.embeddings);
           },
@@ -2316,34 +2433,49 @@ export async function runFullAnalysis(
       log(`Warning: could not save parse cache (${(e as Error).message}); continuing.`);
     }
 
-    // Forward the --name alias and the registry-collision bypass bit.
-    // `allowDuplicateName` is its own concern — independent from the
-    // pipeline `force` above. The CLI maps it from
-    // `--allow-duplicate-name` only; `--force` and `--skills` both
-    // trigger pipeline re-run but never bypass the registry guard.
-    // The returned name is the one actually written to the registry
-    // (after applying the precedence chain in registerRepo) — reuse it
-    // so AGENTS.md / skill files reference the same name MCP clients
-    // will look up (#979).
-    const projectName = await registerRepo(repoPath, meta, {
-      name: options.registryName,
-      allowDuplicateName: options.allowDuplicateName,
-      // Non-primary branch runs upsert into the entry's branches[]; the
-      // primary/flat run (placement.branch === undefined) refreshes the
-      // top-level fields (#2106).
-      branch: placement.branch,
-    });
+    // ── Close LadybugDB ──────────────────────────────────────────────
+    // Stop the manual checkpoint driver before closeLbug so its
+    // in-flight CHECKPOINT cannot race the `safeClose` CHECKPOINT.
+    await walCheckpointDriver.stop();
+    // CLI callers (about to process.exit) skip the native close to dodge a
+    // LadybugDB destructor double-free after --pdg writes — closeLbugBeforeExit
+    // CHECKPOINTs for durability then leaves the handles for process exit to
+    // reclaim (#2264). Long-lived callers close for real.
+    await (options.skipNativeCloseOnExit && !stagedPaths ? closeLbugBeforeExit() : closeLbug());
+
+    if (embeddingSnapshotAvailable) {
+      await removeEmbeddingSnapshot(embeddingSnapshotPath).catch((error) => {
+        log(
+          `Warning: could not remove completed embedding preservation snapshot ` +
+            `(${(error as Error).message}); it will be ignored unless its source identity matches.`,
+        );
+      });
+    }
+
+    // The staged DB is closed and checkpointed before validation. Promotion
+    // retains the old canonical file as a backup until metadata + registry are
+    // committed, so every crash boundary has at least one complete generation.
+    let projectName: string;
+    if (stagedPaths) {
+      progress('lbug', 97, 'Validating staged generation...');
+      progress('lbug', 99, 'Promoting staged generation...');
+      const promotedProjectName = await promoteValidatedStage();
+      projectName =
+        promotedProjectName ??
+        options.registryName ??
+        getInferredRepoName(repoPath) ??
+        path.basename(resolveRepoIdentityRoot(repoPath));
+    } else {
+      // Forward the --name alias and registry-collision bypass only after the
+      // canonical DB is finalized. In staged mode this same commit is journaled.
+      projectName = await registerRepo(repoPath, meta, {
+        name: options.registryName,
+        allowDuplicateName: options.allowDuplicateName,
+        branch: placement.branch,
+      });
+    }
 
     // ── #2354: the flat workspace slot has adopted this run's branch ──────
-    // Drop a now-shadowed `branches/<slug>/` sub-index for the same label
-    // (unreachable once the flat slot serves it) and align the registry's
-    // top-level branch label. Best-effort like the parse-cache save above
-    // (#2364 review F5): the index is complete and registered, and a failure
-    // here leaves only a stale registry label / undeleted shadowed dir —
-    // never wrong routing, because the flat meta this run already stamped is
-    // what applyBranchScope trusts. Retried by the next content-changing run
-    // (same-commit fast-path runs skip it: their guard compares the
-    // already-stamped meta label).
     if (!placement.branch && branchLabel) {
       try {
         await adoptFlatBranchLabel(repoPath, branchLabel);
@@ -2354,10 +2486,10 @@ export async function runFullAnalysis(
       }
     }
 
-    // Keep generated .gitnexus contents ignored without editing the user's root .gitignore.
+    // Side effects that describe the canonical generation happen only after a
+    // staged promotion has committed.
     await ensureGitNexusIgnored(repoPath);
 
-    // ── Generate AI context files (best-effort) ───────────────────────
     let aggregatedClusterCount = 0;
     if (pipelineResult.communityResult?.communities) {
       const groups = new Map<string, number>();
@@ -2368,9 +2500,6 @@ export async function runFullAnalysis(
       aggregatedClusterCount = Array.from(groups.values()).filter((count) => count >= 5).length;
     }
 
-    // Only (re)generate the repo-root AI context files (AGENTS.md / CLAUDE.md /
-    // skills) for the primary/flat index (#2106). A non-primary branch analyze
-    // must not churn the repo's committed AGENTS.md with branch-specific stats.
     if (!placement.branch) {
       try {
         await generateAIContextFiles(
@@ -2399,16 +2528,6 @@ export async function runFullAnalysis(
       }
     }
 
-    // ── Close LadybugDB ──────────────────────────────────────────────
-    // Stop the manual checkpoint driver before closeLbug so its
-    // in-flight CHECKPOINT cannot race the `safeClose` CHECKPOINT.
-    await walCheckpointDriver.stop();
-    // CLI callers (about to process.exit) skip the native close to dodge a
-    // LadybugDB destructor double-free after --pdg writes — closeLbugBeforeExit
-    // CHECKPOINTs for durability then leaves the handles for process exit to
-    // reclaim (#2264). Long-lived callers close for real.
-    await (options.skipNativeCloseOnExit ? closeLbugBeforeExit() : closeLbug());
-
     progress('done', 100, 'Done');
 
     return {
@@ -2436,10 +2555,22 @@ export async function runFullAnalysis(
       // process still terminates — no hang, no abort. flushWAL keeps the partial
       // index durable; process exit reclaims the handles. Long-lived callers
       // (skipNativeCloseOnExit unset) close for real.
-      await (options.skipNativeCloseOnExit ? closeLbugBeforeExit() : closeLbug());
+      await (options.skipNativeCloseOnExit && !stagedPaths ? closeLbugBeforeExit() : closeLbug());
     } catch {
       /* swallow */
     }
     throw err;
   }
+};
+
+export async function runFullAnalysis(
+  repoPath: string,
+  options: AnalyzeOptions,
+  callbacks: AnalyzeCallbacks,
+): Promise<AnalyzeResult> {
+  if (!options.staged) return runFullAnalysisImpl(repoPath, options, callbacks);
+  const { storagePath } = getStoragePaths(repoPath);
+  return withStagedAnalyzeLock(storagePath, () =>
+    runFullAnalysisImpl(repoPath, options, callbacks),
+  );
 }

--- a/gitnexus/src/core/staged-promotion.ts
+++ b/gitnexus/src/core/staged-promotion.ts
@@ -6,10 +6,12 @@ import {
   isMissingFilesystemError,
   loadMeta,
   saveMeta,
+  INDEX_METADATA_FILE,
   type RepoMeta,
 } from '../storage/repo-manager.js';
 
 const STAGE_MANIFEST_SCHEMA = 'gitnexus.staged-analyze/v1';
+const STAGE_INTENT_SCHEMA = 'gitnexus.staged-analyze-intent/v1';
 const PROMOTION_JOURNAL_SCHEMA = 'gitnexus.staged-promotion/v1';
 const DB_SIDECARS = ['.wal', '.shadow', '.wal.checkpoint'] as const;
 
@@ -33,12 +35,30 @@ interface MetaIdentity {
   indexedAt: string;
 }
 
+interface MetaFilesIdentity {
+  primary?: FileIdentity;
+  legacy?: FileIdentity;
+}
+
+export interface RepositorySourceIdentity {
+  head: string;
+  branch: string | null;
+}
+
 interface StageManifest {
   schema: typeof STAGE_MANIFEST_SCHEMA;
   generationId: string;
   createdAt: string;
   sourceMeta?: MetaIdentity;
+  sourceMetaFiles?: MetaFilesIdentity;
   sourceDb?: FileIdentity;
+  sourceRepo?: RepositorySourceIdentity;
+}
+
+interface StageIntent extends Omit<StageManifest, 'schema' | 'sourceMetaFiles' | 'sourceRepo'> {
+  schema: typeof STAGE_INTENT_SCHEMA;
+  sourceMetaFiles: MetaFilesIdentity;
+  sourceRepo: RepositorySourceIdentity;
 }
 
 interface PromotionJournal {
@@ -50,6 +70,10 @@ interface PromotionJournal {
   stagedMeta: MetaIdentity;
   stagedDb: FileIdentity;
   oldDb?: FileIdentity;
+  sourceMeta?: MetaIdentity;
+  sourceMetaFiles?: MetaFilesIdentity;
+  sourceDb?: FileIdentity;
+  sourceRepo?: RepositorySourceIdentity;
   projectName?: string;
 }
 
@@ -57,6 +81,7 @@ export interface StagedAnalyzePaths {
   canonicalLbugPath: string;
   canonicalMetaDir: string;
   stageRoot: string;
+  stageIntentPath: string;
   stagedLbugPath: string;
   stagedMetaDir: string;
   stageManifestPath: string;
@@ -67,6 +92,13 @@ export interface StagedAnalyzePaths {
 export interface PromotionHooks {
   /** Test-only crash-injection seam after a durable state transition. */
   afterBoundary?: (boundary: PromotionBoundary) => void | Promise<void>;
+  /** Fresh repository identity, read immediately before promotion transitions. */
+  readRepositoryIdentity?: () => RepositorySourceIdentity | Promise<RepositorySourceIdentity>;
+}
+
+export interface PrepareStagedHooks {
+  /** Test-only crash seam after mutable stage files exist but before the manifest. */
+  afterStagePrepared?: () => void | Promise<void>;
 }
 
 export interface PromotionResult {
@@ -89,6 +121,35 @@ const metaIdentity = (meta: RepoMeta): MetaIdentity => ({
 const identitiesEqual = <T>(a?: T, b?: T): boolean =>
   a === undefined ? b === undefined : b !== undefined && JSON.stringify(a) === JSON.stringify(b);
 
+const validRepositoryIdentity = (value: unknown): value is RepositorySourceIdentity => {
+  const candidate = value as Partial<RepositorySourceIdentity> | null;
+  return (
+    !!candidate &&
+    typeof candidate.head === 'string' &&
+    (candidate.branch === null || typeof candidate.branch === 'string')
+  );
+};
+
+const validFileIdentity = (value: unknown): value is FileIdentity => {
+  const candidate = value as Partial<FileIdentity> | null;
+  return (
+    !!candidate &&
+    Number.isFinite(candidate.dev) &&
+    Number.isFinite(candidate.ino) &&
+    Number.isFinite(candidate.size) &&
+    Number.isFinite(candidate.mtimeMs)
+  );
+};
+
+const validMetaFilesIdentity = (value: unknown): value is MetaFilesIdentity => {
+  const candidate = value as MetaFilesIdentity | null;
+  return (
+    !!candidate &&
+    (candidate.primary === undefined || validFileIdentity(candidate.primary)) &&
+    (candidate.legacy === undefined || validFileIdentity(candidate.legacy))
+  );
+};
+
 const statRegularFile = async (filePath: string): Promise<FileIdentity | undefined> => {
   try {
     const stat = await fs.lstat(filePath);
@@ -99,6 +160,11 @@ const statRegularFile = async (filePath: string): Promise<FileIdentity | undefin
     throw error;
   }
 };
+
+const statMetadataFiles = async (metaDir: string): Promise<MetaFilesIdentity> => ({
+  primary: await statRegularFile(path.join(metaDir, INDEX_METADATA_FILE)),
+  legacy: await statRegularFile(path.join(metaDir, 'meta.json')),
+});
 
 const assertNoDbSidecars = async (lbugPath: string, label: string): Promise<void> => {
   const present: string[] = [];
@@ -171,11 +237,28 @@ const readManifest = async (paths: StagedAnalyzePaths): Promise<StageManifest | 
   if (
     manifest.schema !== STAGE_MANIFEST_SCHEMA ||
     typeof manifest.generationId !== 'string' ||
-    manifest.generationId.length < 8
+    manifest.generationId.length < 8 ||
+    (manifest.sourceMetaFiles !== undefined && !validMetaFilesIdentity(manifest.sourceMetaFiles)) ||
+    (manifest.sourceRepo !== undefined && !validRepositoryIdentity(manifest.sourceRepo))
   ) {
     throw new Error('Staged-analyze manifest is corrupt or from an unsupported version');
   }
   return manifest;
+};
+
+const readIntent = async (paths: StagedAnalyzePaths): Promise<StageIntent | undefined> => {
+  const intent = await readJson<StageIntent>(paths.stageIntentPath);
+  if (!intent) return undefined;
+  if (
+    intent.schema !== STAGE_INTENT_SCHEMA ||
+    typeof intent.generationId !== 'string' ||
+    intent.generationId.length < 8 ||
+    !validMetaFilesIdentity(intent.sourceMetaFiles) ||
+    !validRepositoryIdentity(intent.sourceRepo)
+  ) {
+    throw new Error('Staged-analyze intent is corrupt or from an unsupported version');
+  }
+  return intent;
 };
 
 const readJournal = async (paths: StagedAnalyzePaths): Promise<PromotionJournal | undefined> => {
@@ -189,7 +272,9 @@ const readJournal = async (paths: StagedAnalyzePaths): Promise<PromotionJournal 
     !journal.stagedMeta ||
     !journal.stagedDb ||
     typeof journal.stagedMeta.lastCommit !== 'string' ||
-    typeof journal.stagedMeta.indexedAt !== 'string'
+    typeof journal.stagedMeta.indexedAt !== 'string' ||
+    (journal.sourceMetaFiles !== undefined && !validMetaFilesIdentity(journal.sourceMetaFiles)) ||
+    (journal.sourceRepo !== undefined && !validRepositoryIdentity(journal.sourceRepo))
   ) {
     throw new Error('Staged-promotion journal is corrupt or from an unsupported version');
   }
@@ -226,6 +311,7 @@ export const getStagedAnalyzePaths = (
     canonicalLbugPath,
     canonicalMetaDir,
     stageRoot,
+    stageIntentPath: `${stageRoot}.intent.json`,
     stagedLbugPath: path.join(stageRoot, 'lbug'),
     stagedMetaDir: path.join(stageRoot, 'meta'),
     stageManifestPath: path.join(stageRoot, 'manifest.json'),
@@ -244,12 +330,14 @@ const processIsAlive = (pid: number): boolean => {
   }
 };
 
-/** Serialize staged builders; a dead owner's lock is reclaimed on the next run. */
-export const withStagedAnalyzeLock = async <T>(
+/** Serialize every analyzer writer; a dead owner's lock is reclaimed on the next run. */
+export const withAnalyzeOwnershipLock = async <T>(
   storagePath: string,
   operation: () => Promise<T>,
 ): Promise<T> => {
   await fs.mkdir(storagePath, { recursive: true });
+  // Keep the existing filename so an older staged writer and a newer ordinary
+  // writer still contend during an in-place upgrade.
   const lockPath = path.join(storagePath, 'analyze-staged.lock');
   const record: StageLockRecord = {
     schema: 'gitnexus.staged-analyze-lock/v1',
@@ -267,14 +355,14 @@ export const withStagedAnalyzeLock = async <T>(
       const owner = await readJson<StageLockRecord>(lockPath);
       if (owner?.schema === record.schema && processIsAlive(owner.pid)) {
         throw new Error(
-          `Another staged analyze is active (pid ${owner.pid}, started ${owner.startedAt}).`,
+          `Another analyze is active (pid ${owner.pid}, started ${owner.startedAt}).`,
         );
       }
-      if (attempt === 1) throw new Error('Could not reclaim the stale staged-analyze lock');
+      if (attempt === 1) throw new Error('Could not reclaim the stale analyze lock');
       await fs.rm(lockPath, { force: true });
     }
   }
-  if (!handle) throw new Error('Could not acquire the staged-analyze lock');
+  if (!handle) throw new Error('Could not acquire the analyze lock');
   try {
     await handle.writeFile(`${JSON.stringify(record)}\n`, 'utf8');
     await handle.sync();
@@ -286,13 +374,19 @@ export const withStagedAnalyzeLock = async <T>(
   }
 };
 
+/** @deprecated Use the common ownership lock so plain and staged writers cannot overlap. */
+export const withStagedAnalyzeLock = withAnalyzeOwnershipLock;
+
 /**
- * Create or resume the isolated build workspace. Only the stage tree may be
- * removed here, and only while a complete canonical generation is present.
+ * Create or resume the isolated build workspace. A stage tree is removed only
+ * when a complete canonical generation or a durable stage intent/manifest
+ * proves that the tree is disposable derived state.
  */
 export const prepareStagedWorkspace = async (
   paths: StagedAnalyzePaths,
   canonicalMeta: RepoMeta | null,
+  sourceRepo: RepositorySourceIdentity = { head: '', branch: null },
+  hooks: PrepareStagedHooks = {},
 ): Promise<{ resumed: boolean; generationId: string }> => {
   if (await readJournal(paths)) {
     throw new Error('A staged-promotion journal must be recovered before preparing another build');
@@ -312,12 +406,18 @@ export const prepareStagedWorkspace = async (
   if (canonicalDb) await assertNoDbSidecars(paths.canonicalLbugPath, 'Canonical index');
 
   const sourceMeta = canonicalMeta ? metaIdentity(canonicalMeta) : undefined;
+  const sourceMetaFiles = await statMetadataFiles(paths.canonicalMetaDir);
   const manifest = await readManifest(paths);
+  const intent = await readIntent(paths);
+  const sameSource = (candidate: StageManifest | StageIntent): boolean =>
+    identitiesEqual(candidate.sourceMeta, sourceMeta) &&
+    identitiesEqual(candidate.sourceMetaFiles, sourceMetaFiles) &&
+    identitiesEqual(candidate.sourceDb, canonicalDb) &&
+    identitiesEqual(candidate.sourceRepo, sourceRepo);
+
   if (manifest) {
-    const sameSource =
-      identitiesEqual(manifest.sourceMeta, sourceMeta) &&
-      identitiesEqual(manifest.sourceDb, canonicalDb);
-    if (sameSource) {
+    if (sameSource(manifest)) {
+      await fs.rm(paths.stageIntentPath, { force: true });
       const stagedDb = await statRegularFile(paths.stagedLbugPath);
       const stagedMeta = await loadMeta(paths.stagedMetaDir);
       if (canonicalDb && (!stagedDb || !stagedMeta)) {
@@ -327,26 +427,48 @@ export const prepareStagedWorkspace = async (
       }
       return { resumed: true, generationId: manifest.generationId };
     }
-    if (!canonicalDb || !canonicalMeta) {
-      throw new Error(
-        'A stale staged workspace exists but no complete canonical generation is available to replace it safely.',
-      );
-    }
+    // A valid manifest proves this is disposable derived state even for a
+    // first-generation index where no canonical DB exists yet.
     await fs.rm(paths.stageRoot, { recursive: true, force: true });
+    await fs.rm(paths.stageIntentPath, { force: true });
   } else {
+    let stageExists = false;
     try {
       await fs.lstat(paths.stageRoot);
-      if (!canonicalDb || !canonicalMeta) {
-        throw new Error(
-          'An incomplete staged workspace exists and no complete canonical generation is available for safe cleanup.',
-        );
-      }
-      await fs.rm(paths.stageRoot, { recursive: true, force: true });
+      stageExists = true;
     } catch (error) {
       if (!isMissingFilesystemError(error)) throw error;
     }
+    if (stageExists) {
+      if (!intent && (!canonicalDb || !canonicalMeta)) {
+        throw new Error(
+          'An unowned incomplete staged workspace exists and no complete canonical generation is available for safe cleanup.',
+        );
+      }
+      // A durable intent proves the incomplete tree belongs to staged analyze;
+      // removing it is safe even on the first generation. A complete canonical
+      // generation remains the fallback for legacy trees without an intent.
+      await fs.rm(paths.stageRoot, { recursive: true, force: true });
+    }
+    if (intent && !sameSource(intent)) await fs.rm(paths.stageIntentPath, { force: true });
   }
 
+  const durableIntent: StageIntent =
+    intent && sameSource(intent)
+      ? intent
+      : {
+          schema: STAGE_INTENT_SCHEMA,
+          generationId: randomBytes(16).toString('hex'),
+          createdAt: new Date().toISOString(),
+          sourceMeta,
+          sourceMetaFiles,
+          sourceDb: canonicalDb,
+          sourceRepo,
+        };
+  // This sibling intent is durable before stageRoot is created. If the process
+  // dies after mkdir/copy but before the manifest, the next run can prove the
+  // partial tree is ours and rebuild it automatically.
+  await writeDurableJson(paths.stageIntentPath, durableIntent);
   await fs.mkdir(paths.stagedMetaDir, { recursive: true });
   if (canonicalDb && canonicalMeta) {
     const tempDb = `${paths.stagedLbugPath}.copy-${randomBytes(8).toString('hex')}`;
@@ -360,15 +482,20 @@ export const prepareStagedWorkspace = async (
     await moveAndSync(tempDb, paths.stagedLbugPath);
     await saveMeta(paths.stagedMetaDir, canonicalMeta);
   }
+  await hooks.afterStagePrepared?.();
 
   const next: StageManifest = {
     schema: STAGE_MANIFEST_SCHEMA,
-    generationId: randomBytes(16).toString('hex'),
-    createdAt: new Date().toISOString(),
+    generationId: durableIntent.generationId,
+    createdAt: durableIntent.createdAt,
     sourceMeta,
+    sourceMetaFiles,
     sourceDb: canonicalDb,
+    sourceRepo,
   };
   await writeDurableJson(paths.stageManifestPath, next);
+  await fs.rm(paths.stageIntentPath, { force: true });
+  await syncDirectory(path.dirname(paths.stageIntentPath));
   return { resumed: false, generationId: next.generationId };
 };
 
@@ -377,6 +504,7 @@ export const discardStagedWorkspace = async (paths: StagedAnalyzePaths): Promise
     throw new Error('Cannot discard a staged workspace while promotion recovery is pending');
   }
   await fs.rm(paths.stageRoot, { recursive: true, force: true });
+  await fs.rm(paths.stageIntentPath, { force: true });
 };
 
 /** Validate the staged DB/meta pair before the first canonical rename. */
@@ -392,6 +520,113 @@ export const validateStagedGeneration = async (paths: StagedAnalyzePaths): Promi
     throw new Error('Staged generation still carries an incomplete write/checkpoint marker');
   }
   return meta;
+};
+
+interface CapturedPromotionSource {
+  sourceMeta?: MetaIdentity;
+  sourceMetaFiles: MetaFilesIdentity;
+  sourceDb?: FileIdentity;
+  sourceRepo: RepositorySourceIdentity;
+  hadCanonical: boolean;
+  stagedDb?: FileIdentity;
+}
+
+class PromotionSourceChangedError extends Error {
+  constructor(
+    readonly kind: 'metadata' | 'database' | 'repository',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'PromotionSourceChangedError';
+  }
+}
+
+const assertPromotionSourceUnchanged = async (
+  paths: StagedAnalyzePaths,
+  source: CapturedPromotionSource,
+  hooks: PromotionHooks,
+  allowOldDbInBackup: boolean,
+): Promise<void> => {
+  const canonicalMeta = await loadMeta(paths.canonicalMetaDir);
+  const currentMeta = canonicalMeta ? metaIdentity(canonicalMeta) : undefined;
+  if (!identitiesEqual(currentMeta, source.sourceMeta)) {
+    throw new PromotionSourceChangedError(
+      'metadata',
+      'Staged promotion refused: canonical metadata changed after the stage source was captured.',
+    );
+  }
+  const currentMetaFiles = await statMetadataFiles(paths.canonicalMetaDir);
+  if (!identitiesEqual(currentMetaFiles, source.sourceMetaFiles)) {
+    throw new PromotionSourceChangedError(
+      'metadata',
+      'Staged promotion refused: canonical metadata file identity changed after the stage source was captured.',
+    );
+  }
+
+  const canonicalDb = await statRegularFile(paths.canonicalLbugPath);
+  const backupDb = allowOldDbInBackup ? await statRegularFile(paths.backupLbugPath) : undefined;
+  const dbMatches = source.hadCanonical
+    ? identitiesEqual(canonicalDb, source.sourceDb) || identitiesEqual(backupDb, source.sourceDb)
+    : source.sourceDb === undefined &&
+      (canonicalDb === undefined ||
+        (allowOldDbInBackup && identitiesEqual(canonicalDb, source.stagedDb)));
+  if (!dbMatches) {
+    throw new PromotionSourceChangedError(
+      'database',
+      'Staged promotion refused: canonical database identity changed after the stage source was captured.',
+    );
+  }
+
+  if (hooks.readRepositoryIdentity) {
+    const currentRepo = await hooks.readRepositoryIdentity();
+    if (!identitiesEqual(currentRepo, source.sourceRepo)) {
+      throw new PromotionSourceChangedError(
+        'repository',
+        'Staged promotion refused: repository HEAD or branch changed while the staged generation was building.',
+      );
+    }
+  }
+};
+
+const rollbackPromotionForRepositoryChange = async (
+  paths: StagedAnalyzePaths,
+  journal: PromotionJournal,
+): Promise<void> => {
+  let canonical = await statRegularFile(paths.canonicalLbugPath);
+  const staged = await statRegularFile(paths.stagedLbugPath);
+  const backup = await statRegularFile(paths.backupLbugPath);
+
+  if (canonical && identitiesEqual(canonical, journal.stagedDb)) {
+    if (staged) {
+      throw new Error('Cannot roll back stale promotion because both new DB copies exist');
+    }
+    await moveAndSync(paths.canonicalLbugPath, paths.stagedLbugPath);
+    canonical = undefined;
+  }
+
+  if (journal.hadCanonical) {
+    if (canonical && identitiesEqual(canonical, journal.oldDb)) {
+      if (backup) {
+        throw new Error('Cannot roll back stale promotion because the old DB exists twice');
+      }
+    } else if (!canonical && backup && identitiesEqual(backup, journal.oldDb)) {
+      await moveAndSync(paths.backupLbugPath, paths.canonicalLbugPath);
+    } else {
+      throw new Error(
+        'Cannot roll back stale promotion because the canonical backup identity is ambiguous',
+      );
+    }
+  } else if (canonical) {
+    throw new Error(
+      'Cannot roll back stale first-generation promotion with an unknown canonical DB',
+    );
+  }
+
+  await fs.rm(paths.backupLbugPath, { force: true });
+  await fs.rm(paths.stageRoot, { recursive: true, force: true });
+  await fs.rm(paths.stageIntentPath, { force: true });
+  await fs.rm(paths.journalPath, { force: true });
+  await syncDirectory(paths.canonicalMetaDir);
 };
 
 /**
@@ -410,11 +645,28 @@ export const promoteStagedGeneration = async (
     const meta = await validateStagedGeneration(paths);
     const manifest = await readManifest(paths);
     if (!manifest) throw new Error('Staged generation manifest disappeared during validation');
+    if (!manifest.sourceMetaFiles || !manifest.sourceRepo) {
+      throw new Error(
+        'Legacy staged generation lacks source identity; rerun staged analyze to rebuild it safely.',
+      );
+    }
     const canonicalDb = await statRegularFile(paths.canonicalLbugPath);
     if (await statRegularFile(paths.backupLbugPath)) {
       throw new Error('Cannot begin promotion while an unjournaled backup generation exists');
     }
     if (canonicalDb) await assertNoDbSidecars(paths.canonicalLbugPath, 'Canonical index');
+    await assertPromotionSourceUnchanged(
+      paths,
+      {
+        sourceMeta: manifest.sourceMeta,
+        sourceMetaFiles: manifest.sourceMetaFiles,
+        sourceDb: manifest.sourceDb,
+        sourceRepo: manifest.sourceRepo,
+        hadCanonical: manifest.sourceDb !== undefined,
+      },
+      hooks,
+      false,
+    );
     journal = {
       schema: PROMOTION_JOURNAL_SCHEMA,
       generationId: manifest.generationId,
@@ -424,10 +676,44 @@ export const promoteStagedGeneration = async (
       stagedMeta: metaIdentity(meta),
       stagedDb: (await statRegularFile(paths.stagedLbugPath))!,
       oldDb: canonicalDb,
+      sourceMeta: manifest.sourceMeta,
+      sourceMetaFiles: manifest.sourceMetaFiles,
+      sourceDb: manifest.sourceDb,
+      sourceRepo: manifest.sourceRepo,
     };
     await writeDurableJson(paths.journalPath, journal);
     await hooks.afterBoundary?.('prepared');
   }
+
+  const ensureJournalSourceCurrent = async (): Promise<void> => {
+    if (journal.state === 'metadata/registry-committed') return;
+    // Journals written by the previous exact head did not capture these two
+    // guards. Preserve their artifact-identity recovery semantics; every new
+    // journal records and enforces the stronger source identity below.
+    if (!journal.sourceMetaFiles || !journal.sourceRepo) return;
+    try {
+      await assertPromotionSourceUnchanged(
+        paths,
+        {
+          sourceMeta: journal.sourceMeta,
+          sourceMetaFiles: journal.sourceMetaFiles,
+          sourceDb: journal.sourceDb,
+          sourceRepo: journal.sourceRepo,
+          hadCanonical: journal.hadCanonical,
+          stagedDb: journal.stagedDb,
+        },
+        hooks,
+        true,
+      );
+    } catch (error) {
+      if (error instanceof PromotionSourceChangedError && error.kind === 'repository') {
+        await rollbackPromotionForRepositoryChange(paths, journal);
+      }
+      throw error;
+    }
+  };
+
+  await ensureJournalSourceCurrent();
 
   if (journal.state === 'prepared') {
     const canonical = await statRegularFile(paths.canonicalLbugPath);
@@ -475,6 +761,7 @@ export const promoteStagedGeneration = async (
   }
 
   if (journal.state === 'old-backed-up') {
+    await ensureJournalSourceCurrent();
     const canonical = await statRegularFile(paths.canonicalLbugPath);
     const staged = await statRegularFile(paths.stagedLbugPath);
     const backup = await statRegularFile(paths.backupLbugPath);
@@ -506,6 +793,7 @@ export const promoteStagedGeneration = async (
   }
 
   if (journal.state === 'new-installed') {
+    await ensureJournalSourceCurrent();
     const canonical = await statRegularFile(paths.canonicalLbugPath);
     const staged = await statRegularFile(paths.stagedLbugPath);
     if (!canonical || !identitiesEqual(canonical, journal.stagedDb)) {
@@ -538,6 +826,7 @@ export const promoteStagedGeneration = async (
   }
   await fs.rm(paths.backupLbugPath, { force: true });
   await fs.rm(paths.stageRoot, { recursive: true, force: true });
+  await fs.rm(paths.stageIntentPath, { force: true });
   await fs.rm(paths.journalPath, { force: true });
   await syncDirectory(paths.canonicalMetaDir);
   return { projectName: journal.projectName, recovered };

--- a/gitnexus/src/core/staged-promotion.ts
+++ b/gitnexus/src/core/staged-promotion.ts
@@ -1,0 +1,547 @@
+import { randomBytes } from 'crypto';
+import path from 'path';
+import fs from 'fs/promises';
+import { retryRename } from '../storage/fs-atomic.js';
+import {
+  isMissingFilesystemError,
+  loadMeta,
+  saveMeta,
+  type RepoMeta,
+} from '../storage/repo-manager.js';
+
+const STAGE_MANIFEST_SCHEMA = 'gitnexus.staged-analyze/v1';
+const PROMOTION_JOURNAL_SCHEMA = 'gitnexus.staged-promotion/v1';
+const DB_SIDECARS = ['.wal', '.shadow', '.wal.checkpoint'] as const;
+
+export type PromotionState =
+  | 'prepared'
+  | 'old-backed-up'
+  | 'new-installed'
+  | 'metadata/registry-committed';
+
+export type PromotionBoundary = PromotionState;
+
+interface FileIdentity {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+}
+
+interface MetaIdentity {
+  lastCommit: string;
+  indexedAt: string;
+}
+
+interface StageManifest {
+  schema: typeof STAGE_MANIFEST_SCHEMA;
+  generationId: string;
+  createdAt: string;
+  sourceMeta?: MetaIdentity;
+  sourceDb?: FileIdentity;
+}
+
+interface PromotionJournal {
+  schema: typeof PROMOTION_JOURNAL_SCHEMA;
+  generationId: string;
+  state: PromotionState;
+  updatedAt: string;
+  hadCanonical: boolean;
+  stagedMeta: MetaIdentity;
+  stagedDb: FileIdentity;
+  oldDb?: FileIdentity;
+  projectName?: string;
+}
+
+export interface StagedAnalyzePaths {
+  canonicalLbugPath: string;
+  canonicalMetaDir: string;
+  stageRoot: string;
+  stagedLbugPath: string;
+  stagedMetaDir: string;
+  stageManifestPath: string;
+  backupLbugPath: string;
+  journalPath: string;
+}
+
+export interface PromotionHooks {
+  /** Test-only crash-injection seam after a durable state transition. */
+  afterBoundary?: (boundary: PromotionBoundary) => void | Promise<void>;
+}
+
+export interface PromotionResult {
+  projectName?: string;
+  recovered: boolean;
+}
+
+interface StageLockRecord {
+  schema: 'gitnexus.staged-analyze-lock/v1';
+  pid: number;
+  nonce: string;
+  startedAt: string;
+}
+
+const metaIdentity = (meta: RepoMeta): MetaIdentity => ({
+  lastCommit: meta.lastCommit,
+  indexedAt: meta.indexedAt,
+});
+
+const identitiesEqual = <T>(a?: T, b?: T): boolean =>
+  a === undefined ? b === undefined : b !== undefined && JSON.stringify(a) === JSON.stringify(b);
+
+const statRegularFile = async (filePath: string): Promise<FileIdentity | undefined> => {
+  try {
+    const stat = await fs.lstat(filePath);
+    if (!stat.isFile()) throw new Error(`Expected a regular file at ${filePath}`);
+    return { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeMs: stat.mtimeMs };
+  } catch (error) {
+    if (isMissingFilesystemError(error)) return undefined;
+    throw error;
+  }
+};
+
+const assertNoDbSidecars = async (lbugPath: string, label: string): Promise<void> => {
+  const present: string[] = [];
+  for (const suffix of DB_SIDECARS) {
+    try {
+      await fs.lstat(`${lbugPath}${suffix}`);
+      present.push(`${lbugPath}${suffix}`);
+    } catch (error) {
+      if (!isMissingFilesystemError(error)) throw error;
+    }
+  }
+  if (present.length > 0) {
+    throw new Error(
+      `${label} has unresolved LadybugDB sidecars (${present.join(', ')}); ` +
+        'refusing staged copy or promotion until WAL/shadow state is resolved.',
+    );
+  }
+};
+
+const syncDirectory = async (dir: string): Promise<void> => {
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  try {
+    handle = await fs.open(dir, 'r');
+    await handle.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'EINVAL' && code !== 'EPERM' && code !== 'EISDIR') throw error;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+};
+
+const writeDurableJson = async (target: string, value: unknown): Promise<void> => {
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  const temp = `${target}.tmp.${randomBytes(8).toString('hex')}`;
+  const handle = await fs.open(temp, 'wx', 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await retryRename(temp, target);
+    await syncDirectory(path.dirname(target));
+  } catch (error) {
+    await fs.rm(temp, { force: true }).catch(() => {});
+    throw error;
+  }
+};
+
+const readJson = async <T>(filePath: string): Promise<T | undefined> => {
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
+  } catch (error) {
+    if (isMissingFilesystemError(error)) return undefined;
+    throw new Error(`Cannot read staged-analyze state at ${filePath}`, { cause: error });
+  }
+};
+
+const isPromotionState = (value: unknown): value is PromotionState =>
+  value === 'prepared' ||
+  value === 'old-backed-up' ||
+  value === 'new-installed' ||
+  value === 'metadata/registry-committed';
+
+const readManifest = async (paths: StagedAnalyzePaths): Promise<StageManifest | undefined> => {
+  const manifest = await readJson<StageManifest>(paths.stageManifestPath);
+  if (!manifest) return undefined;
+  if (
+    manifest.schema !== STAGE_MANIFEST_SCHEMA ||
+    typeof manifest.generationId !== 'string' ||
+    manifest.generationId.length < 8
+  ) {
+    throw new Error('Staged-analyze manifest is corrupt or from an unsupported version');
+  }
+  return manifest;
+};
+
+const readJournal = async (paths: StagedAnalyzePaths): Promise<PromotionJournal | undefined> => {
+  const journal = await readJson<PromotionJournal>(paths.journalPath);
+  if (!journal) return undefined;
+  if (
+    journal.schema !== PROMOTION_JOURNAL_SCHEMA ||
+    typeof journal.generationId !== 'string' ||
+    !isPromotionState(journal.state) ||
+    typeof journal.hadCanonical !== 'boolean' ||
+    !journal.stagedMeta ||
+    !journal.stagedDb ||
+    typeof journal.stagedMeta.lastCommit !== 'string' ||
+    typeof journal.stagedMeta.indexedAt !== 'string'
+  ) {
+    throw new Error('Staged-promotion journal is corrupt or from an unsupported version');
+  }
+  return journal;
+};
+
+const updateJournal = async (
+  paths: StagedAnalyzePaths,
+  journal: PromotionJournal,
+  state: PromotionState,
+  projectName?: string,
+): Promise<PromotionJournal> => {
+  const next: PromotionJournal = {
+    ...journal,
+    state,
+    updatedAt: new Date().toISOString(),
+    projectName: projectName ?? journal.projectName,
+  };
+  await writeDurableJson(paths.journalPath, next);
+  return next;
+};
+
+const moveAndSync = async (source: string, target: string): Promise<void> => {
+  await retryRename(source, target);
+  await syncDirectory(path.dirname(target));
+};
+
+export const getStagedAnalyzePaths = (
+  canonicalLbugPath: string,
+  canonicalMetaDir: string,
+): StagedAnalyzePaths => {
+  const stageRoot = `${canonicalLbugPath}.staged-work`;
+  return {
+    canonicalLbugPath,
+    canonicalMetaDir,
+    stageRoot,
+    stagedLbugPath: path.join(stageRoot, 'lbug'),
+    stagedMetaDir: path.join(stageRoot, 'meta'),
+    stageManifestPath: path.join(stageRoot, 'manifest.json'),
+    backupLbugPath: `${canonicalLbugPath}.promotion-backup`,
+    journalPath: path.join(canonicalMetaDir, 'analyze-promotion.json'),
+  };
+};
+
+const processIsAlive = (pid: number): boolean => {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+};
+
+/** Serialize staged builders; a dead owner's lock is reclaimed on the next run. */
+export const withStagedAnalyzeLock = async <T>(
+  storagePath: string,
+  operation: () => Promise<T>,
+): Promise<T> => {
+  await fs.mkdir(storagePath, { recursive: true });
+  const lockPath = path.join(storagePath, 'analyze-staged.lock');
+  const record: StageLockRecord = {
+    schema: 'gitnexus.staged-analyze-lock/v1',
+    pid: process.pid,
+    nonce: randomBytes(16).toString('hex'),
+    startedAt: new Date().toISOString(),
+  };
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      handle = await fs.open(lockPath, 'wx', 0o600);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      const owner = await readJson<StageLockRecord>(lockPath);
+      if (owner?.schema === record.schema && processIsAlive(owner.pid)) {
+        throw new Error(
+          `Another staged analyze is active (pid ${owner.pid}, started ${owner.startedAt}).`,
+        );
+      }
+      if (attempt === 1) throw new Error('Could not reclaim the stale staged-analyze lock');
+      await fs.rm(lockPath, { force: true });
+    }
+  }
+  if (!handle) throw new Error('Could not acquire the staged-analyze lock');
+  try {
+    await handle.writeFile(`${JSON.stringify(record)}\n`, 'utf8');
+    await handle.sync();
+    return await operation();
+  } finally {
+    await handle.close().catch(() => {});
+    const current = await readJson<StageLockRecord>(lockPath).catch(() => undefined);
+    if (current?.nonce === record.nonce) await fs.rm(lockPath, { force: true });
+  }
+};
+
+/**
+ * Create or resume the isolated build workspace. Only the stage tree may be
+ * removed here, and only while a complete canonical generation is present.
+ */
+export const prepareStagedWorkspace = async (
+  paths: StagedAnalyzePaths,
+  canonicalMeta: RepoMeta | null,
+): Promise<{ resumed: boolean; generationId: string }> => {
+  if (await readJournal(paths)) {
+    throw new Error('A staged-promotion journal must be recovered before preparing another build');
+  }
+  if (await statRegularFile(paths.backupLbugPath)) {
+    throw new Error(
+      `Unjournaled promotion backup exists at ${paths.backupLbugPath}; refusing to overwrite it.`,
+    );
+  }
+
+  const canonicalDb = await statRegularFile(paths.canonicalLbugPath);
+  if ((canonicalMeta === null) !== (canonicalDb === undefined)) {
+    throw new Error(
+      'Canonical metadata/database presence disagrees; refusing staged analysis because the live generation cannot be proven complete.',
+    );
+  }
+  if (canonicalDb) await assertNoDbSidecars(paths.canonicalLbugPath, 'Canonical index');
+
+  const sourceMeta = canonicalMeta ? metaIdentity(canonicalMeta) : undefined;
+  const manifest = await readManifest(paths);
+  if (manifest) {
+    const sameSource =
+      identitiesEqual(manifest.sourceMeta, sourceMeta) &&
+      identitiesEqual(manifest.sourceDb, canonicalDb);
+    if (sameSource) {
+      const stagedDb = await statRegularFile(paths.stagedLbugPath);
+      const stagedMeta = await loadMeta(paths.stagedMetaDir);
+      if (canonicalDb && (!stagedDb || !stagedMeta)) {
+        throw new Error(
+          'The staged workspace manifest matches the canonical generation, but its DB or metadata is missing.',
+        );
+      }
+      return { resumed: true, generationId: manifest.generationId };
+    }
+    if (!canonicalDb || !canonicalMeta) {
+      throw new Error(
+        'A stale staged workspace exists but no complete canonical generation is available to replace it safely.',
+      );
+    }
+    await fs.rm(paths.stageRoot, { recursive: true, force: true });
+  } else {
+    try {
+      await fs.lstat(paths.stageRoot);
+      if (!canonicalDb || !canonicalMeta) {
+        throw new Error(
+          'An incomplete staged workspace exists and no complete canonical generation is available for safe cleanup.',
+        );
+      }
+      await fs.rm(paths.stageRoot, { recursive: true, force: true });
+    } catch (error) {
+      if (!isMissingFilesystemError(error)) throw error;
+    }
+  }
+
+  await fs.mkdir(paths.stagedMetaDir, { recursive: true });
+  if (canonicalDb && canonicalMeta) {
+    const tempDb = `${paths.stagedLbugPath}.copy-${randomBytes(8).toString('hex')}`;
+    await fs.copyFile(paths.canonicalLbugPath, tempDb);
+    const handle = await fs.open(tempDb, 'r');
+    try {
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await moveAndSync(tempDb, paths.stagedLbugPath);
+    await saveMeta(paths.stagedMetaDir, canonicalMeta);
+  }
+
+  const next: StageManifest = {
+    schema: STAGE_MANIFEST_SCHEMA,
+    generationId: randomBytes(16).toString('hex'),
+    createdAt: new Date().toISOString(),
+    sourceMeta,
+    sourceDb: canonicalDb,
+  };
+  await writeDurableJson(paths.stageManifestPath, next);
+  return { resumed: false, generationId: next.generationId };
+};
+
+export const discardStagedWorkspace = async (paths: StagedAnalyzePaths): Promise<void> => {
+  if (await readJournal(paths)) {
+    throw new Error('Cannot discard a staged workspace while promotion recovery is pending');
+  }
+  await fs.rm(paths.stageRoot, { recursive: true, force: true });
+};
+
+/** Validate the staged DB/meta pair before the first canonical rename. */
+export const validateStagedGeneration = async (paths: StagedAnalyzePaths): Promise<RepoMeta> => {
+  const manifest = await readManifest(paths);
+  if (!manifest) throw new Error('Staged generation has no durable manifest');
+  const db = await statRegularFile(paths.stagedLbugPath);
+  if (!db || db.size === 0) throw new Error('Staged generation has no non-empty LadybugDB file');
+  await assertNoDbSidecars(paths.stagedLbugPath, 'Staged index');
+  const meta = await loadMeta(paths.stagedMetaDir);
+  if (!meta) throw new Error('Staged generation has no readable metadata');
+  if (meta.incrementalInProgress || meta.embeddingCheckpoint) {
+    throw new Error('Staged generation still carries an incomplete write/checkpoint marker');
+  }
+  return meta;
+};
+
+/**
+ * Resume or execute the four-state promotion. Every destructive rename has a
+ * complete generation on the other side, and the old DB is retained until
+ * metadata plus registry commit succeeds.
+ */
+export const promoteStagedGeneration = async (
+  paths: StagedAnalyzePaths,
+  commitMetadataAndRegistry: (meta: RepoMeta) => Promise<string>,
+  hooks: PromotionHooks = {},
+): Promise<PromotionResult> => {
+  let journal = await readJournal(paths);
+  const recovered = journal !== undefined;
+  if (!journal) {
+    const meta = await validateStagedGeneration(paths);
+    const manifest = await readManifest(paths);
+    if (!manifest) throw new Error('Staged generation manifest disappeared during validation');
+    const canonicalDb = await statRegularFile(paths.canonicalLbugPath);
+    if (await statRegularFile(paths.backupLbugPath)) {
+      throw new Error('Cannot begin promotion while an unjournaled backup generation exists');
+    }
+    if (canonicalDb) await assertNoDbSidecars(paths.canonicalLbugPath, 'Canonical index');
+    journal = {
+      schema: PROMOTION_JOURNAL_SCHEMA,
+      generationId: manifest.generationId,
+      state: 'prepared',
+      updatedAt: new Date().toISOString(),
+      hadCanonical: canonicalDb !== undefined,
+      stagedMeta: metaIdentity(meta),
+      stagedDb: (await statRegularFile(paths.stagedLbugPath))!,
+      oldDb: canonicalDb,
+    };
+    await writeDurableJson(paths.journalPath, journal);
+    await hooks.afterBoundary?.('prepared');
+  }
+
+  if (journal.state === 'prepared') {
+    const canonical = await statRegularFile(paths.canonicalLbugPath);
+    const staged = await statRegularFile(paths.stagedLbugPath);
+    const backup = await statRegularFile(paths.backupLbugPath);
+    if (journal.hadCanonical) {
+      if (
+        canonical &&
+        staged &&
+        !backup &&
+        identitiesEqual(canonical, journal.oldDb) &&
+        identitiesEqual(staged, journal.stagedDb)
+      ) {
+        await moveAndSync(paths.canonicalLbugPath, paths.backupLbugPath);
+      } else if (
+        !canonical &&
+        staged &&
+        backup &&
+        identitiesEqual(staged, journal.stagedDb) &&
+        identitiesEqual(backup, journal.oldDb)
+      ) {
+        // Crash after the rename but before the journal transition.
+      } else if (
+        canonical &&
+        !staged &&
+        backup &&
+        identitiesEqual(canonical, journal.stagedDb) &&
+        identitiesEqual(backup, journal.oldDb)
+      ) {
+        journal = await updateJournal(paths, journal, 'new-installed');
+      } else {
+        throw new Error('Ambiguous prepared promotion artifacts; refusing to choose a generation');
+      }
+    } else if (!canonical && staged && !backup && identitiesEqual(staged, journal.stagedDb)) {
+      // First index: there is no old generation to back up.
+    } else if (canonical && !staged && !backup && identitiesEqual(canonical, journal.stagedDb)) {
+      journal = await updateJournal(paths, journal, 'new-installed');
+    } else {
+      throw new Error('Ambiguous first-generation promotion artifacts');
+    }
+    if (journal.state === 'prepared') {
+      journal = await updateJournal(paths, journal, 'old-backed-up');
+      await hooks.afterBoundary?.('old-backed-up');
+    }
+  }
+
+  if (journal.state === 'old-backed-up') {
+    const canonical = await statRegularFile(paths.canonicalLbugPath);
+    const staged = await statRegularFile(paths.stagedLbugPath);
+    const backup = await statRegularFile(paths.backupLbugPath);
+    if (
+      !canonical &&
+      staged &&
+      identitiesEqual(staged, journal.stagedDb) &&
+      (!journal.hadCanonical || identitiesEqual(backup, journal.oldDb))
+    ) {
+      await moveAndSync(paths.stagedLbugPath, paths.canonicalLbugPath);
+    } else if (canonical && !staged && identitiesEqual(canonical, journal.stagedDb)) {
+      // Crash after install but before the journal transition.
+    } else if (
+      !canonical &&
+      !staged &&
+      backup &&
+      journal.hadCanonical &&
+      identitiesEqual(backup, journal.oldDb)
+    ) {
+      await moveAndSync(paths.backupLbugPath, paths.canonicalLbugPath);
+      throw new Error('Staged generation is missing; restored the canonical backup instead');
+    } else {
+      throw new Error(
+        'Ambiguous old-backed-up promotion artifacts; refusing to delete or overwrite',
+      );
+    }
+    journal = await updateJournal(paths, journal, 'new-installed');
+    await hooks.afterBoundary?.('new-installed');
+  }
+
+  if (journal.state === 'new-installed') {
+    const canonical = await statRegularFile(paths.canonicalLbugPath);
+    const staged = await statRegularFile(paths.stagedLbugPath);
+    if (!canonical || !identitiesEqual(canonical, journal.stagedDb)) {
+      const backup = await statRegularFile(paths.backupLbugPath);
+      if (backup && journal.hadCanonical && identitiesEqual(backup, journal.oldDb)) {
+        await moveAndSync(paths.backupLbugPath, paths.canonicalLbugPath);
+      }
+      throw new Error(
+        'Installed generation is missing or has the wrong identity; restored the backup when available',
+      );
+    }
+    if (staged) throw new Error('Both staged and installed DB files exist after promotion');
+    const stagedMeta = await loadMeta(paths.stagedMetaDir);
+    if (!stagedMeta || !identitiesEqual(metaIdentity(stagedMeta), journal.stagedMeta)) {
+      throw new Error('Staged metadata identity changed after promotion was prepared');
+    }
+    const projectName = await commitMetadataAndRegistry(stagedMeta);
+    journal = await updateJournal(paths, journal, 'metadata/registry-committed', projectName);
+    await hooks.afterBoundary?.('metadata/registry-committed');
+  }
+
+  if (journal.state !== 'metadata/registry-committed') {
+    throw new Error(`Unsupported promotion state: ${journal.state}`);
+  }
+  const committedCanonical = await statRegularFile(paths.canonicalLbugPath);
+  if (!committedCanonical || !identitiesEqual(committedCanonical, journal.stagedDb)) {
+    throw new Error(
+      'Cannot clean promotion artifacts because the canonical DB is missing or has the wrong identity',
+    );
+  }
+  await fs.rm(paths.backupLbugPath, { force: true });
+  await fs.rm(paths.stageRoot, { recursive: true, force: true });
+  await fs.rm(paths.journalPath, { force: true });
+  await syncDirectory(paths.canonicalMetaDir);
+  return { projectName: journal.projectName, recovered };
+};
+
+export const hasPendingPromotion = async (paths: StagedAnalyzePaths): Promise<boolean> =>
+  (await readJournal(paths)) !== undefined;

--- a/gitnexus/src/core/staged-promotion.ts
+++ b/gitnexus/src/core/staged-promotion.ts
@@ -535,6 +535,7 @@ class PromotionSourceChangedError extends Error {
   constructor(
     readonly kind: 'metadata' | 'database' | 'repository',
     message: string,
+    readonly metadataState?: 'source' | 'staged',
   ) {
     super(message);
     this.name = 'PromotionSourceChangedError';
@@ -546,21 +547,30 @@ const assertPromotionSourceUnchanged = async (
   source: CapturedPromotionSource,
   hooks: PromotionHooks,
   allowOldDbInBackup: boolean,
-): Promise<void> => {
+  allowedStagedMeta?: RepoMeta,
+): Promise<'source' | 'staged'> => {
   const canonicalMeta = await loadMeta(paths.canonicalMetaDir);
   const currentMeta = canonicalMeta ? metaIdentity(canonicalMeta) : undefined;
-  if (!identitiesEqual(currentMeta, source.sourceMeta)) {
+  const metadataState =
+    allowedStagedMeta && identitiesEqual(canonicalMeta, allowedStagedMeta)
+      ? 'staged'
+      : identitiesEqual(currentMeta, source.sourceMeta)
+        ? 'source'
+        : undefined;
+  if (!metadataState) {
     throw new PromotionSourceChangedError(
       'metadata',
       'Staged promotion refused: canonical metadata changed after the stage source was captured.',
     );
   }
-  const currentMetaFiles = await statMetadataFiles(paths.canonicalMetaDir);
-  if (!identitiesEqual(currentMetaFiles, source.sourceMetaFiles)) {
-    throw new PromotionSourceChangedError(
-      'metadata',
-      'Staged promotion refused: canonical metadata file identity changed after the stage source was captured.',
-    );
+  if (metadataState === 'source') {
+    const currentMetaFiles = await statMetadataFiles(paths.canonicalMetaDir);
+    if (!identitiesEqual(currentMetaFiles, source.sourceMetaFiles)) {
+      throw new PromotionSourceChangedError(
+        'metadata',
+        'Staged promotion refused: canonical metadata file identity changed after the stage source was captured.',
+      );
+    }
   }
 
   const canonicalDb = await statRegularFile(paths.canonicalLbugPath);
@@ -583,9 +593,11 @@ const assertPromotionSourceUnchanged = async (
       throw new PromotionSourceChangedError(
         'repository',
         'Staged promotion refused: repository HEAD or branch changed while the staged generation was building.',
+        metadataState,
       );
     }
   }
+  return metadataState;
 };
 
 const rollbackPromotionForRepositoryChange = async (
@@ -691,6 +703,16 @@ export const promoteStagedGeneration = async (
     // guards. Preserve their artifact-identity recovery semantics; every new
     // journal records and enforces the stronger source identity below.
     if (!journal.sourceMetaFiles || !journal.sourceRepo) return;
+    let allowedStagedMeta: RepoMeta | undefined;
+    if (journal.state === 'new-installed') {
+      allowedStagedMeta = await loadMeta(paths.stagedMetaDir);
+      if (
+        !allowedStagedMeta ||
+        !identitiesEqual(metaIdentity(allowedStagedMeta), journal.stagedMeta)
+      ) {
+        throw new Error('Staged metadata identity changed after promotion was prepared');
+      }
+    }
     try {
       await assertPromotionSourceUnchanged(
         paths,
@@ -704,9 +726,14 @@ export const promoteStagedGeneration = async (
         },
         hooks,
         true,
+        allowedStagedMeta,
       );
     } catch (error) {
-      if (error instanceof PromotionSourceChangedError && error.kind === 'repository') {
+      if (
+        error instanceof PromotionSourceChangedError &&
+        error.kind === 'repository' &&
+        error.metadataState !== 'staged'
+      ) {
         await rollbackPromotionForRepositoryChange(paths, journal);
       }
       throw error;

--- a/gitnexus/src/core/staged-promotion.ts
+++ b/gitnexus/src/core/staged-promotion.ts
@@ -575,11 +575,15 @@ const assertPromotionSourceUnchanged = async (
 
   const canonicalDb = await statRegularFile(paths.canonicalLbugPath);
   const backupDb = allowOldDbInBackup ? await statRegularFile(paths.backupLbugPath) : undefined;
-  const dbMatches = source.hadCanonical
-    ? identitiesEqual(canonicalDb, source.sourceDb) || identitiesEqual(backupDb, source.sourceDb)
-    : source.sourceDb === undefined &&
-      (canonicalDb === undefined ||
-        (allowOldDbInBackup && identitiesEqual(canonicalDb, source.stagedDb)));
+  const dbMatches =
+    metadataState === 'staged'
+      ? identitiesEqual(canonicalDb, source.stagedDb)
+      : source.hadCanonical
+        ? identitiesEqual(canonicalDb, source.sourceDb) ||
+          identitiesEqual(backupDb, source.sourceDb)
+        : source.sourceDb === undefined &&
+          (canonicalDb === undefined ||
+            (allowOldDbInBackup && identitiesEqual(canonicalDb, source.stagedDb)));
   if (!dbMatches) {
     throw new PromotionSourceChangedError(
       'database',
@@ -587,7 +591,10 @@ const assertPromotionSourceUnchanged = async (
     );
   }
 
-  if (hooks.readRepositoryIdentity) {
+  // Once the exact staged DB/meta pair is canonical, source HEAD movement no
+  // longer invalidates that installed generation. Registration is the only
+  // unfinished idempotent step and must be allowed to complete.
+  if (hooks.readRepositoryIdentity && metadataState === 'source') {
     const currentRepo = await hooks.readRepositoryIdentity();
     if (!identitiesEqual(currentRepo, source.sourceRepo)) {
       throw new PromotionSourceChangedError(

--- a/gitnexus/test/integration/large-embedding-bounds.test.ts
+++ b/gitnexus/test/integration/large-embedding-bounds.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { embedBatchMock, createVectorIndexMock } = vi.hoisted(() => ({
+  embedBatchMock: vi.fn(),
+  createVectorIndexMock: vi.fn(async () => true),
+}));
+
+vi.mock('../../src/core/embeddings/embedder.js', () => ({
+  initEmbedder: vi.fn(async () => undefined),
+  embedBatch: embedBatchMock,
+  embedText: vi.fn(async () => new Float32Array(2_048)),
+  embeddingToArray: (embedding: Float32Array) => Array.from(embedding),
+  isEmbedderReady: vi.fn(() => true),
+}));
+
+vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
+  loadVectorExtension: vi.fn(async () => true),
+  createVectorIndex: createVectorIndexMock,
+}));
+
+import { runEmbeddingPipeline } from '../../src/core/embeddings/embedding-pipeline.js';
+
+const NODE_COUNT = 25_000;
+const PAGE_SIZE = 512;
+
+const idFor = (index: number): string =>
+  `Function:node-${String(index).padStart(5, '0')}:src/generated.ts`;
+
+const rowFor = (index: number) => ({
+  id: idFor(index),
+  name: `node${index}`,
+  label: 'Function',
+  filePath: 'src/generated.ts',
+  content: `function node${index}() { return ${index}; }`,
+  startLine: index + 1,
+  endLine: index + 1,
+});
+
+describe('25k x 2,048 bounded embedding integration', () => {
+  beforeEach(() => {
+    embedBatchMock
+      .mockReset()
+      .mockImplementation(async (texts: string[]) => texts.map(() => new Float32Array(2_048)));
+    createVectorIndexMock.mockClear();
+  });
+
+  it('holds node pages at 512, checkpoint windows at 5,000, and vectors at 8', async () => {
+    const queryPageSizes: number[] = [];
+    const identityPageSizes: number[] = [];
+    const checkpointWindowSizes: number[] = [];
+    let inserted = 0;
+    let maxInsertBatch = 0;
+    let maxHeapUsed = process.memoryUsage().heapUsed;
+    const startHeapUsed = maxHeapUsed;
+
+    const executeQuery = vi.fn(async (cypher: string) => {
+      maxHeapUsed = Math.max(maxHeapUsed, process.memoryUsage().heapUsed);
+      if (!cypher.includes('MATCH (n:`Function`)')) return [];
+      const inMatch = cypher.match(/WHERE n\.id IN \[(.*?)\] RETURN/s);
+      if (inMatch) {
+        const ids = [...inMatch[1].matchAll(/'([^']+)'/g)].map((match) => match[1]);
+        queryPageSizes.push(ids.length);
+        return ids.map((id) => rowFor(Number(id.match(/node-(\d+)/)?.[1] ?? -1)));
+      }
+      const afterIndex = Number(cypher.match(/WHERE n\.id > 'Function:node-(\d+)/)?.[1] ?? -1);
+      const start = afterIndex >= 0 ? afterIndex + 1 : 0;
+      const size = Math.min(PAGE_SIZE, NODE_COUNT - start);
+      queryPageSizes.push(Math.max(0, size));
+      return Array.from({ length: Math.max(0, size) }, (_, offset) => rowFor(start + offset));
+    });
+
+    const executeWithReusedStatement = vi.fn(async (cypher: string, params: unknown[]) => {
+      maxHeapUsed = Math.max(maxHeapUsed, process.memoryUsage().heapUsed);
+      if (!cypher.includes('CREATE')) return;
+      inserted += params.length;
+      maxInsertBatch = Math.max(maxInsertBatch, params.length);
+      for (const param of params as Array<{ embedding: number[] }>) {
+        expect(param.embedding).toHaveLength(2_048);
+      }
+    });
+
+    const result = await runEmbeddingPipeline(
+      executeQuery,
+      executeWithReusedStatement,
+      () => {},
+      { batchSize: 64, subBatchSize: 64 },
+      undefined,
+      undefined,
+      {
+        loadExistingEmbeddingHashes: async (nodeIds) => {
+          identityPageSizes.push(nodeIds.length);
+          return new Map();
+        },
+        onCheckpointWindowStart: async ({ nodeIds }) => {
+          checkpointWindowSizes.push(nodeIds.length);
+        },
+      },
+    );
+
+    expect(result.nodesProcessed).toBe(NODE_COUNT);
+    expect(inserted).toBe(NODE_COUNT);
+    expect(checkpointWindowSizes).toEqual([5_000, 5_000, 5_000, 5_000, 5_000]);
+    expect(Math.max(...queryPageSizes)).toBeLessThanOrEqual(PAGE_SIZE);
+    expect(Math.max(...identityPageSizes)).toBeLessThanOrEqual(PAGE_SIZE);
+    expect(Math.max(...embedBatchMock.mock.calls.map(([texts]) => texts.length))).toBe(8);
+    expect(maxInsertBatch).toBe(8);
+    expect(maxHeapUsed - startHeapUsed).toBeLessThan(512 * 1024 * 1024);
+  });
+});

--- a/gitnexus/test/integration/lbug-conn-serialization.test.ts
+++ b/gitnexus/test/integration/lbug-conn-serialization.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { withTestLbugDB } from '../helpers/test-indexed-db.js';
-import { NODE_TABLES } from '../../src/core/lbug/schema.js';
+import { EMBEDDING_DIMS, NODE_TABLES } from '../../src/core/lbug/schema.js';
 
 // Spy `withConnLock` while preserving its real behavior (call-through). The
 // adapter imports this module, so the spy observes every lock acquisition.
@@ -91,6 +91,46 @@ withTestLbugDB('conn-serialization', () => {
       expect(lockSpy).toHaveBeenCalled();
       expect(cached.embeddings).toEqual([]);
       expect(cached.embeddingNodeIds.size).toBe(0);
+    });
+
+    it('streams cached vectors in bounded batches and propagates sink failures', async () => {
+      const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+      const vector = Array.from({ length: EMBEDDING_DIMS }, () => 0.25);
+      await adapter.executeWithReusedStatement(
+        'CREATE (e:CodeEmbedding {id: $id, nodeId: $nodeId, chunkIndex: $chunkIndex, startLine: $startLine, endLine: $endLine, embedding: $embedding, contentHash: $contentHash})',
+        [0, 1, 2].map((index) => ({
+          id: `stream-node:${index}`,
+          nodeId: `stream-node-${index}`,
+          chunkIndex: 0,
+          startLine: 1,
+          endLine: 1,
+          embedding: vector,
+          contentHash: `hash-${index}`,
+        })),
+      );
+      lockSpy.mockClear();
+
+      const sizes: number[] = [];
+      const cached = await adapter.loadCachedEmbeddings({
+        batchSize: 2,
+        onBatch: async (batch) => sizes.push(batch.length),
+      });
+      expect(lockSpy).toHaveBeenCalled();
+      expect(sizes).toEqual([2, 1]);
+      expect(cached.embeddings).toEqual([]);
+      expect(cached.embeddingNodeIds.size).toBe(0);
+
+      await expect(
+        adapter.loadCachedEmbeddings({
+          batchSize: 1,
+          onBatch: async () => {
+            throw new Error('snapshot sink failed');
+          },
+        }),
+      ).rejects.toThrow('snapshot sink failed');
+      await adapter.executeQuery(
+        "MATCH (e:CodeEmbedding) WHERE e.nodeId STARTS WITH 'stream-node-' DELETE e",
+      );
     });
 
     it('U4: deleteAllInterprocTaintPaths routes through withConnLock', async () => {

--- a/gitnexus/test/unit/analyze-heap-respawn.test.ts
+++ b/gitnexus/test/unit/analyze-heap-respawn.test.ts
@@ -15,8 +15,8 @@ vi.mock('v8', () => ({
   },
 }));
 
-// Pin physical RAM to 16GB so the RAM-aware auto-cap (0.75 x RAM, clamped
-// >= 16384) resolves deterministically to 16384 regardless of the host machine.
+// Pin physical RAM to 16GB so the bounded auto-cap resolves deterministically
+// to its 6144MB ceiling regardless of the host machine.
 vi.mock('os', async () => {
   const actual = await vi.importActual<typeof import('os')>('os');
   const mocked = { ...actual, totalmem: () => 16 * 1024 * 1024 * 1024 };
@@ -103,7 +103,7 @@ describe('analyzeCommand heap respawn', () => {
     else process.env.NODE_OPTIONS = initialNodeOptions;
   });
 
-  it('re-execs analyze with the auto-sized heap cap (16GB-clamped) + larger semi-space and bridges progress redraw when parent is a TTY', async () => {
+  it('re-execs analyze with the bounded heap cap + larger semi-space and bridges progress redraw when parent is a TTY', async () => {
     delete process.env.NODE_OPTIONS;
     restoreStderrIsTTY = setStreamIsTTY(process.stderr, true);
     getHeapStatisticsMock.mockReturnValue({ heap_size_limit: 512 * 1024 * 1024 });
@@ -114,9 +114,9 @@ describe('analyzeCommand heap respawn', () => {
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args, opts] = spawnMock.mock.calls[0];
-    expect(args).toContain('--max-old-space-size=16384');
+    expect(args).toContain('--max-old-space-size=6144');
     expect(args).toContain('--max-semi-space-size=128');
-    expect(opts.env.NODE_OPTIONS).toContain('--max-old-space-size=16384');
+    expect(opts.env.NODE_OPTIONS).toContain('--max-old-space-size=6144');
     expect(opts.env.NODE_OPTIONS).toContain('--max-semi-space-size=128');
     expect(opts.env.GITNEXUS_RESPAWN_PROGRESS_TTY).toBe('1');
   });
@@ -146,6 +146,16 @@ describe('analyzeCommand heap respawn', () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  it('honors the underscore spelling of an explicit NODE_OPTIONS heap cap', async () => {
+    process.env.NODE_OPTIONS = '--max_old_space_size=4096';
+    getHeapStatisticsMock.mockReturnValue({ heap_size_limit: 512 * 1024 * 1024 });
+
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+    await analyzeCommand('/__gitnexus_nonexistent__', {});
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it('prints heap guidance when respawned analyze exits with likely OOM', async () => {
     delete process.env.NODE_OPTIONS;
     getHeapStatisticsMock.mockReturnValue({ heap_size_limit: 512 * 1024 * 1024 });
@@ -164,7 +174,7 @@ describe('analyzeCommand heap respawn', () => {
       .find((r) => r.msg.includes('Analysis likely ran out of memory'));
     expect(oomGuidance).toBeDefined();
     const msg = oomGuidance?.msg ?? '';
-    expect(msg).toContain('auto-sized to 16384MB');
+    expect(msg).toContain('auto-sized to 6144MB');
     expect(msg).toContain('NODE_OPTIONS="--max-old-space-size=<MB>"');
     expect(msg).toContain('[your-args]');
     expect(msg).toContain('native crash unrelated to heap size');
@@ -283,33 +293,35 @@ describe('analyzeCommand heap respawn', () => {
 describe('computeHeapCapMb (RAM-aware auto heap cap)', () => {
   const GB = 1024 * 1024 * 1024;
 
-  it('sizes to 0.75x physical RAM when unconstrained', async () => {
+  it('clamps half of large physical RAM to 6144MB', async () => {
     const { computeHeapCapMb } = await import('../../src/cli/analyze.js');
-    // 31GB -> 31744MB -> floor(0.75 * 31744) = 23808
-    expect(computeHeapCapMb(31 * GB, null)).toBe(23808);
+    expect(computeHeapCapMb(31 * GB, null)).toBe(6144);
   });
 
-  it('clamps to the 16384 floor on small boxes', async () => {
+  it('uses half of effective RAM inside the clamp range', async () => {
     const { computeHeapCapMb } = await import('../../src/cli/analyze.js');
-    // 8GB -> 0.75 * 8192 = 6144 -> clamped to 16384
-    expect(computeHeapCapMb(8 * GB, null)).toBe(16384);
+    expect(computeHeapCapMb(8 * GB, null)).toBe(4096);
+  });
+
+  it('clamps small effective memory to the 2048MB floor', async () => {
+    const { computeHeapCapMb } = await import('../../src/cli/analyze.js');
+    expect(computeHeapCapMb(2 * GB, null)).toBe(2048);
+    expect(computeHeapCapMb(8 * GB, 1 * GB)).toBe(2048);
   });
 
   it('ignores the unconstrained sentinel from constrainedMemory()', async () => {
     const { computeHeapCapMb } = await import('../../src/cli/analyze.js');
     // ~1.8e19 sentinel > totalmem -> ignored, uses physical RAM
-    expect(computeHeapCapMb(31 * GB, 1.8e19)).toBe(23808);
+    expect(computeHeapCapMb(31 * GB, 1.8e19)).toBe(6144);
   });
 
   it('honors a real cgroup cap smaller than physical RAM', async () => {
     const { computeHeapCapMb } = await import('../../src/cli/analyze.js');
-    // min(31, 12) = 12GB -> 0.75 * 12288 = 9216 -> clamped to 16384
-    expect(computeHeapCapMb(31 * GB, 12 * GB)).toBe(16384);
+    expect(computeHeapCapMb(31 * GB, 12 * GB)).toBe(6144);
   });
 
   it('uses a large cgroup cap when it exceeds the floor', async () => {
     const { computeHeapCapMb } = await import('../../src/cli/analyze.js');
-    // 48GB cap on a 64GB box -> floor(0.75 * 49152) = 36864
-    expect(computeHeapCapMb(64 * GB, 48 * GB)).toBe(36864);
+    expect(computeHeapCapMb(64 * GB, 48 * GB)).toBe(6144);
   });
 });

--- a/gitnexus/test/unit/analyze-no-stats-bridge.test.ts
+++ b/gitnexus/test/unit/analyze-no-stats-bridge.test.ts
@@ -137,6 +137,14 @@ describe('analyzeCommand commander → runFullAnalysis noStats bridge (#1477)', 
     expect(opts.incrementalOnly).toBe(true);
   });
 
+  it('passes --staged through to runFullAnalysis', async () => {
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+
+    await analyzeCommand(undefined, { staged: true });
+
+    expect(runFullAnalysisMock.mock.calls[0][1].staged).toBe(true);
+  });
+
   it('rejects combining --repair-fts with --force', async () => {
     const { analyzeCommand } = await import('../../src/cli/analyze.js');
 

--- a/gitnexus/test/unit/analyze-resource-log.test.ts
+++ b/gitnexus/test/unit/analyze-resource-log.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { createAnalyzeResourceLogger } from '../../src/cli/analyze-resource-log.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe('analyze resource JSONL', () => {
+  it('emits only the fixed schema, restricted phase tokens, and numeric counters', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-resource-log-'));
+    tempDirs.push(dir);
+    const logPath = path.join(dir, 'nested', 'resource.jsonl');
+    const logger = await createAnalyzeResourceLogger(logPath);
+    if (!logger) throw new Error('expected resource logger');
+
+    await logger.emit('start', 'initializing', -10);
+    await logger.emit('progress', '/private/repo?token=secret', 200);
+    await logger.emit('complete', 'done', 100);
+    await logger.close();
+
+    const records = (await fs.readFile(logPath, 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toHaveLength(3);
+    expect(records[0]).toMatchObject({
+      schema: 'gitnexus.analyze-resource/v1',
+      event: 'start',
+      phase: 'initializing',
+      percent: 0,
+    });
+    expect(records[1]).toMatchObject({ event: 'progress', percent: 100 });
+    expect(records[1]).not.toHaveProperty('phase');
+    expect(records[2]).toMatchObject({ event: 'complete', phase: 'done', percent: 100 });
+    for (const record of records) {
+      expect(Object.keys(record).sort()).toEqual(
+        expect.arrayContaining([
+          'arrayBuffersMiB',
+          'at',
+          'event',
+          'externalMiB',
+          'heapTotalMiB',
+          'heapUsedMiB',
+          'pid',
+          'rssMiB',
+          'schema',
+          'systemFreeMiB',
+          'systemTotalMiB',
+        ]),
+      );
+      expect(JSON.stringify(record)).not.toContain('secret');
+      expect(JSON.stringify(record)).not.toContain('/private/repo');
+    }
+    expect((await fs.stat(logPath)).mode & 0o777).toBe(0o600);
+  });
+
+  it('serializes concurrent events and closes idempotently', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-resource-log-'));
+    tempDirs.push(dir);
+    const logPath = path.join(dir, 'resource.jsonl');
+    const logger = await createAnalyzeResourceLogger(logPath);
+    if (!logger) throw new Error('expected resource logger');
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) => logger.emit('progress', 'parse', index)),
+    );
+    await logger.close();
+    await logger.close();
+    const lines = (await fs.readFile(logPath, 'utf8')).trim().split('\n');
+    expect(lines).toHaveLength(20);
+    expect(lines.map((line) => JSON.parse(line).percent)).toEqual(
+      Array.from({ length: 20 }, (_, index) => index),
+    );
+  });
+});

--- a/gitnexus/test/unit/analyze-resource-log.test.ts
+++ b/gitnexus/test/unit/analyze-resource-log.test.ts
@@ -77,4 +77,29 @@ describe('analyze resource JSONL', () => {
       Array.from({ length: 20 }, (_, index) => index),
     );
   });
+
+  it('tightens an existing regular log file to mode 0600', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-resource-log-'));
+    tempDirs.push(dir);
+    const logPath = path.join(dir, 'resource.jsonl');
+    await fs.writeFile(logPath, '');
+    await fs.chmod(logPath, 0o644);
+
+    const logger = await createAnalyzeResourceLogger(logPath);
+    await logger?.close();
+
+    expect((await fs.stat(logPath)).mode & 0o777).toBe(0o600);
+  });
+
+  it.runIf(process.platform !== 'win32')('refuses a symlink log target', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-resource-log-'));
+    tempDirs.push(dir);
+    const target = path.join(dir, 'target.jsonl');
+    const link = path.join(dir, 'resource.jsonl');
+    await fs.writeFile(target, '');
+    await fs.symlink(target, link);
+
+    await expect(createAnalyzeResourceLogger(link)).rejects.toThrow('non-symlink');
+    expect(await fs.readFile(target, 'utf8')).toBe('');
+  });
 });

--- a/gitnexus/test/unit/analyze-sigterm.test.ts
+++ b/gitnexus/test/unit/analyze-sigterm.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 
 const { runFullAnalysisMock, boundedCheckpointMock } = vi.hoisted(() => ({
   runFullAnalysisMock: vi.fn(),
@@ -37,6 +40,7 @@ vi.mock('../../src/cli/ai-context.js', () => ({
 describe('analyze SIGTERM checkpoint shutdown', () => {
   let savedNodeOptions: string | undefined;
   let savedResourceLog: string | undefined;
+  const tempDirs: string[] = [];
 
   beforeEach(() => {
     vi.resetModules();
@@ -55,6 +59,9 @@ describe('analyze SIGTERM checkpoint shutdown', () => {
     if (savedResourceLog === undefined) delete process.env.GITNEXUS_ANALYZE_RESOURCE_LOG;
     else process.env.GITNEXUS_ANALYZE_RESOURCE_LOG = savedResourceLog;
     process.exitCode = undefined;
+    return Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    ).then(() => undefined);
   });
 
   it('routes SIGTERM through the bounded checkpoint helper with exit code 143', async () => {
@@ -87,5 +94,28 @@ describe('analyze SIGTERM checkpoint shutdown', () => {
     });
     await running;
     expect(process.listeners('SIGTERM')).not.toContain(listener);
+  });
+
+  it('warns and continues when resource-log setup rejects a non-file target', async () => {
+    const logDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-resource-setup-'));
+    tempDirs.push(logDirectory);
+    process.env.GITNEXUS_ANALYZE_RESOURCE_LOG = logDirectory;
+    runFullAnalysisMock.mockResolvedValue({
+      repoName: 'repo',
+      repoPath: '/repo',
+      stats: {},
+      alreadyUpToDate: true,
+    });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const { analyzeCommand } = await import('../../src/cli/analyze.js');
+      await expect(analyzeCommand(undefined, {})).resolves.toBeUndefined();
+      expect(runFullAnalysisMock).toHaveBeenCalledTimes(1);
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('resource logging failed; analysis will continue'),
+      );
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });

--- a/gitnexus/test/unit/analyze-sigterm.test.ts
+++ b/gitnexus/test/unit/analyze-sigterm.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { runFullAnalysisMock, boundedCheckpointMock } = vi.hoisted(() => ({
+  runFullAnalysisMock: vi.fn(),
+  boundedCheckpointMock: vi.fn(),
+}));
+
+vi.mock('../../src/core/run-analyze.js', () => ({ runFullAnalysis: runFullAnalysisMock }));
+vi.mock('../../src/core/lbug/shutdown-helpers.js', () => ({
+  boundedCheckpointBeforeExit: boundedCheckpointMock,
+}));
+vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
+  closeLbug: vi.fn(async () => undefined),
+  closeLbugBeforeExit: vi.fn(async () => undefined),
+  isLbugReady: vi.fn(() => false),
+  LbugWipeError: class LbugWipeError extends Error {},
+}));
+vi.mock('../../src/storage/repo-manager.js', () => ({
+  getStoragePaths: vi.fn(() => ({ storagePath: '.gitnexus', lbugPath: '.gitnexus/lbug' })),
+  getGlobalRegistryPath: vi.fn(() => 'registry.json'),
+  RegistryNameCollisionError: class RegistryNameCollisionError extends Error {},
+  AnalysisNotFinalizedError: class AnalysisNotFinalizedError extends Error {},
+  assertAnalysisFinalized: vi.fn(async () => undefined),
+}));
+vi.mock('../../src/storage/git.js', () => ({
+  getGitRoot: vi.fn(() => '/repo'),
+  hasGitDir: vi.fn(() => true),
+  getDefaultBranch: vi.fn(() => null),
+}));
+vi.mock('../../src/core/ingestion/utils/max-file-size.js', () => ({
+  getMaxFileSizeBannerMessage: vi.fn(() => null),
+}));
+vi.mock('../../src/cli/ai-context.js', () => ({
+  refreshBaseRefLine: vi.fn(async () => ({ files: [] })),
+}));
+
+describe('analyze SIGTERM checkpoint shutdown', () => {
+  let savedNodeOptions: string | undefined;
+  let savedResourceLog: string | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    runFullAnalysisMock.mockReset();
+    boundedCheckpointMock.mockReset();
+    savedNodeOptions = process.env.NODE_OPTIONS;
+    savedResourceLog = process.env.GITNEXUS_ANALYZE_RESOURCE_LOG;
+    process.env.NODE_OPTIONS = '--max-old-space-size=4096';
+    delete process.env.GITNEXUS_ANALYZE_RESOURCE_LOG;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    if (savedNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+    else process.env.NODE_OPTIONS = savedNodeOptions;
+    if (savedResourceLog === undefined) delete process.env.GITNEXUS_ANALYZE_RESOURCE_LOG;
+    else process.env.GITNEXUS_ANALYZE_RESOURCE_LOG = savedResourceLog;
+    process.exitCode = undefined;
+  });
+
+  it('routes SIGTERM through the bounded checkpoint helper with exit code 143', async () => {
+    let finishAnalysis!: (value: unknown) => void;
+    runFullAnalysisMock.mockReturnValue(
+      new Promise((resolve) => {
+        finishAnalysis = resolve;
+      }),
+    );
+    boundedCheckpointMock.mockImplementation(async (options) => {
+      await options.beforeExit?.();
+    });
+    const baseline = new Set(process.listeners('SIGTERM'));
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+    const running = analyzeCommand(undefined, {});
+    await vi.waitFor(() => expect(runFullAnalysisMock).toHaveBeenCalledTimes(1));
+    const listener = process.listeners('SIGTERM').find((candidate) => !baseline.has(candidate));
+    expect(listener).toBeDefined();
+
+    listener?.('SIGTERM');
+    await vi.waitFor(() => expect(boundedCheckpointMock).toHaveBeenCalledTimes(1));
+    expect(boundedCheckpointMock.mock.calls[0][0]).toMatchObject({ exitCode: 143 });
+    expect(typeof boundedCheckpointMock.mock.calls[0][0].beforeExit).toBe('function');
+
+    finishAnalysis({
+      repoName: 'repo',
+      repoPath: '/repo',
+      stats: {},
+      alreadyUpToDate: true,
+    });
+    await running;
+    expect(process.listeners('SIGTERM')).not.toContain(listener);
+  });
+});

--- a/gitnexus/test/unit/cli-index-help.test.ts
+++ b/gitnexus/test/unit/cli-index-help.test.ts
@@ -274,6 +274,7 @@ describe('CLI help surface', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('--repair-fts');
     expect(result.stdout).toContain('--incremental-only');
+    expect(result.stdout).toContain('--staged');
   });
 
   it('doctor help includes the read-only recovery plan option', () => {

--- a/gitnexus/test/unit/embedding-cache-snapshot.test.ts
+++ b/gitnexus/test/unit/embedding-cache-snapshot.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  createEmbeddingSnapshot,
+  readEmbeddingSnapshot,
+  validateEmbeddingSnapshot,
+} from '../../src/core/embeddings/cache-snapshot.js';
+import type { CachedEmbedding } from '../../src/core/embeddings/types.js';
+
+const tempDirs: string[] = [];
+
+const makeRows = (count: number): CachedEmbedding[] =>
+  Array.from({ length: count }, (_, index) => ({
+    nodeId: `node-${index}`,
+    chunkIndex: 0,
+    startLine: index + 1,
+    endLine: index + 1,
+    embedding: [index, index + 0.25, index + 0.5, index + 0.75],
+    contentHash: `hash-${index}`,
+  }));
+
+const makePath = async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-embedding-snapshot-'));
+  tempDirs.push(dir);
+  return path.join(dir, 'snapshot.jsonl');
+};
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe('bounded embedding preservation snapshot', () => {
+  it('streams 600 vectors through batches of at most 256', async () => {
+    const snapshotPath = await makePath();
+    const rows = makeRows(600);
+    const source = { lastCommit: 'abc', indexedAt: '2026-07-20T00:00:00.000Z' };
+    await createEmbeddingSnapshot(snapshotPath, source, async (emit) => {
+      await emit(rows.slice(0, 256));
+      await emit(rows.slice(256, 512));
+      await emit(rows.slice(512));
+    });
+
+    await expect(validateEmbeddingSnapshot(snapshotPath, source, 600)).resolves.toEqual({
+      count: 600,
+      dimensions: 4,
+    });
+    const batchSizes: number[] = [];
+    const restored: CachedEmbedding[] = [];
+    await readEmbeddingSnapshot(snapshotPath, source, async (batch) => {
+      batchSizes.push(batch.length);
+      restored.push(...batch);
+    });
+    expect(batchSizes).toEqual([256, 256, 88]);
+    expect(restored).toHaveLength(600);
+    expect(restored[599]).toMatchObject({ nodeId: 'node-599', contentHash: 'hash-599' });
+    expect(restored[599].embedding).toEqual(rows[599].embedding);
+  });
+
+  it('rejects tampering before invoking the restore callback', async () => {
+    const snapshotPath = await makePath();
+    const source = { lastCommit: 'abc', indexedAt: '2026-07-20T00:00:00.000Z' };
+    await createEmbeddingSnapshot(snapshotPath, source, async (emit) => emit(makeRows(3)));
+    const raw = await fs.readFile(snapshotPath, 'utf8');
+    await fs.writeFile(snapshotPath, raw.replace('node-1', 'node-x'));
+    const onBatch = vi.fn();
+
+    await expect(validateEmbeddingSnapshot(snapshotPath, source)).resolves.toBeUndefined();
+    await expect(readEmbeddingSnapshot(snapshotPath, source, onBatch)).rejects.toThrow(
+      'failed validation',
+    );
+    expect(onBatch).not.toHaveBeenCalled();
+  });
+
+  it('binds a reusable snapshot to its source generation', async () => {
+    const snapshotPath = await makePath();
+    const source = { lastCommit: 'abc', indexedAt: '2026-07-20T00:00:00.000Z' };
+    await createEmbeddingSnapshot(snapshotPath, source, async (emit) => emit(makeRows(1)));
+
+    await expect(
+      validateEmbeddingSnapshot(snapshotPath, { ...source, lastCommit: 'different' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a producer batch above the 256-vector cap and removes its temp file', async () => {
+    const snapshotPath = await makePath();
+    await expect(
+      createEmbeddingSnapshot(snapshotPath, {}, async (emit) => emit(makeRows(257))),
+    ).rejects.toThrow('exceeds 256 vectors');
+    await expect(fs.access(snapshotPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(
+      (await fs.readdir(path.dirname(snapshotPath))).filter((name) => name.includes('.tmp-')),
+    ).toEqual([]);
+  });
+});

--- a/gitnexus/test/unit/embedding-pipeline.test.ts
+++ b/gitnexus/test/unit/embedding-pipeline.test.ts
@@ -779,6 +779,68 @@ describe('runEmbeddingPipeline incremental filter', () => {
     expect(checkpoints).toEqual([2, 3]);
   });
 
+  it('pages 5,001 nodes by 512, checkpoints exactly 5,000, and caps embed calls at 8', async () => {
+    mockEmbedderSetup();
+    const nodes = Array.from({ length: 5_001 }, (_, index) =>
+      makeNode({
+        id: `Function:node-${String(index).padStart(5, '0')}:src/main.ts`,
+        name: `node${index}`,
+        content: `function node${index}() { return ${index}; }`,
+      }),
+    );
+    const byId = new Map(nodes.map((node) => [node.id, node]));
+    const executeQuery = vi.fn(async (cypher: string) => {
+      queryCalls.push(cypher);
+      if (!cypher.includes('MATCH (n:`Function`)')) return [];
+      const inMatch = cypher.match(/WHERE n\.id IN \[(.*?)\] RETURN/s);
+      if (inMatch) {
+        const ids = [...inMatch[1].matchAll(/'([^']+)'/g)].map((match) => match[1]);
+        return ids.map((id) => byId.get(id)).filter(Boolean);
+      }
+      const afterId = cypher.match(/WHERE n\.id > '([^']+)'/)?.[1];
+      const start = afterId ? nodes.findIndex((node) => node.id > afterId) : 0;
+      if (start < 0) return [];
+      return nodes.slice(start, start + 512);
+    });
+    const executeWithReusedStatement = mockExecuteWithReusedStatement();
+    const identityPageSizes: number[] = [];
+    const checkpointWindowSizes: number[] = [];
+    const { runEmbeddingPipeline } =
+      await import('../../src/core/embeddings/embedding-pipeline.js');
+    const { embedBatch } = await import('../../src/core/embeddings/embedder.js');
+
+    const result = await runEmbeddingPipeline(
+      executeQuery,
+      executeWithReusedStatement,
+      onProgress,
+      { batchSize: 64, subBatchSize: 64 },
+      undefined,
+      undefined,
+      {
+        loadExistingEmbeddingHashes: async (nodeIds) => {
+          identityPageSizes.push(nodeIds.length);
+          return new Map();
+        },
+        onCheckpointWindowStart: async ({ nodeIds }) => {
+          checkpointWindowSizes.push(nodeIds.length);
+        },
+      },
+    );
+
+    expect(result.nodesProcessed).toBe(5_001);
+    expect(checkpointWindowSizes).toEqual([5_000, 1]);
+    expect(Math.max(...identityPageSizes)).toBeLessThanOrEqual(512);
+    expect(
+      executeQuery.mock.calls
+        .map(([cypher]) => cypher as string)
+        .filter((cypher) => cypher.includes('MATCH (n:'))
+        .every((cypher) => cypher.includes('LIMIT 512')),
+    ).toBe(true);
+    expect(Math.max(...vi.mocked(embedBatch).mock.calls.map(([texts]) => texts.length))).toBe(8);
+    const createCalls = stmtCalls.filter((call) => call.cypher.includes('CREATE'));
+    expect(Math.max(...createCalls.map((call) => call.params.length))).toBe(8);
+  });
+
   it('deletes pending-window rows whose node is no longer embeddable', async () => {
     mockEmbedderSetup();
     const live = makeNode({ id: 'Function:live:src/live.ts', name: 'live' });

--- a/gitnexus/test/unit/embedding-pipeline.test.ts
+++ b/gitnexus/test/unit/embedding-pipeline.test.ts
@@ -361,6 +361,67 @@ describe('runEmbeddingPipeline incremental filter', () => {
     expect(result.nodesProcessed).toBe(1);
   });
 
+  it('propagates unexpected symbol-query failures instead of building a partial index', async () => {
+    mockEmbedderSetup();
+
+    const executeQuery = vi.fn().mockRejectedValue(new Error('connection reset by peer'));
+    const executeWithReusedStatement = mockExecuteWithReusedStatement();
+
+    const { runEmbeddingPipeline } =
+      await import('../../src/core/embeddings/embedding-pipeline.js');
+
+    await expect(
+      runEmbeddingPipeline(executeQuery, executeWithReusedStatement, onProgress),
+    ).rejects.toThrow('connection reset by peer');
+    expect(vectorIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates unexpected fallback File-query failures', async () => {
+    mockEmbedderSetup();
+
+    const executeQuery = vi.fn().mockImplementation(async (cypher: string) => {
+      if (cypher.includes('MATCH (n:File)')) throw new Error('database is closed');
+      return [];
+    });
+    const executeWithReusedStatement = mockExecuteWithReusedStatement();
+
+    const { runEmbeddingPipeline } =
+      await import('../../src/core/embeddings/embedding-pipeline.js');
+
+    await expect(
+      runEmbeddingPipeline(executeQuery, executeWithReusedStatement, onProgress),
+    ).rejects.toThrow('database is closed');
+    expect(vectorIndexMock).not.toHaveBeenCalled();
+  });
+
+  it('retains missing-schema fallback for labels absent from legacy databases', async () => {
+    mockEmbedderSetup();
+
+    const fileNode = makeNode({
+      id: 'File:README.md',
+      name: 'README.md',
+      label: 'File',
+      filePath: 'README.md',
+      content: '# Legacy repository',
+    });
+    const executeQuery = vi.fn().mockImplementation(async (cypher: string) => {
+      if (cypher.includes('MATCH (n:`Function`)')) {
+        throw new Error('Binder exception: Table Function does not exist');
+      }
+      if (cypher.includes('MATCH (n:File)')) return [fileNode];
+      return [];
+    });
+    const executeWithReusedStatement = mockExecuteWithReusedStatement();
+
+    const { runEmbeddingPipeline } =
+      await import('../../src/core/embeddings/embedding-pipeline.js');
+
+    const result = await runEmbeddingPipeline(executeQuery, executeWithReusedStatement, onProgress);
+
+    expect(result.nodesProcessed).toBe(1);
+    expect(vectorIndexMock).toHaveBeenCalledOnce();
+  });
+
   it('skips unchanged nodes when hash matches', async () => {
     mockEmbedderSetup();
 

--- a/gitnexus/test/unit/http-embedder.test.ts
+++ b/gitnexus/test/unit/http-embedder.test.ts
@@ -401,14 +401,18 @@ describe('HTTP embedding backend', () => {
       });
       vi.stubGlobal(
         'fetch',
-        vi.fn().mockResolvedValueOnce(makeResp(64)).mockResolvedValueOnce(makeResp(6)),
+        vi
+          .fn()
+          .mockResolvedValueOnce(makeResp(8))
+          .mockResolvedValueOnce(makeResp(8))
+          .mockResolvedValueOnce(makeResp(2)),
       );
 
       const { embedBatch } = await import('../../src/core/embeddings/embedder.js');
-      const results = await embedBatch(Array.from({ length: 70 }, (_, i) => `text ${i}`));
+      const results = await embedBatch(Array.from({ length: 18 }, (_, i) => `text ${i}`));
 
-      expect(fetch).toHaveBeenCalledTimes(2);
-      expect(results).toHaveLength(70);
+      expect(fetch).toHaveBeenCalledTimes(3);
+      expect(results).toHaveLength(18);
     });
 
     it('forwards dimensions in every batch when splitting large inputs', async () => {
@@ -423,20 +427,22 @@ describe('HTTP embedding backend', () => {
       });
       vi.stubGlobal(
         'fetch',
-        vi.fn().mockResolvedValueOnce(makeResp(64)).mockResolvedValueOnce(makeResp(6)),
+        vi
+          .fn()
+          .mockResolvedValueOnce(makeResp(8))
+          .mockResolvedValueOnce(makeResp(8))
+          .mockResolvedValueOnce(makeResp(2)),
       );
 
       const { embedBatch } = await import('../../src/core/embeddings/embedder.js');
-      const results = await embedBatch(Array.from({ length: 70 }, (_, i) => `text ${i}`));
+      const results = await embedBatch(Array.from({ length: 18 }, (_, i) => `text ${i}`));
 
-      expect(fetch).toHaveBeenCalledTimes(2);
-      expect(results).toHaveLength(70);
+      expect(fetch).toHaveBeenCalledTimes(3);
+      expect(results).toHaveLength(18);
 
-      // Verify dimensions is sent in BOTH batch requests
-      const body0 = JSON.parse((fetch as any).mock.calls[0][1].body);
-      const body1 = JSON.parse((fetch as any).mock.calls[1][1].body);
-      expect(body0.dimensions).toBe(512);
-      expect(body1.dimensions).toBe(512);
+      for (const call of (fetch as any).mock.calls) {
+        expect(JSON.parse(call[1].body).dimensions).toBe(512);
+      }
     });
 
     it('rejects non-numeric GITNEXUS_EMBEDDING_DIMS values', async () => {
@@ -639,12 +645,12 @@ describe('HTTP embedding backend', () => {
         vi
           .fn()
           .mockResolvedValueOnce({ ok: false, status: 503 })
-          .mockResolvedValueOnce(makeResp(64))
-          .mockResolvedValueOnce(makeResp(6)),
+          .mockResolvedValueOnce(makeResp(8))
+          .mockResolvedValueOnce(makeResp(2)),
       );
 
       const { embedBatch } = await import('../../src/core/embeddings/embedder.js');
-      const promise = embedBatch(Array.from({ length: 70 }, (_, i) => `text ${i}`));
+      const promise = embedBatch(Array.from({ length: 10 }, (_, i) => `text ${i}`));
       await vi.advanceTimersByTimeAsync(0);
       expect(fetch).toHaveBeenCalledTimes(1);
       await vi.advanceTimersByTimeAsync(999);
@@ -654,7 +660,7 @@ describe('HTTP embedding backend', () => {
       await vi.advanceTimersByTimeAsync(999);
       expect(fetch).toHaveBeenCalledTimes(2);
       await vi.advanceTimersByTimeAsync(1);
-      await expect(promise).resolves.toHaveLength(70);
+      await expect(promise).resolves.toHaveLength(10);
       expect(fetch).toHaveBeenCalledTimes(3);
     });
 

--- a/gitnexus/test/unit/lbug-embedding-hashes.test.ts
+++ b/gitnexus/test/unit/lbug-embedding-hashes.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { STALE_HASH_SENTINEL } from '../../src/core/lbug/schema.js';
-import { fetchExistingEmbeddingHashes } from '../../src/core/lbug/lbug-adapter.js';
+import {
+  fetchExistingEmbeddingHashes,
+  fetchExistingEmbeddingHashesForNodeIds,
+} from '../../src/core/lbug/lbug-adapter.js';
 
 describe('fetchExistingEmbeddingHashes', () => {
   it('treats rows without chunk-aware metadata as stale even when contentHash exists', async () => {
@@ -46,5 +49,32 @@ describe('fetchExistingEmbeddingHashes', () => {
 
     expect(result?.get('Function:src/main.ts:foo')).toBe(STALE_HASH_SENTINEL);
     expect(execQuery).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('fetchExistingEmbeddingHashesForNodeIds', () => {
+  it('queries only the requested bounded identity page', async () => {
+    const hash = 'abcdef1234567890abcdef1234567890abcdef12';
+    const execQuery = vi
+      .fn()
+      .mockResolvedValue([
+        { nodeId: 'node-1', chunkIndex: 0, startLine: 1, endLine: 2, contentHash: hash },
+      ]);
+
+    const result = await fetchExistingEmbeddingHashesForNodeIds(execQuery, ['node-1', "node-'2"]);
+
+    expect(result.get('node-1')).toBe(hash);
+    expect(execQuery).toHaveBeenCalledWith(expect.stringContaining("['node-1', 'node-\\'2']"));
+  });
+
+  it('rejects identity pages above 512 before querying', async () => {
+    const execQuery = vi.fn();
+    await expect(
+      fetchExistingEmbeddingHashesForNodeIds(
+        execQuery,
+        Array.from({ length: 513 }, (_, index) => `node-${index}`),
+      ),
+    ).rejects.toThrow('exceeds 512');
+    expect(execQuery).not.toHaveBeenCalled();
   });
 });

--- a/gitnexus/test/unit/run-analyze-staged.test.ts
+++ b/gitnexus/test/unit/run-analyze-staged.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'child_process';
+import fsSync from 'fs';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { runFullAnalysis } from '../../src/core/run-analyze.js';
+import { getStoragePaths, loadMeta, saveMeta } from '../../src/storage/repo-manager.js';
+import {
+  getStagedAnalyzePaths,
+  prepareStagedWorkspace,
+  promoteStagedGeneration,
+} from '../../src/core/staged-promotion.js';
+
+const tempDirs: string[] = [];
+
+describe('runFullAnalysis --staged', () => {
+  let priorHome: string | undefined;
+  let priorInstallPolicy: string | undefined;
+
+  beforeEach(() => {
+    priorHome = process.env.GITNEXUS_HOME;
+    priorInstallPolicy = process.env.GITNEXUS_LBUG_EXTENSION_INSTALL;
+    process.env.GITNEXUS_LBUG_EXTENSION_INSTALL = 'never';
+  });
+
+  afterEach(async () => {
+    if (priorHome === undefined) delete process.env.GITNEXUS_HOME;
+    else process.env.GITNEXUS_HOME = priorHome;
+    if (priorInstallPolicy === undefined) delete process.env.GITNEXUS_LBUG_EXTENSION_INSTALL;
+    else process.env.GITNEXUS_LBUG_EXTENSION_INSTALL = priorInstallPolicy;
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('keeps the canonical DB inode unchanged until validated promotion', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-staged-run-'));
+    tempDirs.push(repo);
+    process.env.GITNEXUS_HOME = path.join(repo, '.registry-home');
+    await fs.writeFile(path.join(repo, 'index.ts'), 'export const value = 1;\n');
+    execFileSync('git', ['init'], { cwd: repo });
+    execFileSync('git', ['add', 'index.ts'], { cwd: repo });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=test', '-c', 'user.email=test@test', 'commit', '-m', 'initial'],
+      { cwd: repo },
+    );
+
+    await runFullAnalysis(repo, { skipAgentsMd: true, skipSkills: true }, { onProgress: () => {} });
+    const canonical = getStoragePaths(repo);
+    const before = fsSync.statSync(canonical.lbugPath);
+
+    await fs.writeFile(path.join(repo, 'index.ts'), 'export const value = 2;\n');
+    execFileSync('git', ['add', 'index.ts'], { cwd: repo });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=test', '-c', 'user.email=test@test', 'commit', '-m', 'change'],
+      { cwd: repo },
+    );
+
+    let sawPrePromotion = false;
+    const result = await runFullAnalysis(
+      repo,
+      { staged: true, skipAgentsMd: true, skipSkills: true },
+      {
+        onProgress: (_phase, percent) => {
+          if (percent >= 99) return;
+          sawPrePromotion = true;
+          const during = fsSync.statSync(canonical.lbugPath);
+          expect(during.ino).toBe(before.ino);
+          expect(during.mtimeMs).toBe(before.mtimeMs);
+        },
+      },
+    );
+
+    expect(sawPrePromotion).toBe(true);
+    expect(result.alreadyUpToDate).not.toBe(true);
+    const after = fsSync.statSync(canonical.lbugPath);
+    expect(after.ino).not.toBe(before.ino);
+    const finalMeta = await loadMeta(canonical.storagePath);
+    expect(finalMeta?.lastCommit).toBe(
+      execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim(),
+    );
+
+    const staged = getStagedAnalyzePaths(canonical.lbugPath, canonical.storagePath);
+    await expect(fs.access(staged.stageRoot)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.access(staged.backupLbugPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.access(staged.journalPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('recovers a missing canonical pathname before rejecting a branch mismatch', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-staged-recover-'));
+    tempDirs.push(repo);
+    process.env.GITNEXUS_HOME = path.join(repo, '.registry-home');
+    await fs.writeFile(path.join(repo, 'index.ts'), 'export const value = 1;\n');
+    execFileSync('git', ['init'], { cwd: repo });
+    execFileSync('git', ['add', 'index.ts'], { cwd: repo });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=test', '-c', 'user.email=test@test', 'commit', '-m', 'initial'],
+      { cwd: repo },
+    );
+    const originalBranch = execFileSync('git', ['branch', '--show-current'], {
+      cwd: repo,
+      encoding: 'utf8',
+    }).trim();
+    await runFullAnalysis(repo, { skipAgentsMd: true, skipSkills: true }, { onProgress: () => {} });
+
+    const canonical = getStoragePaths(repo);
+    const canonicalMeta = await loadMeta(canonical.storagePath);
+    if (!canonicalMeta) throw new Error('expected canonical metadata');
+    const staged = getStagedAnalyzePaths(canonical.lbugPath, canonical.storagePath);
+    await prepareStagedWorkspace(staged, canonicalMeta);
+    await saveMeta(staged.stagedMetaDir, {
+      ...canonicalMeta,
+      indexedAt: '2026-07-20T12:00:00.000Z',
+    });
+    await expect(
+      promoteStagedGeneration(staged, async () => 'repo', {
+        afterBoundary: (boundary) => {
+          if (boundary === 'old-backed-up') throw new Error('simulated crash');
+        },
+      }),
+    ).rejects.toThrow('simulated crash');
+    await expect(fs.access(canonical.lbugPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    execFileSync('git', ['switch', '-c', 'other'], { cwd: repo, stdio: 'pipe' });
+
+    await expect(
+      runFullAnalysis(
+        repo,
+        { staged: true, branch: originalBranch, skipAgentsMd: true, skipSkills: true },
+        { onProgress: () => {} },
+      ),
+    ).rejects.toThrow('does not match the checked-out branch');
+    await expect(fs.access(canonical.lbugPath)).resolves.toBeUndefined();
+    await expect(fs.access(staged.journalPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('promotes a completed resumed stage when the process died before journaling', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-staged-prejournal-'));
+    tempDirs.push(repo);
+    const registryHome = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-staged-registry-'));
+    tempDirs.push(registryHome);
+    process.env.GITNEXUS_HOME = registryHome;
+    await fs.writeFile(path.join(repo, 'index.ts'), 'export const value = 1;\n');
+    execFileSync('git', ['init'], { cwd: repo });
+    execFileSync('git', ['add', 'index.ts'], { cwd: repo });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=test', '-c', 'user.email=test@test', 'commit', '-m', 'initial'],
+      { cwd: repo },
+    );
+    await runFullAnalysis(repo, { skipAgentsMd: true, skipSkills: true }, { onProgress: () => {} });
+
+    const canonical = getStoragePaths(repo);
+    const canonicalMeta = await loadMeta(canonical.storagePath);
+    if (!canonicalMeta) throw new Error('expected canonical metadata');
+    const before = await fs.stat(canonical.lbugPath);
+    const staged = getStagedAnalyzePaths(canonical.lbugPath, canonical.storagePath);
+    await prepareStagedWorkspace(staged, canonicalMeta);
+    await saveMeta(staged.stagedMetaDir, {
+      ...canonicalMeta,
+      indexedAt: '2026-07-20T12:00:00.000Z',
+    });
+
+    const result = await runFullAnalysis(
+      repo,
+      { staged: true, skipAgentsMd: true, skipSkills: true },
+      { onProgress: () => {} },
+    );
+
+    expect(result.alreadyUpToDate).toBe(true);
+    expect((await fs.stat(canonical.lbugPath)).ino).not.toBe(before.ino);
+    expect((await loadMeta(canonical.storagePath))?.indexedAt).toBe('2026-07-20T12:00:00.000Z');
+    await expect(fs.access(staged.stageRoot)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.access(staged.backupLbugPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.access(staged.journalPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/gitnexus/test/unit/run-analyze-staged.test.ts
+++ b/gitnexus/test/unit/run-analyze-staged.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execFileSync } from 'child_process';
 import fsSync from 'fs';
 import fs from 'fs/promises';
@@ -10,9 +10,18 @@ import {
   getStagedAnalyzePaths,
   prepareStagedWorkspace,
   promoteStagedGeneration,
+  withAnalyzeOwnershipLock,
+  type RepositorySourceIdentity,
 } from '../../src/core/staged-promotion.js';
 
 const tempDirs: string[] = [];
+
+const repositoryIdentity = (repo: string): RepositorySourceIdentity => ({
+  head: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim(),
+  branch:
+    execFileSync('git', ['branch', '--show-current'], { cwd: repo, encoding: 'utf8' }).trim() ||
+    null,
+});
 
 describe('runFullAnalysis --staged', () => {
   let priorHome: string | undefined;
@@ -89,7 +98,7 @@ describe('runFullAnalysis --staged', () => {
     await expect(fs.access(staged.journalPath)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
-  it('recovers a missing canonical pathname before rejecting a branch mismatch', async () => {
+  it('rolls back a missing canonical pathname before refusing a changed branch', async () => {
     const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-staged-recover-'));
     tempDirs.push(repo);
     process.env.GITNEXUS_HOME = path.join(repo, '.registry-home');
@@ -111,7 +120,7 @@ describe('runFullAnalysis --staged', () => {
     const canonicalMeta = await loadMeta(canonical.storagePath);
     if (!canonicalMeta) throw new Error('expected canonical metadata');
     const staged = getStagedAnalyzePaths(canonical.lbugPath, canonical.storagePath);
-    await prepareStagedWorkspace(staged, canonicalMeta);
+    await prepareStagedWorkspace(staged, canonicalMeta, repositoryIdentity(repo));
     await saveMeta(staged.stagedMetaDir, {
       ...canonicalMeta,
       indexedAt: '2026-07-20T12:00:00.000Z',
@@ -132,7 +141,7 @@ describe('runFullAnalysis --staged', () => {
         { staged: true, branch: originalBranch, skipAgentsMd: true, skipSkills: true },
         { onProgress: () => {} },
       ),
-    ).rejects.toThrow('does not match the checked-out branch');
+    ).rejects.toThrow('repository HEAD or branch changed');
     await expect(fs.access(canonical.lbugPath)).resolves.toBeUndefined();
     await expect(fs.access(staged.journalPath)).rejects.toMatchObject({ code: 'ENOENT' });
   });
@@ -158,7 +167,7 @@ describe('runFullAnalysis --staged', () => {
     if (!canonicalMeta) throw new Error('expected canonical metadata');
     const before = await fs.stat(canonical.lbugPath);
     const staged = getStagedAnalyzePaths(canonical.lbugPath, canonical.storagePath);
-    await prepareStagedWorkspace(staged, canonicalMeta);
+    await prepareStagedWorkspace(staged, canonicalMeta, repositoryIdentity(repo));
     await saveMeta(staged.stagedMetaDir, {
       ...canonicalMeta,
       indexedAt: '2026-07-20T12:00:00.000Z',
@@ -176,5 +185,85 @@ describe('runFullAnalysis --staged', () => {
     await expect(fs.access(staged.stageRoot)).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(fs.access(staged.backupLbugPath)).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(fs.access(staged.journalPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('recovers an old-backed-up journal during plain analyze before its fast path', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-plain-recover-'));
+    const registryHome = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-plain-registry-'));
+    tempDirs.push(repo, registryHome);
+    process.env.GITNEXUS_HOME = registryHome;
+    await fs.writeFile(path.join(repo, 'index.ts'), 'export const value = 1;\n');
+    execFileSync('git', ['init'], { cwd: repo });
+    execFileSync('git', ['add', 'index.ts'], { cwd: repo });
+    execFileSync(
+      'git',
+      ['-c', 'user.name=test', '-c', 'user.email=test@test', 'commit', '-m', 'initial'],
+      { cwd: repo },
+    );
+    await runFullAnalysis(repo, { skipAgentsMd: true, skipSkills: true }, { onProgress: () => {} });
+
+    const canonical = getStoragePaths(repo);
+    const canonicalMeta = await loadMeta(canonical.storagePath);
+    if (!canonicalMeta) throw new Error('expected canonical metadata');
+    const staged = getStagedAnalyzePaths(canonical.lbugPath, canonical.storagePath);
+    await prepareStagedWorkspace(staged, canonicalMeta, repositoryIdentity(repo));
+    await saveMeta(staged.stagedMetaDir, {
+      ...canonicalMeta,
+      indexedAt: '2026-07-20T12:00:00.000Z',
+    });
+    await expect(
+      promoteStagedGeneration(staged, async () => 'repo', {
+        afterBoundary: (boundary) => {
+          if (boundary === 'old-backed-up') throw new Error('simulated crash');
+        },
+      }),
+    ).rejects.toThrow('simulated crash');
+    await expect(fs.access(canonical.lbugPath)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    await expect(
+      runFullAnalysis(
+        repo,
+        { incrementalOnly: true, skipAgentsMd: true, skipSkills: true },
+        { onProgress: () => {} },
+      ),
+    ).rejects.toThrow('staged-promotion journal requires recovery');
+    await expect(fs.access(canonical.lbugPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.access(staged.journalPath)).resolves.toBeUndefined();
+
+    const result = await runFullAnalysis(
+      repo,
+      { skipAgentsMd: true, skipSkills: true },
+      { onProgress: () => {} },
+    );
+
+    expect(result.alreadyUpToDate).toBe(true);
+    await expect(fs.access(canonical.lbugPath)).resolves.toBeUndefined();
+    await expect(fs.access(staged.journalPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('uses the same ownership lock for ordinary and staged analyze', async () => {
+    const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-common-lock-'));
+    tempDirs.push(repo);
+    const storage = getStoragePaths(repo).storagePath;
+    let release!: () => void;
+    const owner = withAnalyzeOwnershipLock(
+      storage,
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    await vi.waitFor(async () => {
+      await expect(fs.access(path.join(storage, 'analyze-staged.lock'))).resolves.toBeUndefined();
+    });
+
+    await expect(runFullAnalysis(repo, {}, { onProgress: () => {} })).rejects.toThrow(
+      'Another analyze is active',
+    );
+    await expect(runFullAnalysis(repo, { staged: true }, { onProgress: () => {} })).rejects.toThrow(
+      'Another analyze is active',
+    );
+    release();
+    await owner;
   });
 });

--- a/gitnexus/test/unit/staged-promotion.test.ts
+++ b/gitnexus/test/unit/staged-promotion.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  getStagedAnalyzePaths,
+  prepareStagedWorkspace,
+  promoteStagedGeneration,
+  withStagedAnalyzeLock,
+  type PromotionBoundary,
+} from '../../src/core/staged-promotion.js';
+import { loadMeta, saveMeta, type RepoMeta } from '../../src/storage/repo-manager.js';
+
+const tempDirs: string[] = [];
+
+const makeMeta = (generation: string): RepoMeta => ({
+  repoPath: '/repo',
+  lastCommit: generation,
+  indexedAt: `2026-07-20T00:00:0${generation === 'old' ? '0' : '1'}.000Z`,
+  stats: { nodes: generation === 'old' ? 1 : 2, edges: 0 },
+});
+
+const setup = async (withCanonical = true) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-stage-'));
+  tempDirs.push(root);
+  const canonicalMetaDir = path.join(root, '.gitnexus');
+  const canonicalLbugPath = path.join(canonicalMetaDir, 'lbug');
+  await fs.mkdir(canonicalMetaDir, { recursive: true });
+  const oldMeta = withCanonical ? makeMeta('old') : null;
+  if (oldMeta) {
+    await fs.writeFile(canonicalLbugPath, 'old-generation');
+    await saveMeta(canonicalMetaDir, oldMeta);
+  }
+  const paths = getStagedAnalyzePaths(canonicalLbugPath, canonicalMetaDir);
+  await prepareStagedWorkspace(paths, oldMeta);
+  await fs.writeFile(paths.stagedLbugPath, 'new-generation');
+  const newMeta = makeMeta('new');
+  await saveMeta(paths.stagedMetaDir, newMeta);
+  return { paths, canonicalLbugPath, canonicalMetaDir, newMeta };
+};
+
+const exists = async (filePath: string): Promise<boolean> =>
+  fs
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false);
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe('staged promotion journal', () => {
+  for (const boundary of [
+    'prepared',
+    'old-backed-up',
+    'new-installed',
+    'metadata/registry-committed',
+  ] as const) {
+    it(`recovers after a crash at ${boundary}`, async () => {
+      const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+      let commits = 0;
+      const commit = async (meta: RepoMeta): Promise<string> => {
+        commits++;
+        await saveMeta(canonicalMetaDir, meta);
+        return 'repo';
+      };
+
+      await expect(
+        promoteStagedGeneration(paths, commit, {
+          afterBoundary: (reached: PromotionBoundary) => {
+            if (reached === boundary) throw new Error(`crash:${boundary}`);
+          },
+        }),
+      ).rejects.toThrow(`crash:${boundary}`);
+
+      expect((await exists(canonicalLbugPath)) || (await exists(paths.backupLbugPath))).toBe(true);
+
+      await promoteStagedGeneration(paths, commit);
+      expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
+      expect((await loadMeta(canonicalMetaDir))?.lastCommit).toBe('new');
+      expect(await exists(paths.backupLbugPath)).toBe(false);
+      expect(await exists(paths.journalPath)).toBe(false);
+      expect(commits).toBe(1);
+    });
+  }
+
+  it('recovers a canonical-to-backup rename that happened before the journal advanced', async () => {
+    const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+    const commit = async (meta: RepoMeta) => {
+      await saveMeta(canonicalMetaDir, meta);
+      return 'repo';
+    };
+    await expect(
+      promoteStagedGeneration(paths, commit, {
+        afterBoundary: (boundary) => {
+          if (boundary === 'prepared') throw new Error('crash');
+        },
+      }),
+    ).rejects.toThrow('crash');
+    await fs.rename(canonicalLbugPath, paths.backupLbugPath);
+
+    await promoteStagedGeneration(paths, commit);
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
+  });
+
+  it('recovers a staged-to-canonical rename that happened before the journal advanced', async () => {
+    const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+    const commit = async (meta: RepoMeta) => {
+      await saveMeta(canonicalMetaDir, meta);
+      return 'repo';
+    };
+    await expect(
+      promoteStagedGeneration(paths, commit, {
+        afterBoundary: (boundary) => {
+          if (boundary === 'old-backed-up') throw new Error('crash');
+        },
+      }),
+    ).rejects.toThrow('crash');
+    await fs.rename(paths.stagedLbugPath, canonicalLbugPath);
+
+    await promoteStagedGeneration(paths, commit);
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
+  });
+
+  it('restores the old generation when the staged DB disappears after backup', async () => {
+    const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+    await expect(
+      promoteStagedGeneration(
+        paths,
+        async (meta) => {
+          await saveMeta(canonicalMetaDir, meta);
+          return 'repo';
+        },
+        {
+          afterBoundary: (boundary) => {
+            if (boundary === 'old-backed-up') throw new Error('crash');
+          },
+        },
+      ),
+    ).rejects.toThrow('crash');
+    await fs.rm(paths.stagedLbugPath, { force: true });
+
+    await expect(promoteStagedGeneration(paths, async () => 'repo')).rejects.toThrow(
+      'restored the canonical backup',
+    );
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('old-generation');
+  });
+
+  it('promotes the first generation without inventing an old backup', async () => {
+    const { paths, canonicalLbugPath, canonicalMetaDir } = await setup(false);
+    await promoteStagedGeneration(paths, async (meta) => {
+      await saveMeta(canonicalMetaDir, meta);
+      return 'repo';
+    });
+
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
+    expect(await exists(paths.backupLbugPath)).toBe(false);
+  });
+
+  it('reuses an interrupted stage only while canonical source identity is unchanged', async () => {
+    const { paths, canonicalLbugPath } = await setup();
+    await fs.writeFile(paths.stagedLbugPath, 'partial-new-generation');
+    const oldMeta = makeMeta('old');
+    await expect(prepareStagedWorkspace(paths, oldMeta)).resolves.toMatchObject({ resumed: true });
+    expect(await fs.readFile(paths.stagedLbugPath, 'utf8')).toBe('partial-new-generation');
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await fs.writeFile(canonicalLbugPath, 'externally-changed-canonical');
+    await expect(prepareStagedWorkspace(paths, oldMeta)).resolves.toMatchObject({ resumed: false });
+    expect(await fs.readFile(paths.stagedLbugPath, 'utf8')).toBe('externally-changed-canonical');
+  });
+
+  it('refuses to copy a canonical DB with unresolved WAL state', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-stage-wal-'));
+    tempDirs.push(root);
+    const metaDir = path.join(root, '.gitnexus');
+    const lbugPath = path.join(metaDir, 'lbug');
+    await fs.mkdir(metaDir, { recursive: true });
+    await fs.writeFile(lbugPath, 'canonical');
+    await fs.writeFile(`${lbugPath}.wal`, 'pending');
+    const meta = makeMeta('old');
+    await saveMeta(metaDir, meta);
+
+    await expect(
+      prepareStagedWorkspace(getStagedAnalyzePaths(lbugPath, metaDir), meta),
+    ).rejects.toThrow('unresolved LadybugDB sidecars');
+    expect(await fs.readFile(lbugPath, 'utf8')).toBe('canonical');
+  });
+});
+
+describe('staged analyze lock', () => {
+  it('refuses a concurrent staged builder', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-stage-lock-'));
+    tempDirs.push(root);
+    let release!: () => void;
+    const first = withStagedAnalyzeLock(
+      root,
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    await vi.waitFor(async () => {
+      await expect(fs.access(path.join(root, 'analyze-staged.lock'))).resolves.toBeUndefined();
+    });
+
+    await expect(withStagedAnalyzeLock(root, async () => undefined)).rejects.toThrow(
+      'Another staged analyze is active',
+    );
+    release();
+    await first;
+  });
+
+  it('reclaims a lock whose owner process is gone', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-stage-lock-'));
+    tempDirs.push(root);
+    await fs.writeFile(
+      path.join(root, 'analyze-staged.lock'),
+      `${JSON.stringify({
+        schema: 'gitnexus.staged-analyze-lock/v1',
+        pid: 2_147_483_647,
+        nonce: 'dead-owner',
+        startedAt: '2026-07-20T00:00:00.000Z',
+      })}\n`,
+    );
+
+    await expect(withStagedAnalyzeLock(root, async () => 'ok')).resolves.toBe('ok');
+    await expect(fs.access(path.join(root, 'analyze-staged.lock'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+});

--- a/gitnexus/test/unit/staged-promotion.test.ts
+++ b/gitnexus/test/unit/staged-promotion.test.ts
@@ -177,6 +177,68 @@ describe('staged promotion journal', () => {
     expect(await exists(paths.journalPath)).toBe(false);
   });
 
+  for (const installedDbState of ['missing', 'wrong'] as const) {
+    it(`does not restore the old DB over staged metadata when the installed DB is ${installedDbState}`, async () => {
+      const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+      let attempts = 0;
+      const commit = async (meta: RepoMeta): Promise<string> => {
+        attempts++;
+        await saveMeta(canonicalMetaDir, meta);
+        throw new Error('register failed');
+      };
+
+      await expect(promoteStagedGeneration(paths, commit)).rejects.toThrow('register failed');
+      if (installedDbState === 'missing') {
+        await fs.rm(canonicalLbugPath);
+      } else {
+        await fs.writeFile(canonicalLbugPath, 'wrong-installed-generation');
+      }
+
+      await expect(promoteStagedGeneration(paths, commit)).rejects.toThrow(
+        'canonical database identity changed',
+      );
+      expect(attempts).toBe(1);
+      expect((await loadMeta(canonicalMetaDir))?.lastCommit).toBe('new');
+      expect(await fs.readFile(paths.backupLbugPath, 'utf8')).toBe('old-generation');
+      expect(await exists(paths.journalPath)).toBe(true);
+      if (installedDbState === 'missing') {
+        expect(await exists(canonicalLbugPath)).toBe(false);
+      } else {
+        expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe(
+          'wrong-installed-generation',
+        );
+      }
+    });
+  }
+
+  it('finishes registration after source HEAD moves once the staged DB and metadata are canonical', async () => {
+    const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+    let attempts = 0;
+    const commit = async (meta: RepoMeta): Promise<string> => {
+      attempts++;
+      await saveMeta(canonicalMetaDir, meta);
+      if (attempts === 1) throw new Error('register failed');
+      return 'repo';
+    };
+
+    await expect(
+      promoteStagedGeneration(paths, commit, {
+        readRepositoryIdentity: () => sourceRepo,
+      }),
+    ).rejects.toThrow('register failed');
+
+    await expect(
+      promoteStagedGeneration(paths, commit, {
+        readRepositoryIdentity: () => ({ head: 'later-head', branch: 'other' }),
+      }),
+    ).resolves.toMatchObject({ projectName: 'repo', recovered: true });
+    expect(attempts).toBe(2);
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
+    expect((await loadMeta(canonicalMetaDir))?.lastCommit).toBe('new');
+    expect(await exists(paths.backupLbugPath)).toBe(false);
+    expect(await exists(paths.journalPath)).toBe(false);
+  });
+
   it('refuses recovery when metadata differs from both source and staged generations', async () => {
     const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
     let attempts = 0;

--- a/gitnexus/test/unit/staged-promotion.test.ts
+++ b/gitnexus/test/unit/staged-promotion.test.ts
@@ -149,6 +149,58 @@ describe('staged promotion journal', () => {
     expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
   });
 
+  it('retries metadata and registration after metadata was saved but registration failed', async () => {
+    const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+    let attempts = 0;
+    const commit = async (meta: RepoMeta): Promise<string> => {
+      attempts++;
+      await saveMeta(canonicalMetaDir, meta);
+      if (attempts === 1) throw new Error('register failed');
+      return 'repo';
+    };
+
+    await expect(promoteStagedGeneration(paths, commit)).rejects.toThrow('register failed');
+    expect(
+      (JSON.parse(await fs.readFile(paths.journalPath, 'utf8')) as { state: string }).state,
+    ).toBe('new-installed');
+    expect((await loadMeta(canonicalMetaDir))?.lastCommit).toBe('new');
+    expect(await exists(paths.backupLbugPath)).toBe(true);
+
+    await expect(promoteStagedGeneration(paths, commit)).resolves.toMatchObject({
+      projectName: 'repo',
+      recovered: true,
+    });
+    expect(attempts).toBe(2);
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
+    expect((await loadMeta(canonicalMetaDir))?.lastCommit).toBe('new');
+    expect(await exists(paths.backupLbugPath)).toBe(false);
+    expect(await exists(paths.journalPath)).toBe(false);
+  });
+
+  it('refuses recovery when metadata differs from both source and staged generations', async () => {
+    const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+    let attempts = 0;
+    const commit = async (meta: RepoMeta): Promise<string> => {
+      attempts++;
+      await saveMeta(canonicalMetaDir, meta);
+      throw new Error('register failed');
+    };
+
+    await expect(promoteStagedGeneration(paths, commit)).rejects.toThrow('register failed');
+    await saveMeta(canonicalMetaDir, {
+      ...makeMeta('new'),
+      stats: { nodes: 99, edges: 99 },
+    });
+
+    await expect(promoteStagedGeneration(paths, commit)).rejects.toThrow(
+      'canonical metadata changed',
+    );
+    expect(attempts).toBe(1);
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
+    expect(await exists(paths.backupLbugPath)).toBe(true);
+    expect(await exists(paths.journalPath)).toBe(true);
+  });
+
   it('restores the old generation when the staged DB disappears after backup', async () => {
     const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
     await expect(

--- a/gitnexus/test/unit/staged-promotion.test.ts
+++ b/gitnexus/test/unit/staged-promotion.test.ts
@@ -204,9 +204,7 @@ describe('staged promotion journal', () => {
       if (installedDbState === 'missing') {
         expect(await exists(canonicalLbugPath)).toBe(false);
       } else {
-        expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe(
-          'wrong-installed-generation',
-        );
+        expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('wrong-installed-generation');
       }
     });
   }

--- a/gitnexus/test/unit/staged-promotion.test.ts
+++ b/gitnexus/test/unit/staged-promotion.test.ts
@@ -6,12 +6,14 @@ import {
   getStagedAnalyzePaths,
   prepareStagedWorkspace,
   promoteStagedGeneration,
-  withStagedAnalyzeLock,
+  withAnalyzeOwnershipLock,
   type PromotionBoundary,
+  type RepositorySourceIdentity,
 } from '../../src/core/staged-promotion.js';
 import { loadMeta, saveMeta, type RepoMeta } from '../../src/storage/repo-manager.js';
 
 const tempDirs: string[] = [];
+const sourceRepo: RepositorySourceIdentity = { head: 'source-head', branch: 'main' };
 
 const makeMeta = (generation: string): RepoMeta => ({
   repoPath: '/repo',
@@ -32,11 +34,11 @@ const setup = async (withCanonical = true) => {
     await saveMeta(canonicalMetaDir, oldMeta);
   }
   const paths = getStagedAnalyzePaths(canonicalLbugPath, canonicalMetaDir);
-  await prepareStagedWorkspace(paths, oldMeta);
+  await prepareStagedWorkspace(paths, oldMeta, sourceRepo);
   await fs.writeFile(paths.stagedLbugPath, 'new-generation');
   const newMeta = makeMeta('new');
   await saveMeta(paths.stagedMetaDir, newMeta);
-  return { paths, canonicalLbugPath, canonicalMetaDir, newMeta };
+  return { paths, canonicalLbugPath, canonicalMetaDir, newMeta, sourceRepo };
 };
 
 const exists = async (filePath: string): Promise<boolean> =>
@@ -122,6 +124,31 @@ describe('staged promotion journal', () => {
     expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
   });
 
+  it('preserves recovery for a journal written before source guards were added', async () => {
+    const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+    const commit = async (meta: RepoMeta) => {
+      await saveMeta(canonicalMetaDir, meta);
+      return 'repo';
+    };
+    await expect(
+      promoteStagedGeneration(paths, commit, {
+        afterBoundary: (boundary) => {
+          if (boundary === 'old-backed-up') throw new Error('crash');
+        },
+      }),
+    ).rejects.toThrow('crash');
+    const legacyJournal = JSON.parse(await fs.readFile(paths.journalPath, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    delete legacyJournal.sourceMetaFiles;
+    delete legacyJournal.sourceRepo;
+    await fs.writeFile(paths.journalPath, `${JSON.stringify(legacyJournal)}\n`);
+
+    await promoteStagedGeneration(paths, commit);
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('new-generation');
+  });
+
   it('restores the old generation when the staged DB disappears after backup', async () => {
     const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
     await expect(
@@ -161,12 +188,16 @@ describe('staged promotion journal', () => {
     const { paths, canonicalLbugPath } = await setup();
     await fs.writeFile(paths.stagedLbugPath, 'partial-new-generation');
     const oldMeta = makeMeta('old');
-    await expect(prepareStagedWorkspace(paths, oldMeta)).resolves.toMatchObject({ resumed: true });
+    await expect(prepareStagedWorkspace(paths, oldMeta, sourceRepo)).resolves.toMatchObject({
+      resumed: true,
+    });
     expect(await fs.readFile(paths.stagedLbugPath, 'utf8')).toBe('partial-new-generation');
 
     await new Promise((resolve) => setTimeout(resolve, 5));
     await fs.writeFile(canonicalLbugPath, 'externally-changed-canonical');
-    await expect(prepareStagedWorkspace(paths, oldMeta)).resolves.toMatchObject({ resumed: false });
+    await expect(prepareStagedWorkspace(paths, oldMeta, sourceRepo)).resolves.toMatchObject({
+      resumed: false,
+    });
     expect(await fs.readFile(paths.stagedLbugPath, 'utf8')).toBe('externally-changed-canonical');
   });
 
@@ -186,14 +217,82 @@ describe('staged promotion journal', () => {
     ).rejects.toThrow('unresolved LadybugDB sidecars');
     expect(await fs.readFile(lbugPath, 'utf8')).toBe('canonical');
   });
+
+  it('refuses promotion when canonical DB or metadata changed after prepare', async () => {
+    const { paths, canonicalLbugPath, canonicalMetaDir } = await setup();
+    await fs.writeFile(canonicalLbugPath, 'newer-canonical-generation');
+    await saveMeta(canonicalMetaDir, {
+      ...makeMeta('old'),
+      indexedAt: '2026-07-20T00:00:09.000Z',
+    });
+
+    await expect(promoteStagedGeneration(paths, async () => 'repo')).rejects.toThrow(
+      'canonical metadata changed',
+    );
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('newer-canonical-generation');
+    expect((await loadMeta(canonicalMetaDir))?.indexedAt).toBe('2026-07-20T00:00:09.000Z');
+  });
+
+  it('refuses promotion when only the canonical DB identity changed after prepare', async () => {
+    const { paths, canonicalLbugPath } = await setup();
+    await fs.writeFile(canonicalLbugPath, 'newer-canonical-generation');
+
+    await expect(promoteStagedGeneration(paths, async () => 'repo')).rejects.toThrow(
+      'canonical database identity changed',
+    );
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('newer-canonical-generation');
+  });
+
+  it('refuses promotion when metadata files were replaced with the same semantic values', async () => {
+    const { paths, canonicalMetaDir } = await setup();
+    await saveMeta(canonicalMetaDir, makeMeta('old'));
+
+    await expect(promoteStagedGeneration(paths, async () => 'repo')).rejects.toThrow(
+      'metadata file identity changed',
+    );
+  });
+
+  it('refuses promotion when repository HEAD or branch changed after prepare', async () => {
+    const { paths, canonicalLbugPath } = await setup();
+
+    await expect(
+      promoteStagedGeneration(paths, async () => 'repo', {
+        readRepositoryIdentity: () => ({ head: 'new-head', branch: 'other' }),
+      }),
+    ).rejects.toThrow('repository HEAD or branch changed');
+    expect(await fs.readFile(canonicalLbugPath, 'utf8')).toBe('old-generation');
+  });
+
+  it('recovers a first-generation crash after stage creation but before its manifest', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-stage-first-intent-'));
+    tempDirs.push(root);
+    const metaDir = path.join(root, '.gitnexus');
+    const paths = getStagedAnalyzePaths(path.join(metaDir, 'lbug'), metaDir);
+
+    await expect(
+      prepareStagedWorkspace(paths, null, sourceRepo, {
+        afterStagePrepared: () => {
+          throw new Error('crash-before-manifest');
+        },
+      }),
+    ).rejects.toThrow('crash-before-manifest');
+    expect(await exists(paths.stageIntentPath)).toBe(true);
+    expect(await exists(paths.stageManifestPath)).toBe(false);
+
+    await expect(prepareStagedWorkspace(paths, null, sourceRepo)).resolves.toMatchObject({
+      resumed: false,
+    });
+    expect(await exists(paths.stageManifestPath)).toBe(true);
+    expect(await exists(paths.stageIntentPath)).toBe(false);
+  });
 });
 
-describe('staged analyze lock', () => {
-  it('refuses a concurrent staged builder', async () => {
+describe('common analyze ownership lock', () => {
+  it('refuses a concurrent ordinary or staged writer', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-stage-lock-'));
     tempDirs.push(root);
     let release!: () => void;
-    const first = withStagedAnalyzeLock(
+    const first = withAnalyzeOwnershipLock(
       root,
       () =>
         new Promise<void>((resolve) => {
@@ -204,8 +303,8 @@ describe('staged analyze lock', () => {
       await expect(fs.access(path.join(root, 'analyze-staged.lock'))).resolves.toBeUndefined();
     });
 
-    await expect(withStagedAnalyzeLock(root, async () => undefined)).rejects.toThrow(
-      'Another staged analyze is active',
+    await expect(withAnalyzeOwnershipLock(root, async () => undefined)).rejects.toThrow(
+      'Another analyze is active',
     );
     release();
     await first;
@@ -224,7 +323,7 @@ describe('staged analyze lock', () => {
       })}\n`,
     );
 
-    await expect(withStagedAnalyzeLock(root, async () => 'ok')).resolves.toBe('ok');
+    await expect(withAnalyzeOwnershipLock(root, async () => 'ok')).resolves.toBe('ok');
     await expect(fs.access(path.join(root, 'analyze-staged.lock'))).rejects.toMatchObject({
       code: 'ENOENT',
     });


### PR DESCRIPTION
## Outcome

Make large GitNexus analysis bounded, staged, resumable, and SIGTERM-safe while the canonical index remains readable.

Closes #132. Part of #130 and a release dependency for #137.

## Changes

- Add `analyze --staged` with isolated database/metadata generation and a durable promotion journal: `prepared`, `old-backed-up`, `new-installed`, `metadata/registry-committed`.
- Recover safely at every journal/rename gap, preserve DB/metadata generation pairs through registry commit, require exact staged DB plus metadata identity before idempotent registration, support first-generation installs, and refuse incompatible source identity, branch, sidecar, owner, or artifact state.
- Route SIGTERM through the same bounded checkpoint path as SIGINT, preserving at most the 5,000-node pending window plus genuine source changes.
- Stream a checksummed disk-backed cached-vector snapshot in at most 256-vector chunks; page nodes at 512; embed at 16; and cap HTTP/vector-insert sub-batches at 8.
- Size automatic V8 heap as `max(2048, min(6144, floor(effectiveMemoryMb * 0.5)))`; explicit hyphenated or underscored `NODE_OPTIONS` values still win.
- Add opt-in, fixed-schema numeric JSONL resource telemetry through `GITNEXUS_ANALYZE_RESOURCE_LOG`, mode `0600`, with fail-safe handling of mid-run I/O failure.

## Safety and proof boundaries

- No live registry/index or source checkout was changed by this PR work.
- Source tests include a synthetic 25,000-row, 2,048-dimensional corpus. The required sequential 85k/125k and disposable OpenClaw release soaks remain downstream release gates.
- Voyage-backed release soaks have no host memory/swap admission gate and will run sequentially, one repository at a time, after the staged-analysis source and exact `.3` artifact are ready.
- Source merge does not prove release artifact, installed runtime, Codex/Claude behavior, fleet repair, or customer readiness.

## Validation

- TypeScript typecheck passed.
- Production build passed (existing Vite large-chunk warning only).
- 16 focused test files / 244 tests passed at exact head `ee5b942af1f138e1bcbecf9b5478cfb68662af32`.
- Real LadybugDB staged promotion and crash recovery passed at every journal boundary and rename-before-journal gap.
- Pre-journal completed-stage, first-generation, branch-switch, snapshot-corruption/count, SIGTERM, heap-option, and 5,001-node checkpoint cases passed.
- Synthetic 25,000 × 2,048 integration stayed within 512-node pages, 5,000-node windows, 8-vector/insert sub-batches, and less than 512 MiB measured heap growth.
- GitNexus `detect_changes` classified the aggregate change CRITICAL because it touches central analyze/embedding flows; the affected processes and central symbol contexts were reviewed.
- Independent exact-head high-risk review is required before publication.

## Rollback

Revert this PR before the `.3` release. At runtime, staged promotion retains a validated old generation until metadata/registry commit and its journal recovers to a validated old or new generation; it never intentionally deletes both.

Closes #132
