### PR TITLE
chore: ship 1.6.10-electric.3

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.2",
+      "version": "1.6.10-electric.3",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.2",
+      "version": "1.6.10-electric.3",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.3.md
+++ b/Documentation/releases/1.6.10-electric.3.md
@@ -1,0 +1,41 @@
+# GitNexus 1.6.10-electric.3
+
+`1.6.10-electric.3` makes semantic search truthful and large-repository indexing safer. It keeps one canonical index readable while staged work proceeds, exposes partial retrieval instead of silently dropping it, and prevents duplicate indexes for the same GitHub remote.
+
+## Highlights
+
+- Every prewarmed LadybugDB read connection loads FTS and VECTOR before the pool is published. Query responses now say which keyword and semantic paths actually ran.
+- Large analysis uses bounded pages, embedding batches, checkpoints, and a promotion journal so interrupted work can resume without replacing the readable index early.
+- Invalid MCP repository policy remains fully fail-closed but visible to stdio agents, and new read-only doctors diagnose policy, registry, extension, count, and WAL/shadow state.
+- GitHub SSH and HTTPS spellings normalize to one repository identity, and duplicate top-level registration is refused before storage is created.
+
+## Changes
+
+- Query results add retrieval metadata for keyword mode, semantic mode, embedding count, exact-scan limit, and a stable reason when semantic contribution is unavailable.
+- Staged analysis preserves at most the pending checkpoint window plus real changes, handles SIGTERM through the bounded checkpoint path, and promotes through explicit journal states.
+- `gitnexus doctor --mcp-config --json` reuses the production policy resolver without binding MCP or opening an index.
+- `gitnexus doctor --registry --json` reports normalized-remote and alias collisions, metadata/database count drift, WAL/shadow state, and live eight-connection extension capability. Paths remain redacted unless explicitly requested locally.
+- Voyage requests for `voyage-code-3` now send the provider-native `output_dimension` field for 2,048-dimensional embeddings.
+
+## Fixes
+
+- Repositories above the 20,000-row exact-scan limit no longer lose semantic contribution silently when one pooled connection lacks VECTOR.
+- Successful zero-result HNSW queries remain distinct from VECTOR query failures.
+- Malformed or ambiguous stdio allowlists initialize only in blocked mode: repository operations return a sanitized configuration error, with no partial allowlist acceptance and no unrestricted fallback. HTTP remains fail-fast.
+- Concurrent attempts to index the same normalized GitHub remote produce one canonical winner and one stable collision error instead of duplicate registry rows.
+- Voyage-compatible embedding calls no longer fail because an OpenAI-specific dimension field was sent to the Voyage API.
+
+## Known Boundaries
+
+- Distribution is GitHub-only. Public npm dist-tags and container registries remain unchanged.
+- The exact-scan limit remains 20,000; this release fixes indexed retrieval rather than raising the fallback cap.
+- Voyage work runs exactly one repository at a time and has no host memory, swap, RSS, free-memory, or pressure gate. Optional resource JSONL is telemetry only. Local embedding backends require a separate explicit resource policy.
+- A published release proves the exact artifact and release workflow. Side-by-side local installation, registry repair, fleet embedding refresh, and live Codex/Claude behavior are separate post-release gates.
+- Worktree branch-overlay indexing remains out of scope.
+
+## Release Verification
+
+- Capability PRs: #129, #138, #139, #140, and #142; sprint epic: #130; release gate: #137.
+- Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.3`.
+- Required proof includes protected exact-head CI, pooled VECTOR integration, staged interruption/recovery tests, canonical identity and doctor suites, sequential large-repository Voyage soaks, and the protected Electric Release workflow.
+- The protected workflow publishes `electric/v1.6.10-electric.3` with one proved tarball plus `SHA256SUMS`; rollback retains `1.6.10-electric.2`.

--- a/Documentation/releases/1.6.10-electric.3.md
+++ b/Documentation/releases/1.6.10-electric.3.md
@@ -13,6 +13,7 @@
 
 - Query results add retrieval metadata for keyword mode, semantic mode, embedding count, exact-scan limit, and a stable reason when semantic contribution is unavailable.
 - Staged analysis preserves at most the pending checkpoint window plus real changes, handles SIGTERM through the bounded checkpoint path, and promotes through explicit journal states.
+- Staged embedding snapshots coalesce repeated `(nodeId, chunkIndex)` identities on write and restore legacy duplicate rows once, while still validating every physical row and buffering at most 256 vectors.
 - `gitnexus doctor --mcp-config --json` reuses the production policy resolver without binding MCP or opening an index.
 - `gitnexus doctor --registry --json` reports normalized-remote and alias collisions, metadata/database count drift, WAL/shadow state, and live eight-connection extension capability. Paths remain redacted unless explicitly requested locally.
 - Voyage requests for `voyage-code-3` now send the provider-native `output_dimension` field for 2,048-dimensional embeddings.
@@ -25,6 +26,7 @@
 - Concurrent attempts to index the same normalized GitHub remote produce one canonical winner and one stable collision error instead of duplicate registry rows.
 - Voyage-compatible embedding calls no longer fail because an OpenAI-specific dimension field was sent to the Voyage API.
 - Non-Git and `--skip-git` staged indexes stamp the current schema identity, so a valid embedding checkpoint resumes instead of being misclassified as pre-versioning metadata.
+- Interrupted staged resumes no longer fail with a duplicate `CodeEmbedding` primary key when a preserved legacy snapshot contains repeated embedding identities.
 
 ## Known Boundaries
 
@@ -36,7 +38,7 @@
 
 ## Release Verification
 
-- Capability PRs: #129, #138, #139, #140, #142, and #144; sprint epic: #130; release gate: #137.
+- Capability PRs: #129, #138, #139, #140, #142, #144, and #146; sprint epic: #130; release gate: #137.
 - Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.3`.
 - Required proof includes protected exact-head CI, pooled VECTOR integration, staged interruption/recovery tests, canonical identity and doctor suites, sequential large-repository Voyage soaks, and the protected Electric Release workflow.
 - The protected workflow publishes `electric/v1.6.10-electric.3` with one proved tarball plus `SHA256SUMS`; rollback retains `1.6.10-electric.2`.

