### PR TITLE
ci: extend Windows shard watchdog

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -240,6 +240,12 @@ jobs:
         shell: bash
         env:
           SHARD: ${{ matrix.shard }}/${{ needs.shard-plan.outputs.total }}
+          # Shard 1 includes cli-e2e (about 4.5 minutes by itself). Two release
+          # runs completed every other file but reached the 15-minute process
+          # watchdog before cli-e2e could report its summary on slower Windows
+          # runners. Keep macOS at the default and give Windows bounded headroom
+          # inside the existing 25-minute job timeout.
+          GITNEXUS_CROSS_PLATFORM_TIMEOUT_MINUTES: ${{ runner.os == 'Windows' && '20' || '15' }}
         run: npx tsx scripts/run-cross-platform.ts --shard="$SHARD"
         working-directory: gitnexus
 


### PR DESCRIPTION
## Summary

- give Windows platform-sensitive shards a 20-minute process watchdog
- keep macOS at the existing 15-minute default
- retain the existing 25-minute GitHub job timeout

## Evidence

Electric release run 29799036268 reached the 15-minute process watchdog twice on the same Windows 1/3 shard, including its one unchanged failed-job retry. Both attempts completed every other shard file with no assertion failure; `test/integration/cli-e2e.test.ts` was the only file without a completion summary. The same exact source head passed this shard in PR CI, where `cli-e2e` alone took 280.9 seconds and the shard took 526 seconds. On slower release runners, the existing process watchdog expired before that last summary.

Exact-head PR CI job 88541973135 passed Windows 1/3 in 520 seconds under the bounded 20-minute process watchdog. This is CI-only headroom, not a runtime or release artifact behavior change.

Supports #137.

## Validation

- `actionlint .github/workflows/ci-tests.yml`
- `git diff --check`
- GitNexus `detect_changes`: 1 workflow file, 0 symbols, LOW risk
- Windows platform-sensitive 1/3: green at exact head `ca2f293bed2c61cbb0b973e923b1277d425da94f` (job 88541973135)
- Independent exact-head review: no validated findings

## Rollback

Revert this single workflow commit to restore the 15-minute default on Windows. The unchanged 25-minute GitHub job timeout remains the outer bound either way.
