### PR TITLE
fix: bound Swift target namespace sharing

### DIFF
--- a/gitnexus/src/core/ingestion/languages/swift/sibling-type-bindings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/sibling-type-bindings.ts
@@ -35,7 +35,11 @@ import type { ParsedFile, ScopeId, TypeRef } from 'gitnexus-shared';
 import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
 import type { WorkspaceResolutionIndex } from '../../scope-resolution/workspace-index.js';
 import { followChainPostFinalize } from '../../scope-resolution/passes/imported-return-types.js';
-import { coerceSwiftTargets, groupSwiftFilesBySpmTarget } from './target-grouping.js';
+import {
+  groupParsedSwiftFilesBySpmTarget,
+  registerSwiftTargetAccess,
+  swiftTargetNamespaceKey,
+} from './target-grouping.js';
 
 export function mirrorSwiftSiblingTypeBindings(
   parsedFiles: readonly ParsedFile[],
@@ -47,18 +51,13 @@ export function mirrorSwiftSiblingTypeBindings(
 
   // Group files by SPM target subtree (the module). No-source-dir → all
   // files in one `__default__` bucket.
-  const targets = coerceSwiftTargets(resolutionConfig);
-  const filesByTarget = groupSwiftFilesBySpmTarget(
-    parsedFiles,
-    (parsed) => parsed.filePath,
-    targets,
-  );
+  const filesByTarget = groupParsedSwiftFilesBySpmTarget(parsedFiles, resolutionConfig);
   const sharedTypes = indexes.namespaceTypeBindings as Map<string, Map<string, TypeRef>>;
   const accessibleTargets = indexes.accessibleNamespacesByScope as Map<ScopeId, string[]>;
 
   for (const [targetName, group] of filesByTarget) {
     if (group.length < 2) continue; // no siblings to mirror from
-    const targetKey = `swift-target:${targetName}`;
+    const targetKey = swiftTargetNamespaceKey(targetName);
     let targetTypes = sharedTypes.get(targetKey);
     if (targetTypes === undefined) {
       targetTypes = new Map<string, TypeRef>();
@@ -66,7 +65,7 @@ export function mirrorSwiftSiblingTypeBindings(
     }
 
     for (const parsed of group) {
-      registerTargetAccess(accessibleTargets, parsed.moduleScope, targetKey);
+      registerSwiftTargetAccess(accessibleTargets, parsed.moduleScope, targetKey);
     }
     for (const parsed of group) {
       const sourceModule = moduleScopeByFile.get(parsed.filePath);
@@ -76,18 +75,5 @@ export function mirrorSwiftSiblingTypeBindings(
         targetTypes.set(name, followChainPostFinalize(ref, sourceModule.id, indexes));
       }
     }
-  }
-}
-
-function registerTargetAccess(
-  accessibleTargets: Map<ScopeId, string[]>,
-  scopeId: ScopeId,
-  targetKey: string,
-): void {
-  const existing = accessibleTargets.get(scopeId);
-  if (existing === undefined) {
-    accessibleTargets.set(scopeId, [targetKey]);
-  } else if (!existing.includes(targetKey)) {
-    existing.push(targetKey);
   }
 }

--- a/gitnexus/src/core/ingestion/languages/swift/sibling-type-bindings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/sibling-type-bindings.ts
@@ -12,10 +12,12 @@
  * to resolve `user.save()` cross-file, App.swift's scope chain must be
  * able to follow `getUser → User`. The function return-type binding
  * (`getUser → User`) lives on Models.swift's module scope, so we mirror
- * sibling module-scope typeBindings into the importer's module scope —
- * the same trick Go uses (`mirrorGoNamespaceTypeBindings`), but Swift has
- * no namespace-import edges, so module membership is the SPM target
- * subtree (`Sources/<Target>/…`): threaded in via the SPM target map
+ * sibling module-scope typeBindings once into the target's shared
+ * `namespaceTypeBindings` channel. Each module scope is gated to its target
+ * through `accessibleNamespacesByScope`, so lookup sees exactly its siblings
+ * without the old O(files x bindings) per-module copy. Swift has no
+ * namespace-import edges, so module membership is the SPM target subtree
+ * (`Sources/<Target>/…`): threaded in via the SPM target map
  * (`resolutionConfig` → `coerceSwiftTargets`) and grouped by
  * `groupSwiftFilesBySpmTarget` (replicating legacy `groupSwiftFilesByTarget`;
  * no-source-dir → all files form one `__default__` module).
@@ -29,7 +31,7 @@
  * sanctioned non-frozen Map cast (Contract Invariant I6).
  */
 
-import type { ParsedFile, TypeRef } from 'gitnexus-shared';
+import type { ParsedFile, ScopeId, TypeRef } from 'gitnexus-shared';
 import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
 import type { WorkspaceResolutionIndex } from '../../scope-resolution/workspace-index.js';
 import { followChainPostFinalize } from '../../scope-resolution/passes/imported-return-types.js';
@@ -51,28 +53,41 @@ export function mirrorSwiftSiblingTypeBindings(
     (parsed) => parsed.filePath,
     targets,
   );
+  const sharedTypes = indexes.namespaceTypeBindings as Map<string, Map<string, TypeRef>>;
+  const accessibleTargets = indexes.accessibleNamespacesByScope as Map<ScopeId, string[]>;
 
-  for (const [, group] of filesByTarget) {
+  for (const [targetName, group] of filesByTarget) {
     if (group.length < 2) continue; // no siblings to mirror from
-    const files = group.map((parsed) => parsed.filePath);
-    for (const importerFile of files) {
-      const importerModule = moduleScopeByFile.get(importerFile);
-      if (importerModule === undefined) continue;
+    const targetKey = `swift-target:${targetName}`;
+    let targetTypes = sharedTypes.get(targetKey);
+    if (targetTypes === undefined) {
+      targetTypes = new Map<string, TypeRef>();
+      sharedTypes.set(targetKey, targetTypes);
+    }
 
-      for (const sourceFile of files) {
-        if (sourceFile === importerFile) continue;
-        const sourceModule = moduleScopeByFile.get(sourceFile);
-        if (sourceModule === undefined) continue;
-
-        for (const [name, ref] of sourceModule.typeBindings) {
-          if (name.length === 0) continue;
-          // A local annotation on the importer must win over a sibling's.
-          if (importerModule.typeBindings.has(name)) continue;
-
-          const terminal = followChainPostFinalize(ref, sourceModule.id, indexes);
-          (importerModule.typeBindings as Map<string, TypeRef>).set(name, terminal);
-        }
+    for (const parsed of group) {
+      registerTargetAccess(accessibleTargets, parsed.moduleScope, targetKey);
+    }
+    for (const parsed of group) {
+      const sourceModule = moduleScopeByFile.get(parsed.filePath);
+      if (sourceModule === undefined) continue;
+      for (const [name, ref] of sourceModule.typeBindings) {
+        if (name.length === 0 || targetTypes.has(name)) continue;
+        targetTypes.set(name, followChainPostFinalize(ref, sourceModule.id, indexes));
       }
     }
+  }
+}
+
+function registerTargetAccess(
+  accessibleTargets: Map<ScopeId, string[]>,
+  scopeId: ScopeId,
+  targetKey: string,
+): void {
+  const existing = accessibleTargets.get(scopeId);
+  if (existing === undefined) {
+    accessibleTargets.set(scopeId, [targetKey]);
+  } else if (!existing.includes(targetKey)) {
+    existing.push(targetKey);
   }
 }

--- a/gitnexus/src/core/ingestion/languages/swift/target-grouping.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/target-grouping.ts
@@ -25,9 +25,17 @@
  * one bucket per file. Do not copy the import-config behavior here.
  */
 
+import type { ParsedFile, ScopeId } from 'gitnexus-shared';
 import type { SwiftPackageConfig } from '../../language-config.js';
 
 const DEFAULT_TARGET = '__default__';
+const parsedFileGroupsCache = new WeakMap<
+  readonly ParsedFile[],
+  {
+    readonly resolutionConfig: unknown;
+    readonly groups: ReadonlyMap<string, readonly ParsedFile[]>;
+  }
+>();
 
 /**
  * Group `items` by SPM target subtree, replicating legacy
@@ -101,4 +109,43 @@ export function coerceSwiftTargets(resolutionConfig: unknown): ReadonlyMap<strin
     return config.targets;
   }
   return null;
+}
+
+/**
+ * Group parsed Swift files once for the sibling-definition and sibling-type
+ * passes. Both passes receive the same parsed-files array and opaque resolution
+ * config during one workspace run, so a weak identity cache avoids rebuilding
+ * the target buckets while allowing the workspace objects to be collected.
+ */
+export function groupParsedSwiftFilesBySpmTarget(
+  parsedFiles: readonly ParsedFile[],
+  resolutionConfig: unknown,
+): ReadonlyMap<string, readonly ParsedFile[]> {
+  const cached = parsedFileGroupsCache.get(parsedFiles);
+  if (cached !== undefined && cached.resolutionConfig === resolutionConfig) return cached.groups;
+
+  const groups = groupSwiftFilesBySpmTarget(
+    parsedFiles,
+    (parsed) => parsed.filePath,
+    coerceSwiftTargets(resolutionConfig),
+  );
+  parsedFileGroupsCache.set(parsedFiles, { resolutionConfig, groups });
+  return groups;
+}
+
+export function swiftTargetNamespaceKey(targetName: string): string {
+  return `swift-target:${targetName}`;
+}
+
+export function registerSwiftTargetAccess(
+  accessibleTargets: Map<ScopeId, string[]>,
+  scopeId: ScopeId,
+  targetKey: string,
+): void {
+  const existing = accessibleTargets.get(scopeId);
+  if (existing === undefined) {
+    accessibleTargets.set(scopeId, [targetKey]);
+  } else if (!existing.includes(targetKey)) {
+    existing.push(targetKey);
+  }
 }

--- a/gitnexus/src/core/ingestion/languages/swift/target-siblings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/target-siblings.ts
@@ -17,13 +17,15 @@
  * single-Xcode-project assumption). Every `.swift` file in the same target
  * sees its siblings' top-level defs.
  *
- * Bindings are added through the append-only `bindingAugmentations`
- * channel (Contract Invariant I8) with `origin: 'namespace'`, exactly
- * like the Go implementation — `indexes.bindings` is frozen post-
- * finalize and must not be mutated.
+ * Bindings are added once per SPM target through the shared
+ * `namespaceFqnBindings` channel, gated for each module scope by
+ * `accessibleNamespacesByScope`. This preserves same-target visibility and
+ * local-first lookup without copying every target definition into every file
+ * (the old O(files x definitions) fan-out exhausted the heap on large Xcode
+ * workspaces with no Package.swift).
  */
 
-import type { BindingRef, ParsedFile, ScopeId, SymbolDefinition } from 'gitnexus-shared';
+import type { BindingRef, ParsedFile, ScopeId } from 'gitnexus-shared';
 import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
 import { coerceSwiftTargets, groupSwiftFilesBySpmTarget } from './target-grouping.js';
 
@@ -44,46 +46,51 @@ export function populateSwiftTargetSiblings(
     targets,
   );
 
-  const augmentations = indexes.bindingAugmentations as Map<ScopeId, Map<string, BindingRef[]>>;
+  const namespaceBindings = indexes.namespaceFqnBindings as Map<string, Map<string, BindingRef[]>>;
+  const accessibleTargets = indexes.accessibleNamespacesByScope as Map<ScopeId, string[]>;
 
-  for (const [, group] of filesByTarget) {
+  for (const [targetName, group] of filesByTarget) {
     if (group.length < 2) continue; // no siblings to share
-    const siblings = group.map((parsed) => ({
-      filePath: parsed.filePath,
-      defs: [...parsed.localDefs] as SymbolDefinition[],
-    }));
-    for (const target of siblings) {
-      for (const receiver of siblings) {
-        if (receiver.filePath === target.filePath) continue; // no self-reference
-        const receiverModule = indexes.moduleScopes.byFilePath.get(receiver.filePath);
-        if (receiverModule === undefined) continue;
+    const targetKey = `swift-target:${targetName}`;
+    let targetBindings = namespaceBindings.get(targetKey);
+    if (targetBindings === undefined) {
+      targetBindings = new Map<string, BindingRef[]>();
+      namespaceBindings.set(targetKey, targetBindings);
+    }
+    const seenByName = new Map<string, Set<string>>();
 
-        for (const def of target.defs) {
-          const name = def.qualifiedName?.split('.').pop() ?? def.qualifiedName ?? '';
-          if (name === '') continue;
-          const bucket = getAugmentationBucket(augmentations, receiverModule, name);
-          if (bucket.some((b) => b.def.nodeId === def.nodeId)) continue;
-          bucket.push({ def, origin: 'namespace' });
+    for (const parsed of group) {
+      registerTargetAccess(accessibleTargets, parsed.moduleScope, targetKey);
+      for (const def of parsed.localDefs) {
+        const name = def.qualifiedName?.split('.').pop() ?? def.qualifiedName ?? '';
+        if (name === '') continue;
+        let bucket = targetBindings.get(name);
+        if (bucket === undefined) {
+          bucket = [];
+          targetBindings.set(name, bucket);
         }
+        let seen = seenByName.get(name);
+        if (seen === undefined) {
+          seen = new Set(bucket.map((binding) => binding.def.nodeId));
+          seenByName.set(name, seen);
+        }
+        if (seen.has(def.nodeId)) continue;
+        seen.add(def.nodeId);
+        bucket.push({ def, origin: 'namespace' });
       }
     }
   }
 }
 
-function getAugmentationBucket(
-  augmentations: Map<ScopeId, Map<string, BindingRef[]>>,
+function registerTargetAccess(
+  accessibleTargets: Map<ScopeId, string[]>,
   scopeId: ScopeId,
-  name: string,
-): BindingRef[] {
-  let scopeBindings = augmentations.get(scopeId);
-  if (scopeBindings === undefined) {
-    scopeBindings = new Map<string, BindingRef[]>();
-    augmentations.set(scopeId, scopeBindings);
+  targetKey: string,
+): void {
+  const existing = accessibleTargets.get(scopeId);
+  if (existing === undefined) {
+    accessibleTargets.set(scopeId, [targetKey]);
+  } else if (!existing.includes(targetKey)) {
+    existing.push(targetKey);
   }
-  let bucketArr = scopeBindings.get(name);
-  if (bucketArr === undefined) {
-    bucketArr = [];
-    scopeBindings.set(name, bucketArr);
-  }
-  return bucketArr;
 }

--- a/gitnexus/src/core/ingestion/languages/swift/target-siblings.ts
+++ b/gitnexus/src/core/ingestion/languages/swift/target-siblings.ts
@@ -27,7 +27,11 @@
 
 import type { BindingRef, ParsedFile, ScopeId } from 'gitnexus-shared';
 import type { ScopeResolutionIndexes } from '../../model/scope-resolution-indexes.js';
-import { coerceSwiftTargets, groupSwiftFilesBySpmTarget } from './target-grouping.js';
+import {
+  groupParsedSwiftFilesBySpmTarget,
+  registerSwiftTargetAccess,
+  swiftTargetNamespaceKey,
+} from './target-grouping.js';
 
 export function populateSwiftTargetSiblings(
   parsedFiles: readonly ParsedFile[],
@@ -39,19 +43,14 @@ export function populateSwiftTargetSiblings(
 ): void {
   // Group files by SPM target subtree (the module). No-source-dir → all
   // files in one `__default__` bucket.
-  const targets = coerceSwiftTargets(ctx.resolutionConfig);
-  const filesByTarget = groupSwiftFilesBySpmTarget(
-    parsedFiles,
-    (parsed) => parsed.filePath,
-    targets,
-  );
+  const filesByTarget = groupParsedSwiftFilesBySpmTarget(parsedFiles, ctx.resolutionConfig);
 
   const namespaceBindings = indexes.namespaceFqnBindings as Map<string, Map<string, BindingRef[]>>;
   const accessibleTargets = indexes.accessibleNamespacesByScope as Map<ScopeId, string[]>;
 
   for (const [targetName, group] of filesByTarget) {
     if (group.length < 2) continue; // no siblings to share
-    const targetKey = `swift-target:${targetName}`;
+    const targetKey = swiftTargetNamespaceKey(targetName);
     let targetBindings = namespaceBindings.get(targetKey);
     if (targetBindings === undefined) {
       targetBindings = new Map<string, BindingRef[]>();
@@ -60,7 +59,7 @@ export function populateSwiftTargetSiblings(
     const seenByName = new Map<string, Set<string>>();
 
     for (const parsed of group) {
-      registerTargetAccess(accessibleTargets, parsed.moduleScope, targetKey);
+      registerSwiftTargetAccess(accessibleTargets, parsed.moduleScope, targetKey);
       for (const def of parsed.localDefs) {
         const name = def.qualifiedName?.split('.').pop() ?? def.qualifiedName ?? '';
         if (name === '') continue;
@@ -79,18 +78,5 @@ export function populateSwiftTargetSiblings(
         bucket.push({ def, origin: 'namespace' });
       }
     }
-  }
-}
-
-function registerTargetAccess(
-  accessibleTargets: Map<ScopeId, string[]>,
-  scopeId: ScopeId,
-  targetKey: string,
-): void {
-  const existing = accessibleTargets.get(scopeId);
-  if (existing === undefined) {
-    accessibleTargets.set(scopeId, [targetKey]);
-  } else if (!existing.includes(targetKey)) {
-    existing.push(targetKey);
   }
 }

--- a/gitnexus/test/unit/scope-resolution/swift/shared-target-bindings.test.ts
+++ b/gitnexus/test/unit/scope-resolution/swift/shared-target-bindings.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { ParsedFile, Scope, ScopeId, SymbolDefinition, TypeRef } from 'gitnexus-shared';
+import { finalizeScopeModel } from '../../../../src/core/ingestion/finalize-orchestrator.js';
+import { populateSwiftTargetSiblings } from '../../../../src/core/ingestion/languages/swift/target-siblings.js';
+import { mirrorSwiftSiblingTypeBindings } from '../../../../src/core/ingestion/languages/swift/sibling-type-bindings.js';
+import { buildWorkspaceResolutionIndex } from '../../../../src/core/ingestion/scope-resolution/workspace-index.js';
+import {
+  findReceiverTypeBinding,
+  lookupBindingsAt,
+} from '../../../../src/core/ingestion/scope-resolution/scope/walkers.js';
+
+const RANGE = { startLine: 1, startCol: 0, endLine: 10, endCol: 0 } as const;
+
+function parsedFile(
+  filePath: string,
+  defName: string,
+  typeBindings: ReadonlyMap<string, TypeRef> = new Map(),
+): ParsedFile {
+  const moduleScope = `scope:${filePath}#1:0-10:0:Module` as ScopeId;
+  const def: SymbolDefinition = {
+    nodeId: `def:${filePath}:${defName}`,
+    filePath,
+    type: 'Class',
+    qualifiedName: defName,
+  };
+  const scope: Scope = {
+    id: moduleScope,
+    parent: null,
+    kind: 'Module',
+    range: RANGE,
+    filePath,
+    bindings: new Map([[defName, [{ def, origin: 'local' }]]]),
+    ownedDefs: [def],
+    imports: [],
+    typeBindings,
+  };
+  return {
+    filePath,
+    moduleScope,
+    scopes: [scope],
+    parsedImports: [],
+    localDefs: [def],
+    referenceSites: [],
+  };
+}
+
+function populate(
+  parsedFiles: readonly ParsedFile[],
+  targets: ReadonlyMap<string, string> | null = null,
+) {
+  const indexes = finalizeScopeModel(parsedFiles);
+  const workspaceIndex = buildWorkspaceResolutionIndex(parsedFiles, indexes.scopeTree);
+  const resolutionConfig = targets === null ? undefined : { targets };
+  populateSwiftTargetSiblings(parsedFiles, indexes, {
+    fileContents: new Map(),
+    resolutionConfig,
+  });
+  mirrorSwiftSiblingTypeBindings(parsedFiles, indexes, workspaceIndex, resolutionConfig);
+  return { indexes, workspaceIndex };
+}
+
+function totalBindingRefs(
+  buckets: ReadonlyMap<string, ReadonlyMap<string, readonly unknown[]>>,
+): number {
+  let total = 0;
+  for (const names of buckets.values()) {
+    for (const refs of names.values()) total += refs.length;
+  }
+  return total;
+}
+
+describe('Swift same-target shared binding channels', () => {
+  it('stores one binding per definition instead of copying every definition to every module', () => {
+    const files = Array.from({ length: 100 }, (_, i) =>
+      parsedFile(`Sources/App/File${i}.swift`, `Type${i}`),
+    );
+
+    const { indexes } = populate(files);
+
+    expect(indexes.bindingAugmentations.size).toBe(0);
+    expect(indexes.namespaceFqnBindings.size).toBe(1);
+    expect(totalBindingRefs(indexes.namespaceFqnBindings)).toBe(100);
+    expect(indexes.accessibleNamespacesByScope.size).toBe(100);
+  });
+
+  it('preserves local-first lookup and isolates definitions between SPM targets', () => {
+    const alphaLocal = parsedFile('Sources/Alpha/A.swift', 'User');
+    const alphaSibling = parsedFile('Sources/Alpha/B.swift', 'User');
+    const beta = parsedFile('Sources/Beta/User.swift', 'User');
+    const targets = new Map([
+      ['Alpha', 'Sources/Alpha'],
+      ['Beta', 'Sources/Beta'],
+    ]);
+
+    const { indexes } = populate([alphaLocal, alphaSibling, beta], targets);
+    const refs = lookupBindingsAt(alphaLocal.moduleScope, 'User', indexes);
+
+    expect(refs.map((ref) => ref.def.nodeId)).toEqual([
+      'def:Sources/Alpha/A.swift:User',
+      'def:Sources/Alpha/B.swift:User',
+    ]);
+    expect(refs.some((ref) => ref.def.filePath.startsWith('Sources/Beta/'))).toBe(false);
+  });
+
+  it('shares return-type bindings once per target without mutating sibling module scopes', () => {
+    const sourceScope = 'scope:Sources/App/Models.swift#1:0-10:0:Module' as ScopeId;
+    const getUserType: TypeRef = {
+      rawName: 'User',
+      declaredAtScope: sourceScope,
+      source: 'return-annotation',
+    };
+    const source = parsedFile(
+      'Sources/App/Models.swift',
+      'User',
+      new Map([['getUser', getUserType]]),
+    );
+    const consumer = parsedFile('Sources/App/App.swift', 'App');
+
+    const { indexes } = populate([source, consumer]);
+
+    const consumerModule = indexes.scopeTree.getScope(consumer.moduleScope)!;
+    expect(consumerModule.typeBindings.has('getUser')).toBe(false);
+    expect(indexes.namespaceTypeBindings.size).toBe(1);
+    expect(findReceiverTypeBinding(consumer.moduleScope, 'getUser', indexes)).toEqual(getUserType);
+  });
+});

--- a/gitnexus/test/unit/scope-resolution/swift/target-grouping.test.ts
+++ b/gitnexus/test/unit/scope-resolution/swift/target-grouping.test.ts
@@ -20,8 +20,10 @@
  * (no `instanceof` on the config object) and returns `null` otherwise.
  */
 import { describe, it, expect } from 'vitest';
+import type { ParsedFile } from 'gitnexus-shared';
 import {
   groupSwiftFilesBySpmTarget,
+  groupParsedSwiftFilesBySpmTarget,
   coerceSwiftTargets,
 } from '../../../../src/core/ingestion/languages/swift/target-grouping.js';
 
@@ -136,5 +138,18 @@ describe('coerceSwiftTargets — duck-type the opaque resolutionConfig', () => {
     expect(coerceSwiftTargets({})).toBeNull();
     expect(coerceSwiftTargets({ targets: 'not-a-map' })).toBeNull();
     expect(coerceSwiftTargets({ goModule: { modulePath: 'x' } })).toBeNull();
+  });
+});
+
+describe('groupParsedSwiftFilesBySpmTarget — shared-pass cache', () => {
+  it('reuses one grouping for the same parsed-files and resolution-config identities', () => {
+    const parsedFiles = [{ filePath: 'Sources/App/User.swift' }] as ParsedFile[];
+    const resolutionConfig = { targets: new Map([['App', 'Sources/App']]) };
+
+    const first = groupParsedSwiftFilesBySpmTarget(parsedFiles, resolutionConfig);
+    const second = groupParsedSwiftFilesBySpmTarget(parsedFiles, resolutionConfig);
+
+    expect(second).toBe(first);
+    expect(first.get('App')).toEqual(parsedFiles);
   });
 });


### PR DESCRIPTION
Refs #132.

OpenClaw staged analysis exhausted a 6 GiB heap during Swift scope resolution because same-target definitions and type bindings were copied into every sibling module. For a target with N files and D definitions, that makes retained namespace state scale toward N x D.

This change stores target-wide definitions and type bindings once in the existing namespace channels, gives each module access to that target namespace, and preserves local-first lookup plus SwiftPM target isolation. It does not change language-neutral ingestion code.

Proof at exact head:
- full package build, including parse worker and web bundle
- 116 focused Swift unit/integration tests passed
- npx tsc --noEmit
- regression: 100 default-target files retain 100 shared references instead of 9,900 copied references
- GitNexus change map: low risk, no indexed upstream flow