--- a/Documentation/releases/1.6.10-electric.3.md
+++ b/Documentation/releases/1.6.10-electric.3.md
@@ -13,7 +13,7 @@
 
 - Query results add retrieval metadata for keyword mode, semantic mode, embedding count, exact-scan limit, and a stable reason when semantic contribution is unavailable.
 - Staged analysis preserves at most the pending checkpoint window plus real changes, handles SIGTERM through the bounded checkpoint path, and promotes through explicit journal states.
-- Staged embedding snapshots coalesce repeated `(nodeId, chunkIndex)` identities on write and restore legacy duplicate rows once, while still validating every physical row and buffering at most 256 vectors.
+- Staged embedding snapshots coalesce repeated `(nodeId, chunkIndex)` identities on write and restore legacy duplicate rows once, while still validating every physical row and buffering at most 256 vectors. Rows in the bounded pending checkpoint window are regenerated directly instead of entering an unsafe restore-delete-create cycle against the live VECTOR index.
 - `gitnexus doctor --mcp-config --json` reuses the production policy resolver without binding MCP or opening an index.
 - `gitnexus doctor --registry --json` reports normalized-remote and alias collisions, metadata/database count drift, WAL/shadow state, and live eight-connection extension capability. Paths remain redacted unless explicitly requested locally.
 - Voyage requests for `voyage-code-3` now send the provider-native `output_dimension` field for 2,048-dimensional embeddings.
