### PR TITLE
fix: handle legacy recovery capabilities

### DIFF
--- a/gitnexus/src/core/incremental/recovery-plan.ts
+++ b/gitnexus/src/core/incremental/recovery-plan.ts
@@ -51,7 +51,7 @@ export async function buildRecoveryPlan(repoPath: string): Promise<RecoveryPlan>
     dirty,
     graph: { path: lbugPath, exists: graphBytes !== null, bytes: graphBytes },
     wal: { sidecars },
-    fts: { recordedStatus: meta?.capabilities?.fts.status ?? 'unknown' },
+    fts: { recordedStatus: meta?.capabilities?.fts?.status ?? 'unknown' },
     metadata: { path: metaPath, exists: meta !== null },
     embeddings: { recordedCount: meta?.stats?.embeddings ?? null },
   };

--- a/gitnexus/src/core/incremental/recovery-plan.ts
+++ b/gitnexus/src/core/incremental/recovery-plan.ts
@@ -1,6 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { getStoragePaths, loadMeta, type RepoMeta } from '../../storage/repo-manager.js';
+import {
+  getStoragePaths,
+  LEGACY_CAPABILITY_PROVIDER,
+  loadMeta,
+  type RepoMeta,
+} from '../../storage/repo-manager.js';
 
 export interface RecoveryPlan {
   repoPath: string;
@@ -40,6 +45,7 @@ export async function buildRecoveryPlan(repoPath: string): Promise<RecoveryPlan>
   }
 
   const dirty = meta?.incrementalInProgress ?? null;
+  const recordedFts = meta?.capabilities?.fts;
   return {
     repoPath: resolvedRepoPath,
     state: !meta ? 'unindexed' : dirty ? 'interrupted' : 'clean',
@@ -51,7 +57,12 @@ export async function buildRecoveryPlan(repoPath: string): Promise<RecoveryPlan>
     dirty,
     graph: { path: lbugPath, exists: graphBytes !== null, bytes: graphBytes },
     wal: { sidecars },
-    fts: { recordedStatus: meta?.capabilities?.fts?.status ?? 'unknown' },
+    fts: {
+      recordedStatus:
+        !recordedFts || recordedFts.provider === LEGACY_CAPABILITY_PROVIDER
+          ? 'unknown'
+          : recordedFts.status,
+    },
     metadata: { path: metaPath, exists: meta !== null },
     embeddings: { recordedCount: meta?.stats?.embeddings ?? null },
   };

--- a/gitnexus/src/storage/repo-manager.ts
+++ b/gitnexus/src/storage/repo-manager.ts
@@ -497,13 +497,77 @@ export const cleanupOldKuzuFiles = async (
   }
 };
 
+export const LEGACY_CAPABILITY_PROVIDER = 'legacy-metadata';
+
+type RecordedCapabilities = NonNullable<RepoMeta['capabilities']>;
+type RecordedAvailability = RecordedCapabilities['graph'];
+
+const isJsonRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizeRecordedAvailability = (value: unknown): RecordedAvailability => {
+  const recorded = isJsonRecord(value) ? value : {};
+  const status = recorded.status;
+  return {
+    provider:
+      typeof recorded.provider === 'string' ? recorded.provider : LEGACY_CAPABILITY_PROVIDER,
+    status:
+      status === 'available' || status === 'degraded' || status === 'unavailable'
+        ? status
+        : 'unavailable',
+  };
+};
+
+const normalizeRecordedVector = (value: unknown): RecordedCapabilities['vectorSearch'] => {
+  const recorded = isJsonRecord(value) ? value : {};
+  const status = recorded.status;
+  const exactScanLimit = Number(recorded.exactScanLimit);
+  const normalized: RecordedCapabilities['vectorSearch'] = {
+    provider:
+      typeof recorded.provider === 'string' ? recorded.provider : LEGACY_CAPABILITY_PROVIDER,
+    status:
+      status === 'vector-index' || status === 'exact-scan' || status === 'unavailable'
+        ? status
+        : 'unavailable',
+    exactScanLimit:
+      Number.isFinite(exactScanLimit) && exactScanLimit >= 0 ? Math.floor(exactScanLimit) : 0,
+  };
+  if (typeof recorded.reason === 'string') normalized.reason = recorded.reason;
+  return normalized;
+};
+
+/**
+ * Normalize parseable pre-capability metadata at the read boundary. `saveMeta`
+ * still accepts only the full RepoMeta contract; this compatibility path fills
+ * missing nested capability fields with conservative, non-positive values and
+ * never writes the synthesized shape back to disk.
+ */
+const normalizeLoadedMeta = (value: unknown): RepoMeta | null => {
+  if (!isJsonRecord(value)) return null;
+  const rawCapabilities = value.capabilities;
+  if (rawCapabilities === undefined) return value as unknown as RepoMeta;
+  if (!isJsonRecord(rawCapabilities)) {
+    return { ...value, capabilities: undefined } as unknown as RepoMeta;
+  }
+  return {
+    ...value,
+    capabilities: {
+      graph: normalizeRecordedAvailability(rawCapabilities.graph),
+      fts: normalizeRecordedAvailability(rawCapabilities.fts),
+      vectorSearch: normalizeRecordedVector(rawCapabilities.vectorSearch),
+    },
+  } as unknown as RepoMeta;
+};
+
 /**
  * Load metadata from the legacy `meta.json` mirror in the given directory.
  * Returns null when the file is absent, unreadable, or unparseable — a
  * corrupt legacy file is treated the same as a missing one (safe rebuild).
  */
