### PR TITLE
fix(embeddings): make staged snapshot resume idempotent

### DIFF
--- a/gitnexus/src/core/embeddings/cache-snapshot.ts
+++ b/gitnexus/src/core/embeddings/cache-snapshot.ts
@@ -41,6 +41,19 @@ export interface EmbeddingSnapshotInfo {
   duplicateRows?: number;
 }
 
+const hasValidEmbeddingIdentity = (
+  row: unknown,
+): row is Pick<SnapshotRow, 'nodeId' | 'chunkIndex'> => {
+  if (!row || typeof row !== 'object') return false;
+  const candidate = row as Record<string, unknown>;
+  return (
+    typeof candidate.nodeId === 'string' &&
+    candidate.nodeId.length > 0 &&
+    Number.isSafeInteger(candidate.chunkIndex) &&
+    Number(candidate.chunkIndex) >= 0
+  );
+};
+
 const embeddingIdentity = (row: Pick<SnapshotRow, 'nodeId' | 'chunkIndex'>): string =>
   `${row.nodeId}\0${row.chunkIndex}`;
 
@@ -196,7 +209,12 @@ export const validateEmbeddingSnapshot = async (
         footer = value;
         continue;
       }
-      if (footer || value.type !== 'embedding' || typeof value.embeddingBase64 !== 'string') {
+      if (
+        footer ||
+        value.type !== 'embedding' ||
+        !hasValidEmbeddingIdentity(value) ||
+        typeof value.embeddingBase64 !== 'string'
+      ) {
         return undefined;
       }
       const byteLength = decodeEmbeddingBytes(value.embeddingBase64).byteLength;
@@ -257,6 +275,9 @@ export const readEmbeddingSnapshot = async (
       if (!line) continue;
       const value = JSON.parse(line) as SnapshotRow | SnapshotFooter;
       if (value.type === 'complete') break;
+      if (!hasValidEmbeddingIdentity(value)) {
+        throw new Error('Embedding preservation snapshot failed validation');
+      }
       const identity = embeddingIdentity(value);
       if (seenIdentities.has(identity)) continue;
       seenIdentities.add(identity);

--- a/gitnexus/src/core/embeddings/cache-snapshot.ts
+++ b/gitnexus/src/core/embeddings/cache-snapshot.ts
@@ -56,8 +56,23 @@ const encodeEmbedding = (embedding: number[]): string => {
   return Buffer.from(vector.buffer, vector.byteOffset, vector.byteLength).toString('base64');
 };
 
-const decodeEmbedding = (encoded: string, dimensions: number): number[] => {
+const decodeEmbeddingBytes = (encoded: string): Buffer => {
+  if (
+    encoded.length === 0 ||
+    encoded.length % 4 !== 0 ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded)
+  ) {
+    throw new Error('Embedding preservation snapshot contains a malformed vector');
+  }
   const bytes = Buffer.from(encoded, 'base64');
+  if (bytes.toString('base64') !== encoded) {
+    throw new Error('Embedding preservation snapshot contains a malformed vector');
+  }
+  return bytes;
+};
+
+const decodeEmbedding = (encoded: string, dimensions: number): number[] => {
+  const bytes = decodeEmbeddingBytes(encoded);
   if (bytes.byteLength !== dimensions * Float32Array.BYTES_PER_ELEMENT) {
     throw new Error('Embedding preservation snapshot contains a malformed vector');
   }
@@ -184,7 +199,7 @@ export const validateEmbeddingSnapshot = async (
       if (footer || value.type !== 'embedding' || typeof value.embeddingBase64 !== 'string') {
         return undefined;
       }
-      const byteLength = Buffer.byteLength(value.embeddingBase64, 'base64');
+      const byteLength = decodeEmbeddingBytes(value.embeddingBase64).byteLength;
       if (byteLength === 0 || byteLength % Float32Array.BYTES_PER_ELEMENT !== 0) return undefined;
       const rowDimensions = byteLength / Float32Array.BYTES_PER_ELEMENT;
       if (dimensions === 0) dimensions = rowDimensions;

--- a/gitnexus/src/core/embeddings/cache-snapshot.ts
+++ b/gitnexus/src/core/embeddings/cache-snapshot.ts
@@ -37,7 +37,19 @@ export interface EmbeddingSnapshotSource {
 export interface EmbeddingSnapshotInfo {
   count: number;
   dimensions: number;
+  /** Repeated physical rows coalesced by (nodeId, chunkIndex). */
+  duplicateRows?: number;
 }
+
+const embeddingIdentity = (row: Pick<SnapshotRow, 'nodeId' | 'chunkIndex'>): string =>
+  `${row.nodeId}\0${row.chunkIndex}`;
+
+const snapshotInfo = (
+  count: number,
+  dimensions: number,
+  duplicateRows: number,
+): EmbeddingSnapshotInfo =>
+  duplicateRows > 0 ? { count, dimensions, duplicateRows } : { count, dimensions };
 
 const encodeEmbedding = (embedding: number[]): string => {
   const vector = Float32Array.from(embedding);
@@ -80,6 +92,9 @@ export const createEmbeddingSnapshot = async (
   const digest = createHash('sha256');
   let count = 0;
   let dimensions = 0;
+  let duplicateRows = 0;
+  // Identities are small; vectors remain bounded to the caller's 256-row batch.
+  const seenIdentities = new Set<string>();
 
   const emit = async (batch: readonly CachedEmbedding[]): Promise<void> => {
     if (batch.length > EMBEDDING_PRESERVATION_BATCH_SIZE) {
@@ -94,6 +109,12 @@ export const createEmbeddingSnapshot = async (
       if (rowDimensions !== dimensions) {
         throw new Error('Embedding preservation snapshot mixes vector dimensions');
       }
+      const identity = embeddingIdentity(embedding);
+      if (seenIdentities.has(identity)) {
+        duplicateRows++;
+        continue;
+      }
+      seenIdentities.add(identity);
       const line = `${JSON.stringify(toSnapshotRow(embedding))}\n`;
       digest.update(line);
       payload += line;
@@ -122,7 +143,7 @@ export const createEmbeddingSnapshot = async (
     await handle.sync();
     await handle.close();
     await fs.rename(tempPath, snapshotPath);
-    return { count, dimensions };
+    return snapshotInfo(count, dimensions, duplicateRows);
   } catch (error) {
     await handle.close().catch(() => {});
     await fs.rm(tempPath, { force: true }).catch(() => {});
@@ -144,9 +165,12 @@ export const validateEmbeddingSnapshot = async (
   }
   const lines = createInterface({ input, crlfDelay: Infinity });
   const digest = createHash('sha256');
-  let count = 0;
+  let physicalCount = 0;
+  let uniqueCount = 0;
+  let duplicateRows = 0;
   let dimensions = 0;
   let footer: SnapshotFooter | undefined;
+  const seenIdentities = new Set<string>();
 
   try {
     for await (const line of lines) {
@@ -166,7 +190,13 @@ export const validateEmbeddingSnapshot = async (
       if (dimensions === 0) dimensions = rowDimensions;
       if (rowDimensions !== dimensions) return undefined;
       digest.update(`${line}\n`);
-      count++;
+      physicalCount++;
+      const identity = embeddingIdentity(value);
+      if (seenIdentities.has(identity)) duplicateRows++;
+      else {
+        seenIdentities.add(identity);
+        uniqueCount++;
+      }
     }
   } catch {
     return undefined;
@@ -178,16 +208,16 @@ export const validateEmbeddingSnapshot = async (
   if (
     !footer ||
     footer.schema !== SNAPSHOT_SCHEMA ||
-    footer.count !== count ||
+    footer.count !== physicalCount ||
     footer.dimensions !== dimensions ||
     footer.sha256 !== digest.digest('hex') ||
     footer.sourceLastCommit !== source.lastCommit ||
     footer.sourceIndexedAt !== source.indexedAt ||
-    (expectedCount !== undefined && count !== expectedCount)
+    (expectedCount !== undefined && uniqueCount !== expectedCount)
   ) {
     return undefined;
   }
-  return { count, dimensions };
+  return snapshotInfo(uniqueCount, dimensions, duplicateRows);
 };
 
 /**
@@ -206,11 +236,15 @@ export const readEmbeddingSnapshot = async (
   const input = createReadStream(snapshotPath, { encoding: 'utf8' });
   const lines = createInterface({ input, crlfDelay: Infinity });
   let batch: CachedEmbedding[] = [];
+  const seenIdentities = new Set<string>();
   try {
     for await (const line of lines) {
       if (!line) continue;
       const value = JSON.parse(line) as SnapshotRow | SnapshotFooter;
       if (value.type === 'complete') break;
+      const identity = embeddingIdentity(value);
+      if (seenIdentities.has(identity)) continue;
+      seenIdentities.add(identity);
       batch.push({
         nodeId: value.nodeId,
         chunkIndex: value.chunkIndex,

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -2045,6 +2045,7 @@ const runFullAnalysisImpl = async (
     // Restore insertion failures propagate: silently skipping a failed batch
     // would finalize metadata with fewer vectors than the preserved snapshot.
     let restoredEmbeddingCount = 0;
+    let skippedPendingEmbeddingRows = 0;
     if (embeddingSnapshotInfo && embeddingSnapshotInfo.count > 0) {
       const cachedDims = embeddingSnapshotInfo.dimensions;
       const { EMBEDDING_DIMS } = await import('./lbug/schema.js');
@@ -2068,6 +2069,16 @@ const runFullAnalysisImpl = async (
             const rowsToRestore = [];
             const orphanRowIds: string[] = [];
             for (const embedding of snapshotBatch) {
+              // A persisted checkpoint window is deliberately regenerated below.
+              // Restoring those rows first creates a delete-then-create cycle that
+              // LadybugDB's live VECTOR index can still reject as a duplicate key
+              // after an interrupted staged rebuild. The checkpoint bounds this
+              // exclusion to at most the pending window; every skipped row is
+              // force-selected by runEmbeddingPipeline before finalization.
+              if (resumeEmbeddingCheckpoint && pendingEmbeddingNodeIds.has(embedding.nodeId)) {
+                skippedPendingEmbeddingRows += 1;
+                continue;
+              }
               const liveNode = pipelineResult.graph.getNode(embedding.nodeId);
               if (!liveNode) {
                 if (deletedFilePathsForRestore !== null) {
@@ -2112,6 +2123,12 @@ const runFullAnalysisImpl = async (
           },
           resumeEmbeddingCheckpoint ? undefined : existingEmbeddingCount,
         );
+        if (skippedPendingEmbeddingRows > 0) {
+          log(
+            `Skipped ${skippedPendingEmbeddingRows} cached embedding row(s) from the ` +
+              'pending checkpoint window; they will be regenerated.',
+          );
+        }
       }
     }
 

--- a/gitnexus/test/unit/embedding-cache-snapshot.test.ts
+++ b/gitnexus/test/unit/embedding-cache-snapshot.test.ts
@@ -125,6 +125,34 @@ describe('bounded embedding preservation snapshot', () => {
     expect(onBatch).not.toHaveBeenCalled();
   });
 
+  it('rejects malformed base64 before invoking any restore batch', async () => {
+    const snapshotPath = await makePath();
+    const source = { lastCommit: 'abc', indexedAt: '2026-07-20T00:00:00.000Z' };
+    const rows = makeRows(257);
+    await createEmbeddingSnapshot(snapshotPath, source, async (emit) => {
+      await emit(rows.slice(0, 256));
+      await emit(rows.slice(256));
+    });
+
+    const lines = (await fs.readFile(snapshotPath, 'utf8')).trimEnd().split('\n');
+    const footer = JSON.parse(lines.pop() ?? '{}') as Record<string, unknown>;
+    const malformed = JSON.parse(lines[256]) as Record<string, unknown>;
+    const encoded = String(malformed.embeddingBase64);
+    malformed.embeddingBase64 = `${encoded.slice(0, 5)}!${encoded.slice(6)}`;
+    lines[256] = JSON.stringify(malformed);
+    footer.sha256 = createHash('sha256')
+      .update(lines.map((line) => `${line}\n`).join(''))
+      .digest('hex');
+    await fs.writeFile(snapshotPath, `${lines.join('\n')}\n${JSON.stringify(footer)}\n`);
+    const onBatch = vi.fn();
+
+    await expect(validateEmbeddingSnapshot(snapshotPath, source, 257)).resolves.toBeUndefined();
+    await expect(readEmbeddingSnapshot(snapshotPath, source, onBatch, 257)).rejects.toThrow(
+      'failed validation',
+    );
+    expect(onBatch).not.toHaveBeenCalled();
+  });
+
   it('binds a reusable snapshot to its source generation', async () => {
     const snapshotPath = await makePath();
     const source = { lastCommit: 'abc', indexedAt: '2026-07-20T00:00:00.000Z' };

--- a/gitnexus/test/unit/embedding-cache-snapshot.test.ts
+++ b/gitnexus/test/unit/embedding-cache-snapshot.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'crypto';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -56,6 +57,57 @@ describe('bounded embedding preservation snapshot', () => {
     expect(restored).toHaveLength(600);
     expect(restored[599]).toMatchObject({ nodeId: 'node-599', contentHash: 'hash-599' });
     expect(restored[599].embedding).toEqual(rows[599].embedding);
+  });
+
+  it('writes each embedding identity once when the producer repeats rows across batches', async () => {
+    const snapshotPath = await makePath();
+    const rows = makeRows(300);
+    const source = { lastCommit: 'abc', indexedAt: '2026-07-20T00:00:00.000Z' };
+
+    await expect(
+      createEmbeddingSnapshot(snapshotPath, source, async (emit) => {
+        await emit(rows.slice(0, 256));
+        await emit([rows[100], ...rows.slice(256)]);
+      }),
+    ).resolves.toEqual({ count: 300, dimensions: 4, duplicateRows: 1 });
+
+    await expect(validateEmbeddingSnapshot(snapshotPath, source, 300)).resolves.toEqual({
+      count: 300,
+      dimensions: 4,
+    });
+    const restored: CachedEmbedding[] = [];
+    await readEmbeddingSnapshot(snapshotPath, source, async (batch) => restored.push(...batch));
+    expect(restored).toHaveLength(300);
+    expect(restored.filter((row) => row.nodeId === 'node-100')).toHaveLength(1);
+  });
+
+  it('restores each identity once from a valid legacy snapshot with non-adjacent duplicates', async () => {
+    const snapshotPath = await makePath();
+    const source = { lastCommit: 'abc', indexedAt: '2026-07-20T00:00:00.000Z' };
+    await createEmbeddingSnapshot(snapshotPath, source, async (emit) => emit(makeRows(3)));
+
+    const lines = (await fs.readFile(snapshotPath, 'utf8')).trimEnd().split('\n');
+    const footer = JSON.parse(lines.pop() ?? '{}') as Record<string, unknown>;
+    const duplicate = JSON.parse(lines[0]) as Record<string, unknown>;
+    duplicate.contentHash = 'conflicting-later-copy';
+    const physicalRows = [...lines, JSON.stringify(duplicate)];
+    footer.count = physicalRows.length;
+    footer.sha256 = createHash('sha256')
+      .update(physicalRows.map((line) => `${line}\n`).join(''))
+      .digest('hex');
+    await fs.writeFile(snapshotPath, `${physicalRows.join('\n')}\n${JSON.stringify(footer)}\n`);
+
+    await expect(validateEmbeddingSnapshot(snapshotPath, source, 3)).resolves.toEqual({
+      count: 3,
+      dimensions: 4,
+      duplicateRows: 1,
+    });
+    const restored: CachedEmbedding[] = [];
+    await expect(
+      readEmbeddingSnapshot(snapshotPath, source, async (batch) => restored.push(...batch), 3),
+    ).resolves.toEqual({ count: 3, dimensions: 4, duplicateRows: 1 });
+    expect(restored).toHaveLength(3);
+    expect(restored.find((row) => row.nodeId === 'node-0')?.contentHash).toBe('hash-0');
   });
 
   it('rejects tampering before invoking the restore callback', async () => {

--- a/gitnexus/test/unit/embedding-cache-snapshot.test.ts
+++ b/gitnexus/test/unit/embedding-cache-snapshot.test.ts
@@ -153,6 +153,46 @@ describe('bounded embedding preservation snapshot', () => {
     expect(onBatch).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [
+      'missing nodeId',
+      (row: Record<string, unknown>) => {
+        delete row.nodeId;
+      },
+    ],
+    [
+      'non-integer chunkIndex',
+      (row: Record<string, unknown>) => {
+        row.chunkIndex = 'zero';
+      },
+    ],
+  ])('rejects %s before invoking any restore batch', async (_name, corruptIdentity) => {
+    const snapshotPath = await makePath();
+    const source = { lastCommit: 'abc', indexedAt: '2026-07-20T00:00:00.000Z' };
+    const rows = makeRows(257);
+    await createEmbeddingSnapshot(snapshotPath, source, async (emit) => {
+      await emit(rows.slice(0, 256));
+      await emit(rows.slice(256));
+    });
+
+    const lines = (await fs.readFile(snapshotPath, 'utf8')).trimEnd().split('\n');
+    const footer = JSON.parse(lines.pop() ?? '{}') as Record<string, unknown>;
+    const malformed = JSON.parse(lines[256]) as Record<string, unknown>;
+    corruptIdentity(malformed);
+    lines[256] = JSON.stringify(malformed);
+    footer.sha256 = createHash('sha256')
+      .update(lines.map((line) => `${line}\n`).join(''))
+      .digest('hex');
+    await fs.writeFile(snapshotPath, `${lines.join('\n')}\n${JSON.stringify(footer)}\n`);
+    const onBatch = vi.fn();
+
+    await expect(validateEmbeddingSnapshot(snapshotPath, source, 257)).resolves.toBeUndefined();
+    await expect(readEmbeddingSnapshot(snapshotPath, source, onBatch, 257)).rejects.toThrow(
+      'failed validation',
+    );
+    expect(onBatch).not.toHaveBeenCalled();
+  });
+
   it('binds a reusable snapshot to its source generation', async () => {
     const snapshotPath = await makePath();
     const source = { lastCommit: 'abc', indexedAt: '2026-07-20T00:00:00.000Z' };

--- a/gitnexus/test/unit/run-analyze.test.ts
+++ b/gitnexus/test/unit/run-analyze.test.ts
@@ -224,6 +224,11 @@ describe('run-analyze module', () => {
       if (!pendingNodeId) throw new Error('expected a persisted embedding node');
       await saveMeta(storagePath, {
         ...finalized,
+        incrementalInProgress: {
+          startedAt: Date.now(),
+          toWriteCount: 1,
+          phase: 'embedding-window',
+        },
         embeddingCheckpoint: {
           at: new Date().toISOString(),
           nodesProcessed: 0,
@@ -235,15 +240,22 @@ describe('run-analyze module', () => {
         },
       });
       fetchMock.mockClear();
+      const pendingLogs: string[] = [];
 
       await runFullAnalysis(
         tmpRepo.dbPath,
         { skipAgentsMd: true, skipSkills: true },
-        { onProgress: () => {} },
+        { onProgress: () => {}, onLog: (message) => pendingLogs.push(message) },
       );
 
       expect(fetchMock).toHaveBeenCalled();
       expect((await loadMeta(storagePath))?.embeddingCheckpoint).toBeUndefined();
+      expect((await loadMeta(storagePath))?.stats?.embeddings).toBe(1);
+      expect(
+        pendingLogs.some((message) =>
+          message.includes('pending checkpoint window; they will be regenerated'),
+        ),
+      ).toBe(true);
 
       const resumedPending = await loadMeta(storagePath);
       if (!resumedPending) throw new Error('expected pending-window resume metadata');


### PR DESCRIPTION
## Outcome

Make bounded embedding preservation snapshots idempotent when a staged large-repository run fails after partially rewriting its pending checkpoint window.

Closes #145. Parent: #130. Release blocker: #137.

## Runtime reproduction

The preserved 125k Voyage staged generation produced a valid checksummed snapshot with 10,663 physical rows, 9,320 unique `(nodeId, chunkIndex)` identities, and 1,343 repeated identities after a provider timeout. The first resume failed during restore on a repeated `CodeEmbedding` primary key.

After snapshot deduplication, an exact live resume restored the 9,320 unique rows but exposed a second conflict while regenerating a pending checkpoint identity. A read-only database probe after failure found no visible row or stored hash for that identity, while the live VECTOR-backed create still reported a duplicate primary key.

## Fix

- Snapshot creation keeps only the first row for each embedding identity while retaining at most the existing 256 vectors per producer batch.
- Validation checks every physical row and the original footer/checksum, reports unique and repeated identity counts, and rejects malformed or non-canonical Base64 before any restore callback runs.
- Validation rejects missing/invalid embedding identity fields before constructing the deduplication key; the read pass repeats that guard so corruption cannot be silently coalesced after validation.
- Legacy duplicate-containing snapshots remain recoverable: reading streams every physical row, restores each identity once, and keeps only identity strings beyond the bounded vector batch.
- Pending checkpoint identities are not restored from the snapshot. They are already bounded by the 5,000-node checkpoint window and force-selected for regeneration, avoiding the unsafe restore-delete-create cycle against the live VECTOR index.
- A normal expected-count mismatch still fails validation.

## Validation

- `npx vitest run test/unit/run-analyze.test.ts test/unit/embedding-cache-snapshot.test.ts` — 49/49.
- Two 257-row recomputed-footer regressions reject missing `nodeId` and non-integer `chunkIndex` before any restore callback.
- Dirty full-rebuild checkpoint regression proves the pending row is skipped, regenerated, and final embedding count remains exact.
- `npx tsc --noEmit`.
- Focused Prettier and ESLint pass; ESLint reports only six pre-existing warnings in `run-analyze.ts`.
- `npm run build`.
- The exact preserved 113 MiB snapshot validates as 9,320 unique 2,048-dimensional rows with 1,343 repeated physical rows.
- The preserved staged generation and credential source remain unchanged; exact 125k resume proof is the next release gate.

GitNexus impact: LOW and contained to snapshot validation/reading plus pending-window restoration in the embedding recovery path.