@@ -26,7 +26,7 @@
 - Concurrent attempts to index the same normalized GitHub remote produce one canonical winner and one stable collision error instead of duplicate registry rows.
 - Voyage-compatible embedding calls no longer fail because an OpenAI-specific dimension field was sent to the Voyage API.
 - Non-Git and `--skip-git` staged indexes stamp the current schema identity, so a valid embedding checkpoint resumes instead of being misclassified as pre-versioning metadata.
-- Interrupted staged resumes no longer fail with a duplicate `CodeEmbedding` primary key when a preserved legacy snapshot contains repeated embedding identities.
+- Interrupted staged resumes no longer fail with a duplicate `CodeEmbedding` primary key when a preserved legacy snapshot contains repeated identities or rows owned by the pending regeneration window.
 
 ## Known Boundaries
 

--- a/Documentation/releases/1.6.10-electric.3.md
+++ b/Documentation/releases/1.6.10-electric.3.md
@@ -32,13 +32,13 @@
 
 - Distribution is GitHub-only. Public npm dist-tags and container registries remain unchanged.
 - The exact-scan limit remains 20,000; this release fixes indexed retrieval rather than raising the fallback cap.
-- Voyage work runs exactly one repository at a time and has no host memory, swap, RSS, free-memory, or pressure gate. Optional resource JSONL is telemetry only. Local embedding backends require a separate explicit resource policy.
+- Voyage work runs exactly one repository at a time and has no host memory, swap, RSS, free-memory, or pressure gate. Optional resource JSONL is telemetry only. Remote HTTP/Voyage generation also defaults to no automatic node-count cap; the 50,000-node automatic cap is local-model-only, while explicit operator caps remain valid. Local embedding backends require a separate explicit resource policy.
 - A published release proves the exact artifact and release workflow. Side-by-side local installation, registry repair, fleet embedding refresh, and live Codex/Claude behavior are separate post-release gates.
 - Worktree branch-overlay indexing remains out of scope.
 
 ## Release Verification
 
-- Capability PRs: #129, #138, #139, #140, #142, #144, and #146; sprint epic: #130; release gate: #137.
+- Capability PRs: #129, #138, #139, #140, #142, #144, #146, #148, and #150; sprint epic: #130; release gate: #137.
 - Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.3`.
 - Required proof includes protected exact-head CI, pooled VECTOR integration, staged interruption/recovery tests, canonical identity and doctor suites, sequential large-repository Voyage soaks, and the protected Electric Release workflow.
 - The protected workflow publishes `electric/v1.6.10-electric.3` with one proved tarball plus `SHA256SUMS`; rollback retains `1.6.10-electric.2`.

--- a/Documentation/releases/1.6.10-electric.3.md
+++ b/Documentation/releases/1.6.10-electric.3.md
@@ -24,6 +24,7 @@
 - Malformed or ambiguous stdio allowlists initialize only in blocked mode: repository operations return a sanitized configuration error, with no partial allowlist acceptance and no unrestricted fallback. HTTP remains fail-fast.
 - Concurrent attempts to index the same normalized GitHub remote produce one canonical winner and one stable collision error instead of duplicate registry rows.
 - Voyage-compatible embedding calls no longer fail because an OpenAI-specific dimension field was sent to the Voyage API.
+- Non-Git and `--skip-git` staged indexes stamp the current schema identity, so a valid embedding checkpoint resumes instead of being misclassified as pre-versioning metadata.
 
 ## Known Boundaries
 
@@ -35,7 +36,7 @@
 
 ## Release Verification
 
-- Capability PRs: #129, #138, #139, #140, and #142; sprint epic: #130; release gate: #137.
+- Capability PRs: #129, #138, #139, #140, #142, and #144; sprint epic: #130; release gate: #137.
 - Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.3`.
 - Required proof includes protected exact-head CI, pooled VECTOR integration, staged interruption/recovery tests, canonical identity and doctor suites, sequential large-repository Voyage soaks, and the protected Electric Release workflow.
 - The protected workflow publishes `electric/v1.6.10-electric.3` with one proved tarball plus `SHA256SUMS`; rollback retains `1.6.10-electric.2`.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.2",
