### PR TITLE
docs: clarify remote embedding cap behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,15 +360,15 @@ gitnexus analyze --wal-checkpoint-threshold 67108864  # LadybugDB WAL auto-check
 
 If `analyze` reports a worker parse timeout on a large or unusual repository, it keeps running and falls back safely. To give slow worker jobs more time, use `--worker-timeout 60` or set `GITNEXUS_WORKER_SUB_BATCH_TIMEOUT_MS=60000`. For very large files, `GITNEXUS_WORKER_SUB_BATCH_MAX_BYTES` controls the worker job byte budget.
 
-**Embeddings node limit** — `gitnexus analyze --embeddings` generates semantic search vectors with a default 50,000-node safety cap to protect memory on large repositories:
+**Embeddings node limit** — `gitnexus analyze --embeddings` applies the automatic 50,000-node safety cap only to local embedding models. Remote HTTP providers such as Voyage default to no automatic cap:
 
 ```bash
-gitnexus analyze --embeddings          # default 50,000 node safety cap
-gitnexus analyze --embeddings 0        # disable the cap entirely
-gitnexus analyze --embeddings 100000   # custom cap
+gitnexus analyze --embeddings          # local: 50,000 cap; remote HTTP/Voyage: uncapped
+gitnexus analyze --embeddings 0        # explicitly disable the cap
+gitnexus analyze --embeddings 100000   # explicit cap for either provider type
 ```
 
-If embeddings are skipped on a large repository, the indexed graph likely exceeds the default cap — re-run with `--embeddings 0` or a higher limit.
+If local embeddings are skipped on a large repository, the indexed graph likely exceeds the local-model cap — re-run with `--embeddings 0` or a higher explicit limit. Remote HTTP/Voyage generation is not skipped by an automatic node-count cap.
 
 </details>
 

--- a/gitnexus/src/cli/i18n/en.ts
+++ b/gitnexus/src/cli/i18n/en.ts
@@ -176,7 +176,7 @@ export const en = {
     'Refuse recovery, migration, or scale escalation that would require a full rebuild',
   'help.option.analyze.repairFts': 'Repair/rebuild search FTS indexes without full re-analysis',
   'help.option.analyze.embeddings':
-    'Enable embedding generation for semantic search (off by default). Optional [limit] overrides the 50,000-node safety cap; pass 0 to disable the cap entirely.',
+    'Enable embedding generation for semantic search (off by default). Local models default to a 50,000-node safety cap; remote HTTP providers default uncapped. Optional [limit] sets an explicit cap; pass 0 to disable it.',
   'help.option.analyze.dropEmbeddings':
     'Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves any embeddings already present in the index.',
   'help.option.analyze.skills':

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -66,7 +66,8 @@ program
   .option(
     '--embeddings [limit]',
     'Enable embedding generation for semantic search (off by default). ' +
-      'Optional [limit] overrides the 50,000-node safety cap; pass 0 to disable the cap entirely.',
+      'Local models default to a 50,000-node safety cap; remote HTTP providers default uncapped. ' +
+      'Optional [limit] sets an explicit cap; pass 0 to disable it.',
   )
   .option(
     '--drop-embeddings',

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -175,8 +175,9 @@ export interface AnalyzeOptions {
   embeddings?: boolean;
   /**
    * Override the auto-skip node-count cap for embedding generation.
-   * `undefined` (default) keeps the built-in 50,000-node safety limit;
-   * `0` disables the cap entirely; any positive integer sets a custom cap.
+   * `undefined` uses the 50,000-node local-model default and no automatic cap
+   * for remote HTTP providers; `0` disables the cap entirely; any positive
+   * integer sets an explicit cap for either provider type.
    * Mapped from the CLI's `--embeddings [limit]` argument.
    */
   embeddingsNodeLimit?: number;


### PR DESCRIPTION
Closes #149

## Change

Aligns the README, CLI help, and public analyze option comment with the runtime contract already implemented in #142:

- local embedding models default to the 50,000-node cap;
- remote HTTP providers, including Voyage, default to no automatic cap;
- an explicit positive cap is honored for either provider type;
- `0` explicitly disables the cap.

This changes documentation and help only. It does not add a Voyage resource gate or alter the provider selection/runtime behavior.

## Focused proof

- `git diff --check`
- `vitest run gitnexus/test/unit/run-analyze.test.ts -t deriveEmbeddingCap` — 9 passed
- source CLI `analyze --help` renders the provider-specific contract

The full `run-analyze.test.ts` file needs built worker artifacts for two integration-style cases; without a build, those two fail at worker startup while the other 38 pass. Remote CI is the canonical broad gate.
