### PR TITLE
fix(analyze): stamp non-Git staged checkpoints

### DIFF
--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -1106,12 +1106,10 @@ const runFullAnalysisImpl = async (
   // otherwise early-return without ever reaching the `isIncremental` gate
   // that consults `schemaVersion`, defeating the bump's whole point.
   //
-  // `schemaVersion === undefined` covers two cases that should still trip
-  // this guard: a non-git repo (which never stamps the field) and very old
-  // meta from before the field existed. Non-git repos take the
-  // `currentCommit === ''` rebuild branch below regardless, so the redundant
-  // force here is harmless; the friendlier `'pre-versioning'` log avoids a
-  // user-visible "stamped vundefined" line in that edge case.
+  // `schemaVersion === undefined` now means legacy metadata from before the
+  // field existed. New indexes always stamp their schema identity, including
+  // non-Git and `--skip-git` repositories, because staged embedding recovery
+  // must not misclassify a current checkpoint as pre-versioning.
   if (existingMeta && existingMeta.schemaVersion !== INCREMENTAL_SCHEMA_VERSION) {
     if (options.incrementalOnly) {
       incrementalOnlyStop('the index schema requires a full rebuild');
@@ -2219,7 +2217,9 @@ const runFullAnalysisImpl = async (
             processes: pipelineResult.processResult?.stats.totalProcesses,
             embeddings,
           },
-          schemaVersion: hasGitDir(repoPath) ? INCREMENTAL_SCHEMA_VERSION : undefined,
+          // Schema identity belongs to the index, not Git history. Non-Git
+          // staged checkpoints need the same stamp to resume safely.
+          schemaVersion: INCREMENTAL_SCHEMA_VERSION,
           cjkSegmentation: getSearchFTSCjkSegmentation(),
           fileHashes: hasGitDir(repoPath) ? fileHashes : undefined,
           cacheKeys: [...parseCache.usedKeys],
@@ -2378,11 +2378,10 @@ const runFullAnalysisImpl = async (
           reason: runtimeCapabilities.reason,
         },
       },
-      // Incremental-indexing fields. Populated for git repos so the next
-      // analyze run can take the incremental DB-writeback path. Setting
-      // incrementalInProgress to undefined explicitly clears any prior
-      // dirty flag (full and incremental success paths converge here).
-      schemaVersion: hasGitDir(repoPath) ? INCREMENTAL_SCHEMA_VERSION : undefined,
+      // Schema identity is always stamped. Git-only fields below remain
+      // conditional, so non-Git repositories still rebuild their graph while
+      // staged embedding checkpoints remain distinguishable from legacy data.
+      schemaVersion: INCREMENTAL_SCHEMA_VERSION,
       // Always stamped with the live resolved mode (#2331/#2339) — unlike
       // `pdg` below, 'none' is a meaningful value to compare, not an
       // absence, so this is never conditionally omitted.

--- a/gitnexus/test/unit/run-analyze.test.ts
+++ b/gitnexus/test/unit/run-analyze.test.ts
@@ -75,6 +75,74 @@ describe('run-analyze module', () => {
     }
   });
 
+  it('stamps the current index schema for non-Git repositories', async () => {
+    const tmpRepo = await createTempDir('gitnexus-run-analyze-non-git-schema-');
+    const tmpHome = await createTempDir('gitnexus-run-analyze-non-git-schema-home-');
+    const savedHome = process.env.GITNEXUS_HOME;
+    const savedExtension = process.env.GITNEXUS_LBUG_EXTENSION_INSTALL;
+    const savedUrl = process.env.GITNEXUS_EMBEDDING_URL;
+    const savedModel = process.env.GITNEXUS_EMBEDDING_MODEL;
+    const savedDims = process.env.GITNEXUS_EMBEDDING_DIMS;
+    try {
+      process.env.GITNEXUS_HOME = tmpHome.dbPath;
+      process.env.GITNEXUS_LBUG_EXTENSION_INSTALL = 'never';
+      await fs.writeFile(
+        path.join(tmpRepo.dbPath, 'index.ts'),
+        'export function nonGitSchemaStamp() { return "current"; }\n',
+      );
+
+      const { runFullAnalysis } = await import('../../src/core/run-analyze.js');
+      await runFullAnalysis(
+        tmpRepo.dbPath,
+        { skipAgentsMd: true, skipSkills: true },
+        { onProgress: () => {} },
+      );
+
+      const { storagePath } = getStoragePaths(tmpRepo.dbPath);
+      expect((await loadMeta(storagePath))?.schemaVersion).toBe(INCREMENTAL_SCHEMA_VERSION);
+
+      process.env.GITNEXUS_EMBEDDING_URL = 'http://test:8080/v1';
+      process.env.GITNEXUS_EMBEDDING_MODEL = 'test-model';
+      process.env.GITNEXUS_EMBEDDING_DIMS = '384';
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response('{"error":"intentional checkpoint stop"}', {
+              status: 400,
+              headers: { 'content-type': 'application/json' },
+            }),
+        ),
+      );
+
+      await expect(
+        runFullAnalysis(
+          tmpRepo.dbPath,
+          { embeddings: true, force: true, skipAgentsMd: true, skipSkills: true },
+          { onProgress: () => {} },
+        ),
+      ).rejects.toThrow();
+
+      const interrupted = await loadMeta(storagePath);
+      expect(interrupted?.embeddingCheckpoint).toBeDefined();
+      expect(interrupted?.schemaVersion).toBe(INCREMENTAL_SCHEMA_VERSION);
+    } finally {
+      vi.unstubAllGlobals();
+      if (savedHome === undefined) delete process.env.GITNEXUS_HOME;
+      else process.env.GITNEXUS_HOME = savedHome;
+      if (savedExtension === undefined) delete process.env.GITNEXUS_LBUG_EXTENSION_INSTALL;
+      else process.env.GITNEXUS_LBUG_EXTENSION_INSTALL = savedExtension;
+      if (savedUrl === undefined) delete process.env.GITNEXUS_EMBEDDING_URL;
+      else process.env.GITNEXUS_EMBEDDING_URL = savedUrl;
+      if (savedModel === undefined) delete process.env.GITNEXUS_EMBEDDING_MODEL;
+      else process.env.GITNEXUS_EMBEDDING_MODEL = savedModel;
+      if (savedDims === undefined) delete process.env.GITNEXUS_EMBEDDING_DIMS;
+      else process.env.GITNEXUS_EMBEDDING_DIMS = savedDims;
+      await tmpRepo.cleanup();
+      await tmpHome.cleanup();
+    }
+  }, 120_000);
+
   it('resumes a matching embedding checkpoint instead of taking the clean fast path', async () => {
     const tmpRepo = await createTempDir('gitnexus-run-analyze-embedding-checkpoint-');
     const tmpHome = await createTempDir('gitnexus-run-analyze-embedding-checkpoint-home-');


### PR DESCRIPTION
## Outcome

Stamp the current index schema on every new index and embedding checkpoint, including non-Git and `--skip-git` staged repositories. Git-only commit and file-hash fields remain conditional on Git history.

Closes #143. Part of #130 and blocks #137.

## Reproduction and fix

- The 85,345-node Voyage soak checkpointed at 5,000/85,000 with a 5,000-node pending window.
- After controlled SIGTERM, the restart recognized the checkpoint but then forced a rebuild because metadata said `pre-versioning`.
- The regression failed before the production change with `expected undefined to be 6`.
- Final metadata and the embedding checkpoint writer now always persist `INCREMENTAL_SCHEMA_VERSION`; Git-only incremental eligibility remains unchanged.

## Validation

- `run-analyze.test.ts` and `analyze-sigterm.test.ts`: 39/39 pass.
- The new test proves both a completed non-Git index and an intentionally interrupted embedding checkpoint carry schema v6.
- TypeScript passes.
- Prettier passes on changed files.
- ESLint reports zero errors; six pre-existing warnings remain in `run-analyze.ts`.
- `git diff --check` passes.
- GitNexus change detection: medium risk, one expected `runFullAnalysis` process affected.

## Proof boundary

This PR fixes and tests the metadata invariant. The live 85k controlled-resume soak must still pass on the combined current release candidate before merge/release claims are complete. No canonical index, live registry, or local runtime config is changed here.
