### PR TITLE
ci: ignore documented replace-me token fingerprint

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+c9fdab17f25ebaf332fba6e6ba55ee328f20fe66:README.md:curl-auth-header:348


### PR DESCRIPTION
Closes #147

## Change

Adds the one exact full-history Gitleaks fingerprint for the documented `Bearer replace-me` example in historical commit `c9fdab17f25ebaf332fba6e6ba55ee328f20fe66`.

This does not change the detector, path scope, commit range, or full-history push scan. It does not add a broad allowlist rule.

## Proof

- `.gitleaksignore` contains exactly one fingerprint.
- `git diff --check` passes.
- The exact-main full-history Gitleaks push workflow must pass after merge before the release gate is satisfied.
