### PR TITLE
fix: delete restored embeddings by exact identity

### DIFF
--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -362,6 +362,8 @@ export interface EmbeddingPipelineOptions {
   signal?: AbortSignal;
   checkpointEveryNodes?: number;
   forceReembedNodeIds?: ReadonlySet<string>;
+  /** Exact restored row identities, keyed by owner node, for PK-safe stale deletion. */
+  existingEmbeddingRowIds?: ReadonlyMap<string, readonly string[]>;
   /** Load cached node identities for one page; callers must return at most the requested IDs. */
   loadExistingEmbeddingHashes?: (
     nodeIds: readonly string[],
@@ -389,13 +391,29 @@ const deleteStaleEmbeddingRows = async (
     paramsList: Array<Record<string, any>>,
   ) => Promise<void>,
   nodeIds: string[],
+  existingEmbeddingRowIds?: ReadonlyMap<string, readonly string[]>,
 ): Promise<void> => {
   if (nodeIds.length === 0) return;
   try {
-    await executeWithReusedStatement(
-      `MATCH (e:${EMBEDDING_TABLE_NAME} {nodeId: $nodeId}) DELETE e`,
-      nodeIds.map((nodeId) => ({ nodeId })),
-    );
+    const exactRowIds: string[] = [];
+    const fallbackNodeIds: string[] = [];
+    for (const nodeId of nodeIds) {
+      const rowIds = existingEmbeddingRowIds?.get(nodeId);
+      if (rowIds && rowIds.length > 0) exactRowIds.push(...rowIds);
+      else fallbackNodeIds.push(nodeId);
+    }
+    if (exactRowIds.length > 0) {
+      await executeWithReusedStatement(
+        `MATCH (e:${EMBEDDING_TABLE_NAME} {id: $id}) DELETE e`,
+        [...new Set(exactRowIds)].map((id) => ({ id })),
+      );
+    }
+    if (fallbackNodeIds.length > 0) {
+      await executeWithReusedStatement(
+        `MATCH (e:${EMBEDDING_TABLE_NAME} {nodeId: $nodeId}) DELETE e`,
+        fallbackNodeIds.map((nodeId) => ({ nodeId })),
+      );
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (!msg.includes('does not exist')) {
@@ -526,7 +544,11 @@ export const runEmbeddingPipeline = async (
     }
 
     if (removedPendingNodeIds.size > 0) {
-      await deleteStaleEmbeddingRows(executeWithReusedStatement, [...removedPendingNodeIds]);
+      await deleteStaleEmbeddingRows(
+        executeWithReusedStatement,
+        [...removedPendingNodeIds],
+        pipelineOptions.existingEmbeddingRowIds,
+      );
       throwIfCancelled();
     }
 
@@ -649,7 +671,11 @@ export const runEmbeddingPipeline = async (
         const batchStaleIds = batch
           .filter((node) => pageHashes.has(node.id))
           .map((node) => node.id);
-        await deleteStaleEmbeddingRows(executeWithReusedStatement, batchStaleIds);
+        await deleteStaleEmbeddingRows(
+          executeWithReusedStatement,
+          batchStaleIds,
+          pipelineOptions.existingEmbeddingRowIds,
+        );
         throwIfCancelled();
 
         const embedSubBatch = Math.min(finalConfig.subBatchSize, MAX_EMBEDDING_SUB_BATCH_SIZE);

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -125,7 +125,7 @@ import {
 } from './embeddings/cache-snapshot.js';
 import { generateAIContextFiles } from '../cli/ai-context.js';
 import { sanitizeDetectedBranch } from '../cli/analyze-config.js';
-import { EMBEDDING_TABLE_NAME } from './lbug/schema.js';
+import { EMBEDDING_TABLE_NAME, STALE_HASH_SENTINEL } from './lbug/schema.js';
 import {
   discardStagedWorkspace,
   getStagedAnalyzePaths,
@@ -2047,6 +2047,14 @@ const runFullAnalysisImpl = async (
     // would finalize metadata with fewer vectors than the preserved snapshot.
     let restoredEmbeddingCount = 0;
     let skippedPendingEmbeddingRows = 0;
+    // Keep only restored row identities and one hash per owner node; vectors
+    // still stream through the bounded 256-row snapshot batches above. The
+    // exact row IDs are required because LadybugDB can make freshly restored
+    // non-PK nodeId predicates temporarily miss rows even while the PK sees
+    // them. Without this sidecar, stale regeneration can issue CREATE for a
+    // row that already exists and fail with a duplicate primary key (#155).
+    const restoredEmbeddingHashes = new Map<string, string>();
+    const restoredEmbeddingRowIds = new Map<string, string[]>();
     if (embeddingSnapshotInfo && embeddingSnapshotInfo.count > 0) {
       const cachedDims = embeddingSnapshotInfo.dimensions;
       const { EMBEDDING_DIMS } = await import('./lbug/schema.js');
@@ -2098,6 +2106,19 @@ const runFullAnalysisImpl = async (
             if (rowsToRestore.length > 0) {
               await batchInsert(executeWithReusedStatement, rowsToRestore);
               restoredEmbeddingCount += rowsToRestore.length;
+              for (const embedding of rowsToRestore) {
+                const restoredHash = embedding.contentHash || STALE_HASH_SENTINEL;
+                const priorHash = restoredEmbeddingHashes.get(embedding.nodeId);
+                restoredEmbeddingHashes.set(
+                  embedding.nodeId,
+                  priorHash === undefined || priorHash === restoredHash
+                    ? restoredHash
+                    : STALE_HASH_SENTINEL,
+                );
+                const rowIds = restoredEmbeddingRowIds.get(embedding.nodeId) ?? [];
+                rowIds.push(`${embedding.nodeId}:${embedding.chunkIndex}`);
+                restoredEmbeddingRowIds.set(embedding.nodeId, rowIds);
+              }
             }
             if (orphanRowIds.length > 0) {
               try {
@@ -2283,8 +2304,15 @@ const runFullAnalysisImpl = async (
         undefined,
         {
           forceReembedNodeIds: pendingEmbeddingNodeIds,
-          loadExistingEmbeddingHashes: (nodeIds) =>
-            fetchExistingEmbeddingHashesForNodeIds(executeQuery, nodeIds),
+          existingEmbeddingRowIds: restoredEmbeddingRowIds,
+          loadExistingEmbeddingHashes: async (nodeIds) => {
+            const hashes = await fetchExistingEmbeddingHashesForNodeIds(executeQuery, nodeIds);
+            for (const nodeId of nodeIds) {
+              const restoredHash = restoredEmbeddingHashes.get(nodeId);
+              if (restoredHash !== undefined) hashes.set(nodeId, restoredHash);
+            }
+            return hashes;
+          },
           onCheckpointWindowStart: async ({ nodeIds, ...checkpoint }) => {
             await saveEmbeddingCheckpoint(checkpoint, nodeIds, existingMeta?.stats?.embeddings);
           },

--- a/gitnexus/test/unit/embedding-pipeline.test.ts
+++ b/gitnexus/test/unit/embedding-pipeline.test.ts
@@ -606,6 +606,39 @@ describe('runEmbeddingPipeline incremental filter', () => {
     expect(createCalls.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('deletes restored stale rows by exact primary key before recreating them (#155)', async () => {
+    mockEmbedderSetup();
+
+    const node = makeNode({ content: 'function foo() { return 42; }' });
+    const existingEmbeddings = new Map<string, string>([[node.id, 'wronghash']]);
+    const existingEmbeddingRowIds = new Map<string, readonly string[]>([
+      [node.id, [`${node.id}:0`, `${node.id}:1`]],
+    ]);
+    const executeQuery = mockExecuteQuery([node]);
+    const executeWithReusedStatement = mockExecuteWithReusedStatement();
+
+    const { runEmbeddingPipeline } =
+      await import('../../src/core/embeddings/embedding-pipeline.js');
+
+    await runEmbeddingPipeline(
+      executeQuery,
+      executeWithReusedStatement,
+      onProgress,
+      {},
+      undefined,
+      existingEmbeddings,
+      { existingEmbeddingRowIds },
+    );
+
+    const deleteCalls = stmtCalls.filter((call) => call.cypher.includes('DELETE'));
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0].cypher).toContain('{id: $id}');
+    expect(deleteCalls[0].params).toEqual([{ id: `${node.id}:0` }, { id: `${node.id}:1` }]);
+
+    const createCalls = stmtCalls.filter((call) => call.cypher.includes('CREATE'));
+    expect(createCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
   it('treats STALE_HASH_SENTINEL as stale — triggers re-embed', async () => {
     mockEmbedderSetup();
 

--- a/gitnexus/test/unit/run-analyze-fts-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-fts-repair.test.ts
@@ -814,6 +814,109 @@ describe('runFullAnalysis wipe-and-restore vector-index stamp (tri-review 466951
       await tmpRepo.cleanup();
     }
   });
+
+  it('passes restored hashes and exact row identities to the embedding pipeline (#155)', async () => {
+    const restoredNodeId = 'Function:src/app.ts:handler';
+    const stubNode = {
+      id: restoredNodeId,
+      label: 'Function',
+      name: 'handler',
+      properties: { filePath: 'src/app.ts' },
+    };
+    const runEmbeddingPipeline = vi.fn(async () => ({
+      nodesProcessed: 1,
+      chunksProcessed: 1,
+      vectorIndexReady: true,
+      semanticMode: 'vector-index' as const,
+    }));
+    const fetchExistingEmbeddingHashesForNodeIds = vi.fn(async () => new Map<string, string>());
+    vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
+      initLbug: vi.fn(async () => undefined),
+      loadGraphToLbug: vi.fn(async () => undefined),
+      getLbugStats: vi.fn(async () => ({ nodes: 1, edges: 0, communities: 0, processes: 0 })),
+      executeQuery: vi.fn(async (cypher: string) =>
+        /RETURN count\(e\) AS cnt/.test(cypher) ? [{ cnt: 2 }] : [],
+      ),
+      executeWithReusedStatement: vi.fn(async () => undefined),
+      closeLbug: vi.fn(async () => undefined),
+      wipeLbugDbFiles: vi.fn(async () => undefined),
+      loadCachedEmbeddings: vi.fn(async () => ({
+        embeddingNodeIds: new Set([restoredNodeId]),
+        embeddings: [0, 1].map((chunkIndex) => ({
+          nodeId: restoredNodeId,
+          chunkIndex,
+          startLine: chunkIndex + 1,
+          endLine: chunkIndex + 2,
+          embedding: new Array(EMBEDDING_DIMS).fill(0),
+          contentHash: 'restored-hash',
+        })),
+      })),
+      fetchExistingEmbeddingHashesForNodeIds,
+      deleteNodesForFiles: vi.fn(async () => undefined),
+      deleteAllCommunitiesAndProcesses: vi.fn(async () => undefined),
+      queryImportersBatch: vi.fn(async () => []),
+      loadFTSExtension: vi.fn(async () => false),
+      DELETE_FILES_CHUNK_SIZE: 200,
+    }));
+    vi.doMock('../../src/core/search/fts-indexes.js', () => ({
+      initialiseSearchFTSStemmer: vi.fn(() => 'porter'),
+      createSearchFTSIndexes: vi.fn(async () => undefined),
+      verifySearchFTSIndexes: vi.fn(async () => []),
+    }));
+    vi.doMock('../../src/core/ingestion/pipeline.js', () => ({
+      runPipelineFromRepo: vi.fn(async (repoPath: string) => ({
+        repoPath,
+        totalFileCount: 1,
+        graph: {
+          forEachNode: (fn: (node: typeof stubNode) => void) => fn(stubNode),
+          getNode: (id: string) => (id === restoredNodeId ? stubNode : undefined),
+        },
+      })),
+    }));
+    vi.doMock('../../src/storage/repo-manager.js', async (importActual) => ({
+      ...(await importActual<typeof import('../../src/storage/repo-manager.js')>()),
+      registerRepo: vi.fn(async () => 'restored-identity-repo'),
+      ensureGitNexusIgnored: vi.fn(async () => undefined),
+    }));
+    vi.doMock('../../src/core/embeddings/embedding-pipeline.js', async (importActual) => ({
+      ...(await importActual<typeof import('../../src/core/embeddings/embedding-pipeline.js')>()),
+      runEmbeddingPipeline,
+      buildVectorIndex: vi.fn(async () => true),
+    }));
+
+    const tmpRepo = await createTempDir('gitnexus-run-analyze-restored-identities-');
+    try {
+      const { storagePath } = getStoragePaths(tmpRepo.dbPath);
+      await fs.mkdir(storagePath, { recursive: true });
+      await saveMeta(storagePath, {
+        repoPath: tmpRepo.dbPath,
+        lastCommit: '',
+        indexedAt: new Date().toISOString(),
+        stats: { embeddings: 2 },
+      });
+
+      const { runFullAnalysis } = await import('../../src/core/run-analyze.js');
+      await runFullAnalysis(
+        tmpRepo.dbPath,
+        { force: true, embeddings: true, embeddingsNodeLimit: 0 },
+        { onProgress: () => {} },
+      );
+
+      expect(runEmbeddingPipeline).toHaveBeenCalledOnce();
+      const pipelineOptions = runEmbeddingPipeline.mock.calls[0][6];
+      expect(pipelineOptions.existingEmbeddingRowIds.get(restoredNodeId)).toEqual([
+        `${restoredNodeId}:0`,
+        `${restoredNodeId}:1`,
+      ]);
+      const hashes = await pipelineOptions.loadExistingEmbeddingHashes([restoredNodeId]);
+      expect(hashes.get(restoredNodeId)).toBe('restored-hash');
+      expect(fetchExistingEmbeddingHashesForNodeIds).toHaveBeenCalledWith(expect.any(Function), [
+        restoredNodeId,
+      ]);
+    } finally {
+      await tmpRepo.cleanup();
+    }
+  });
 });
 
 /**


### PR DESCRIPTION
Closes #155.

A staged schema rebuild can restore CodeEmbedding rows that LadybugDB finds by primary key but temporarily misses through a non-primary nodeId predicate. The bounded page hash loader then treats a stale restored node as new and attempts a duplicate CREATE.

This change records only restored row identities and one content hash per owner while vectors continue streaming in batches of 256. Restored hashes override the unreliable page predicate, and stale restored rows are deleted by exact primary key before regeneration. Existing checkpoint-window and per-batch interleaving behavior is unchanged.

Proof:
- focused embedding, hash, run-analyze, and 25k x 2048 tests: 65 passed
- npx tsc --noEmit
- git diff --check
- pre-commit GitNexus change map: high because runEmbeddingPipeline participates in nine embedding/vector flows; no unrelated changed surface