-const loadMetaLegacy = async (metaDir: string): Promise<RepoMeta | null> =>
-  tryReadMetaFile(metaDir, LEGACY_METADATA_FILE);
+const loadMetaLegacy = async (metaDir: string): Promise<RepoMeta | null> => {
+  const legacy = await tryReadMetaFile(metaDir, LEGACY_METADATA_FILE);
+  return legacy ? normalizeLoadedMeta(legacy) : null;
+};
 
 /**
  * Load metadata from a directory containing the metadata file (gitnexus.json).
@@ -527,7 +591,7 @@ export const loadMeta = async (metaDir: string): Promise<RepoMeta | null> => {
     return isMissingFilesystemError(err) ? loadMetaLegacy(metaDir) : null;
   }
   try {
-    return JSON.parse(raw) as RepoMeta;
+    return normalizeLoadedMeta(JSON.parse(raw));
   } catch {
     // Corrupt primary file — do NOT mask it with legacy content.
     return null;

--- a/gitnexus/test/unit/recovery-plan.test.ts
+++ b/gitnexus/test/unit/recovery-plan.test.ts
@@ -72,4 +72,31 @@ describe('recovery plan', () => {
     expect(log.mock.calls[0]?.[0]).toContain(`Repository: ${repoPath}`);
     expect(log.mock.calls[0]?.[0]).toContain('State: unindexed');
   });
+
+  it('treats a missing nested FTS capability in legacy metadata as unknown', async () => {
+    const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-recovery-legacy-'));
+    temporaryRoots.push(repoPath);
+    const { storagePath } = getStoragePaths(repoPath);
+    await fs.mkdir(storagePath, { recursive: true });
+    await saveMeta(storagePath, {
+      repoPath,
+      lastCommit: 'legacy-commit',
+      indexedAt: '2026-07-21T00:00:00.000Z',
+      stats: { files: 20_492, nodes: 275_835, embeddings: 84_501 },
+      capabilities: {
+        vectorSearch: {
+          provider: 'ladybugdb-vector',
+          status: 'vector-index',
+        },
+      },
+    });
+
+    const plan = await buildRecoveryPlan(repoPath);
+
+    expect(plan.state).toBe('clean');
+    expect(plan.fts.recordedStatus).toBe('unknown');
+    expect(formatRecoveryPlan(plan)).toContain(
+      'FTS: preserve derived indexes (recorded status: unknown)',
+    );
+  });
 });

--- a/gitnexus/test/unit/recovery-plan.test.ts
+++ b/gitnexus/test/unit/recovery-plan.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { doctorCommand } from '../../src/cli/doctor.js';
 import { buildRecoveryPlan, formatRecoveryPlan } from '../../src/core/incremental/recovery-plan.js';
-import { getStoragePaths, saveMeta } from '../../src/storage/repo-manager.js';
+import { getStoragePaths, loadMeta, saveMeta } from '../../src/storage/repo-manager.js';
 
 const temporaryRoots: string[] = [];
 
@@ -76,9 +76,9 @@ describe('recovery plan', () => {
   it('treats a missing nested FTS capability in legacy metadata as unknown', async () => {
     const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-recovery-legacy-'));
     temporaryRoots.push(repoPath);
-    const { storagePath } = getStoragePaths(repoPath);
+    const { storagePath, metaPath } = getStoragePaths(repoPath);
     await fs.mkdir(storagePath, { recursive: true });
-    await saveMeta(storagePath, {
+    const rawLegacyMeta = JSON.stringify({
       repoPath,
       lastCommit: 'legacy-commit',
       indexedAt: '2026-07-21T00:00:00.000Z',
@@ -90,6 +90,18 @@ describe('recovery plan', () => {
         },
       },
     });
+    await fs.writeFile(metaPath, rawLegacyMeta, 'utf8');
+
+    const loaded = await loadMeta(storagePath);
+    expect(loaded?.capabilities).toEqual({
+      graph: { provider: 'legacy-metadata', status: 'unavailable' },
+      fts: { provider: 'legacy-metadata', status: 'unavailable' },
+      vectorSearch: {
+        provider: 'ladybugdb-vector',
+        status: 'vector-index',
+        exactScanLimit: 0,
+      },
+    });
 
     const plan = await buildRecoveryPlan(repoPath);
 
@@ -98,5 +110,6 @@ describe('recovery plan', () => {
     expect(formatRecoveryPlan(plan)).toContain(
       'FTS: preserve derived indexes (recorded status: unknown)',
     );
+    expect(await fs.readFile(metaPath, 'utf8')).toBe(rawLegacyMeta);
   });
 });


### PR DESCRIPTION
Closes #153

## What changed
- safely treat a missing nested FTS capability in valid legacy metadata as `unknown`
- add a regression fixture matching the partial capability shape observed on the preserved OpenClaw index

## Proof
- focused test failed before the fix with the installed `.3` TypeError
- `npm test -- --run test/unit/recovery-plan.test.ts` passes (3/3)
- `npx tsc --noEmit` passes
- `git diff --check` passes

The broad local suite was stopped as inconclusive because its reused cross-worktree dependency/worker harness slept without progress; exact-head GitHub CI is the canonical broad gate. No index, registry, staged lock, or metadata was mutated by this source fix.