+  "version": "1.6.10-electric.3",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.2",
+  "version": "1.6.10-electric.3",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to GitNexus will be documented in this file.
 
 ### Changed
 
-- Large embedding work pages at bounded sizes and supports optional sanitized resource telemetry. Voyage indexing remains strictly one repository at a time and has no host memory, swap, RSS, or free-memory admission or termination gate.
+- Large embedding work pages at bounded sizes and supports optional sanitized resource telemetry. Voyage indexing remains strictly one repository at a time and has no host memory, swap, RSS, or free-memory admission or termination gate. Remote HTTP/Voyage defaults to no automatic node-count cap; the 50,000-node automatic cap applies only to local models unless an operator supplies an explicit limit.
 - Distribution remains GitHub-only as one tarball plus `SHA256SUMS`; npm and container registries are unchanged.
 
 ## [1.6.10-electric.2] - 2026-07-15

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.3] - 2026-07-20
+
+### Added
+
+- **Truthful retrieval status for every query** reports the active keyword and semantic modes, live embedding count, stable omission reason, and unchanged 20,000-row exact-scan limit (#131, #138)
+- **Bounded staged analysis for large repositories** builds beside the readable canonical index, checkpoints pending embedding work, resumes safely, journals promotion, and routes SIGTERM through the checkpoint path (#132, #139)
+- **Read-only MCP and registry doctors** validate production policy resolution and expose canonical-remote, alias, count, WAL/shadow, and live pooled-extension health without binding MCP or repairing state (#127, #133, #140)
+
+### Fixed
+
+- **Semantic retrieval remains available across the full LadybugDB read pool** by loading FTS and VECTOR on all eight prewarmed connections and treating partial capability or query failure as explicit degradation rather than a silent omission (#131, #138)
+- **Invalid stdio MCP repository policy is fail-closed and agent-visible** while tool discovery remains available; HTTP policy remains fail-fast and no malformed allowlist can fall back to unrestricted access (#129)
+- **GitHub SSH and HTTPS remotes share one canonical identity**, and concurrent or duplicate top-level registration is refused before index storage is created (#133, #140)
+- **Voyage 2,048-dimensional requests use the provider's `output_dimension` field** while OpenAI-compatible endpoints retain `dimensions` (#141, #142)
+
+### Changed
+
+- Large embedding work pages at bounded sizes and supports optional sanitized resource telemetry. Voyage indexing remains strictly one repository at a time and has no host memory, swap, RSS, or free-memory admission or termination gate.
+- Distribution remains GitHub-only as one tarball plus `SHA256SUMS`; npm and container registries are unchanged.
+
 ## [1.6.10-electric.2] - 2026-07-15
 
 ### Added

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to GitNexus will be documented in this file.
 - **Invalid stdio MCP repository policy is fail-closed and agent-visible** while tool discovery remains available; HTTP policy remains fail-fast and no malformed allowlist can fall back to unrestricted access (#129)
 - **GitHub SSH and HTTPS remotes share one canonical identity**, and concurrent or duplicate top-level registration is refused before index storage is created (#133, #140)
 - **Voyage 2,048-dimensional requests use the provider's `output_dimension` field** while OpenAI-compatible endpoints retain `dimensions` (#141, #142)
+- **Non-Git staged embedding checkpoints retain the current schema identity**, so restart resumes bounded pending work instead of forcing a pre-versioning rebuild (#143, #144)
 
 ### Changed
 

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to GitNexus will be documented in this file.
 - **GitHub SSH and HTTPS remotes share one canonical identity**, and concurrent or duplicate top-level registration is refused before index storage is created (#133, #140)
 - **Voyage 2,048-dimensional requests use the provider's `output_dimension` field** while OpenAI-compatible endpoints retain `dimensions` (#141, #142)
 - **Non-Git staged embedding checkpoints retain the current schema identity**, so restart resumes bounded pending work instead of forcing a pre-versioning rebuild (#143, #144)
+- **Legacy staged embedding snapshots restore duplicate identities once** while validating every physical row and keeping vector batches bounded, preventing duplicate-primary-key failures during resume (#145, #146)
 
 ### Changed
 

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to GitNexus will be documented in this file.
 - **GitHub SSH and HTTPS remotes share one canonical identity**, and concurrent or duplicate top-level registration is refused before index storage is created (#133, #140)
 - **Voyage 2,048-dimensional requests use the provider's `output_dimension` field** while OpenAI-compatible endpoints retain `dimensions` (#141, #142)
 - **Non-Git staged embedding checkpoints retain the current schema identity**, so restart resumes bounded pending work instead of forcing a pre-versioning rebuild (#143, #144)
-- **Legacy staged embedding snapshots restore duplicate identities once** while validating every physical row and keeping vector batches bounded, preventing duplicate-primary-key failures during resume (#145, #146)
+- **Staged embedding snapshot resume is idempotent**: legacy duplicate identities restore once, malformed vectors fail before mutation, and pending checkpoint rows regenerate without an unsafe restore-delete-create cycle against the live VECTOR index (#145, #146)
 
 ### Changed
 

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.2",
+  "version": "1.6.10-electric.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-electric.2",
+      "version": "1.6.10-electric.3",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.2",
+  "version": "1.6.10-electric.3",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Outcome

Prepare and publish the GitHub-only `1.6.10-electric.3` release after all source and large-repository gates pass.

Closes #137. Parent: #130. Source dependencies: #146, #148, and #150.

## Release identity

- Version: `1.6.10-electric.3`.
- Tag: `electric/v1.6.10-electric.3`.
- Distribution: one GitHub Release tarball plus `SHA256SUMS` only.
- npm dist-tags and container registries remain unchanged.
- `1.6.10-electric.2` remains installed for rollback.

## Included runtime changes

- Truthful pooled VECTOR retrieval and additive retrieval status.
- Bounded staged/checkpointed large-repository analysis with SIGTERM recovery.
- Fail-closed but agent-visible invalid stdio policy plus read-only MCP/registry doctors.
- Canonical normalized Git remote identity.
- Voyage-native 2,048-dimensional requests and remote-provider no-cap default.
- Current schema stamps for non-Git staged resume.
- Idempotent snapshot validation/restore and direct regeneration of pending checkpoint rows.

## Gates

- [x] PR #146 merged as `e68cc27eadf28e12cc15e4116a72e647c86ad702` with protected exact-head CI, current-head approval, and zero unresolved threads.
- [x] PR #148 restored exact-main full-history Gitleaks at merge `41eb5cc2fcaffc3a6975b323362c1ecc6ddcf28f`; PR #150 merged the local-model-only cap wording as `2444804d371c4203ca96f89ff63389114a551444`.
- [x] 85k staged Voyage interrupt/resume completed with exact counts and live VECTOR retrieval.
- [x] 125k staged Voyage interrupt/resume completed in 7,871.2s with exact 125,000 embeddings, clean promotion, live VECTOR doctor, two semantic queries, and a checksummed archive. The installed release artifact must reopen this index after publication.
- [x] Release branch head `93024df422a9b7057d7d0d7a3363135c029ba7bb` merges current main and differs by only the eight intended version/release files.
- [ ] Protected exact-head release PR checks and required approval pass.
- [ ] Electric Release workflow succeeds from current main and publishes the exact tag/assets.

## Voyage policy

Voyage runs exactly one repository at a time and has no host memory, swap, RSS,
free-memory, or pressure admission/termination gate. Optional resource JSONL is
telemetry only. Remote HTTP/Voyage defaults to no automatic node-count cap;
the automatic 50,000-node cap is local-model-only, while explicit operator
caps remain valid. Local embedding backends require a separate explicit policy.

## Proof boundary

Merge prepares release source; it does not itself prove a GitHub release,
side-by-side install, repaired registry/fleet, or live Codex/Claude behavior.
