### PR TITLE
fix(doctor): verify live vector index

### DIFF
--- a/gitnexus/src/cli/doctor-pool-probe.ts
+++ b/gitnexus/src/cli/doctor-pool-probe.ts
@@ -1,8 +1,4 @@
-import {
-  EMBEDDING_DIMS,
-  EMBEDDING_INDEX_NAME,
-  EMBEDDING_TABLE_NAME,
-} from '../core/lbug/schema.js';
+import { EMBEDDING_DIMS, EMBEDDING_INDEX_NAME, EMBEDDING_TABLE_NAME } from '../core/lbug/schema.js';
 
 export interface DoctorPoolProbe {
   fts: boolean;
@@ -75,8 +71,7 @@ export async function probeDoctorPool(dbPath: string): Promise<DoctorPoolProbe> 
       throw new Error('read-pool capability probe did not exercise all eight connections');
     }
     let vectorIndex = false;
-    let vectorIndexReason: DoctorPoolProbe['vectorIndexReason'] =
-      'vector-extension-unavailable';
+    let vectorIndexReason: DoctorPoolProbe['vectorIndexReason'] = 'vector-extension-unavailable';
     if (capabilities.vector) {
       try {
         // A successful zero-result query is still proof that the named HNSW

--- a/gitnexus/src/cli/doctor-pool-probe.ts
+++ b/gitnexus/src/cli/doctor-pool-probe.ts
@@ -1,6 +1,18 @@
+import {
+  EMBEDDING_DIMS,
+  EMBEDDING_INDEX_NAME,
+  EMBEDDING_TABLE_NAME,
+} from '../core/lbug/schema.js';
+
 export interface DoctorPoolProbe {
   fts: boolean;
   vector: boolean;
+  vectorIndex: boolean;
+  vectorIndexReason:
+    | 'vector-extension-unavailable'
+    | 'vector-index-missing-or-unqueryable'
+    | 'pool-probe-unavailable'
+    | null;
   exercisedConnections: number;
   connectionCount: number;
   reason: string | null;
@@ -8,6 +20,7 @@ export interface DoctorPoolProbe {
 
 interface DoctorPoolAdapter {
   closeLbug(repoId?: string): Promise<void>;
+  executeQuery(repoId: string, cypher: string): Promise<unknown[]>;
   getPoolCapabilities(repoId: string): {
     fts: boolean;
     vector: boolean;
@@ -18,6 +31,14 @@ interface DoctorPoolAdapter {
 }
 
 export const EXPECTED_POOL_CONNECTIONS = 8;
+
+const ZERO_VECTOR = `[${Array.from({ length: EMBEDDING_DIMS }, () => '0').join(',')}]`;
+const VECTOR_INDEX_PROBE_QUERY = `
+  CALL QUERY_VECTOR_INDEX('${EMBEDDING_TABLE_NAME}', '${EMBEDDING_INDEX_NAME}',
+    CAST(${ZERO_VECTOR} AS FLOAT[${EMBEDDING_DIMS}]), 1)
+  YIELD node AS emb, distance
+  RETURN distance
+`;
 
 /**
  * Probe the production indexed read pool without invoking a recovery path.
@@ -35,6 +56,7 @@ export async function probeDoctorPool(dbPath: string): Promise<DoctorPoolProbe> 
     closePool = pool.closeLbug;
     if (
       !closePool ||
+      !pool.executeQuery ||
       !pool.initLbugNonRecovering ||
       !pool.getPoolCapabilities ||
       !pool.probePoolConnections
@@ -52,9 +74,27 @@ export async function probeDoctorPool(dbPath: string): Promise<DoctorPoolProbe> 
     ) {
       throw new Error('read-pool capability probe did not exercise all eight connections');
     }
+    let vectorIndex = false;
+    let vectorIndexReason: DoctorPoolProbe['vectorIndexReason'] =
+      'vector-extension-unavailable';
+    if (capabilities.vector) {
+      try {
+        // A successful zero-result query is still proof that the named HNSW
+        // index exists and is queryable. Extension loading alone is not:
+        // QUERY_VECTOR_INDEX prepares successfully only when this database has
+        // the exact index production semantic retrieval uses.
+        await pool.executeQuery(repoId, VECTOR_INDEX_PROBE_QUERY);
+        vectorIndex = true;
+        vectorIndexReason = null;
+      } catch {
+        vectorIndexReason = 'vector-index-missing-or-unqueryable';
+      }
+    }
     return {
       fts: capabilities.fts,
       vector: capabilities.vector,
+      vectorIndex,
+      vectorIndexReason,
       exercisedConnections,
       connectionCount: capabilities.connectionCount,
       reason: null,
@@ -63,6 +103,8 @@ export async function probeDoctorPool(dbPath: string): Promise<DoctorPoolProbe> 
     return {
       fts: false,
       vector: false,
+      vectorIndex: false,
+      vectorIndexReason: 'pool-probe-unavailable',
       exercisedConnections: 0,
       connectionCount: 0,
       reason: error instanceof Error ? error.message : String(error),

--- a/gitnexus/src/cli/doctor.ts
+++ b/gitnexus/src/cli/doctor.ts
@@ -24,7 +24,7 @@ import { diagnoseExtensionLoad } from '../core/lbug/extension-load-error.js';
 import { getExtensionInstallPolicy } from '../core/lbug/extension-loader.js';
 import { getGitRoot } from '../storage/git.js';
 import { getStoragePaths, loadMeta, type RepoMeta } from '../storage/repo-manager.js';
-import { probeDoctorPool } from './doctor-pool-probe.js';
+import { probeDoctorPool, type DoctorPoolProbe } from './doctor-pool-probe.js';
 import { t } from './i18n/index.js';
 
 export { probeDoctorPool, type DoctorPoolProbe } from './doctor-pool-probe.js';
@@ -157,7 +157,10 @@ export function pageSizeDoctorLines(
   return lines;
 }
 
-export function repoVectorDoctorStatus(meta: RepoMeta | null | undefined): {
+export function repoVectorDoctorStatus(
+  meta: RepoMeta | null | undefined,
+  liveProbe?: DoctorPoolProbe | null,
+): {
   status: string;
   detail: string | null;
 } {
@@ -167,6 +170,18 @@ export function repoVectorDoctorStatus(meta: RepoMeta | null | undefined): {
   const embeddingCount =
     Number.isFinite(rawEmbeddingCount) && rawEmbeddingCount > 0 ? Math.floor(rawEmbeddingCount) : 0;
   if (embeddingCount <= 0) return { status: 'no embeddings', detail: null };
+
+  if (liveProbe) {
+    if (liveProbe.vectorIndex) {
+      return { status: `vector-index (${embeddingCount} chunks)`, detail: null };
+    }
+    return {
+      status: `unavailable (${embeddingCount} chunks)`,
+      detail:
+        `Live HNSW probe failed (${liveProbe.vectorIndexReason ?? 'pool-probe-unavailable'}). ` +
+        'Run gitnexus analyze --embeddings to recreate the named VECTOR index.',
+    };
+  }
 
   const vector = meta.capabilities?.vectorSearch;
   if (!vector) {
@@ -386,7 +401,7 @@ export const doctorCommand = async (
   );
   if (capabilities.reason)
     console.log(`  ${label('doctor.labels.note', 18)}${capabilities.reason}`);
-  const repoVector = repoVectorDoctorStatus(repoMeta);
+  const repoVector = repoVectorDoctorStatus(repoMeta, poolProbe);
   console.log(`  ${padDisplayEnd('Repo VECTOR:', 18)}${repoVector.status}`);
   if (repoVector.detail) {
     console.log(`  ${padDisplayEnd('', 18)}${repoVector.detail}`);

--- a/gitnexus/src/cli/registry-doctor.ts
+++ b/gitnexus/src/cli/registry-doctor.ts
@@ -34,6 +34,7 @@ export interface RegistryCapabilityReport {
   graph: string | null;
   fts: string | null;
   vectorSearch: string | null;
+  vectorSearchReason: DoctorPoolProbe['vectorIndexReason'];
 }
 
 /**
@@ -328,6 +329,7 @@ const unavailableCapabilities = (): RegistryCapabilityReport => ({
   graph: null,
   fts: null,
   vectorSearch: null,
+  vectorSearchReason: 'pool-probe-unavailable',
 });
 
 const liveCapabilities = (probe: DoctorPoolProbe): RegistryCapabilityReport => {
@@ -342,7 +344,8 @@ const liveCapabilities = (probe: DoctorPoolProbe): RegistryCapabilityReport => {
     source: 'active-probe',
     graph: 'available',
     fts: probe.fts ? 'available' : 'unavailable',
-    vectorSearch: probe.vector ? 'vector-index' : 'unavailable',
+    vectorSearch: probe.vectorIndex ? 'vector-index' : 'unavailable',
+    vectorSearchReason: probe.vectorIndexReason,
   };
 };
 

--- a/gitnexus/test/integration/lbug-vector-extension.test.ts
+++ b/gitnexus/test/integration/lbug-vector-extension.test.ts
@@ -168,6 +168,64 @@ withTestLbugDB(
 );
 
 /**
+ * Regression for #158: loading VECTOR on every pooled connection is necessary
+ * but not sufficient for semantic retrieval. The repository must also have the
+ * exact HNSW index used by QUERY_VECTOR_INDEX. A successful query against an
+ * empty index is valid proof even when it returns zero rows.
+ */
+withTestLbugDB(
+  'doctor-vector-index-truth',
+  (handle) => {
+    it.skipIf(process.platform === 'win32')(
+      'reports a missing named HNSW index, then accepts a queryable empty index',
+      async () => {
+        const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+        const { probeDoctorPool } = await import('../../src/cli/doctor-pool-probe.js');
+
+        const missing = await probeDoctorPool(handle.dbPath);
+        expect(missing).toMatchObject({
+          vector: true,
+          vectorIndex: false,
+          vectorIndexReason: 'vector-index-missing-or-unqueryable',
+          exercisedConnections: 8,
+          connectionCount: 8,
+          reason: null,
+        });
+
+        await expect(adapter.createVectorIndex()).resolves.toBe(true);
+
+        const ready = await probeDoctorPool(handle.dbPath);
+        expect(ready).toMatchObject({
+          vector: true,
+          vectorIndex: true,
+          vectorIndexReason: null,
+          exercisedConnections: 8,
+          connectionCount: 8,
+          reason: null,
+        });
+      },
+    );
+  },
+  {
+    poolAdapter: true,
+    beforeFTS: async () => {
+      if (process.platform === 'win32') return;
+
+      const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+      const { resolveAnalyzeInstallPolicy } =
+        await import('../../src/core/lbug/extension-loader.js');
+      const loaded = await adapter.loadVectorExtension(undefined, {
+        policy: resolveAnalyzeInstallPolicy(),
+      });
+      if (!loaded) {
+        throw new Error('VECTOR is required for the live doctor HNSW truth regression test');
+      }
+    },
+    timeout: 120_000,
+  },
+);
+
+/**
  * Regression: VECTOR/HNSW index creation during analyze (#2114).
  *
  * `CALL CREATE_VECTOR_INDEX(...)` compiles to multiple statements, which

--- a/gitnexus/test/unit/doctor-format.test.ts
+++ b/gitnexus/test/unit/doctor-format.test.ts
@@ -184,6 +184,35 @@ describe('doctor current-repository VECTOR status', () => {
     ).toEqual({ status: 'vector-index (25 chunks)', detail: null });
   });
 
+  it('lets a failed live HNSW probe override optimistic persisted metadata', () => {
+    const result = repoVectorDoctorStatus(
+      {
+        stats: { embeddings: 25 },
+        capabilities: {
+          graph: { provider: 'ladybugdb', status: 'available' },
+          fts: { provider: 'ladybugdb-fts', status: 'available' },
+          vectorSearch: {
+            provider: 'ladybugdb-vector',
+            status: 'vector-index',
+            exactScanLimit: 10_000,
+          },
+        },
+      } as RepoMeta,
+      {
+        fts: true,
+        vector: true,
+        vectorIndex: false,
+        vectorIndexReason: 'vector-index-missing-or-unqueryable',
+        exercisedConnections: 8,
+        connectionCount: 8,
+        reason: null,
+      },
+    );
+
+    expect(result.status).toBe('unavailable (25 chunks)');
+    expect(result.detail).toContain('vector-index-missing-or-unqueryable');
+  });
+
   it('makes an exact-scan fallback and its current safety limit explicit', () => {
     const result = repoVectorDoctorStatus({
       stats: { embeddings: 25 },

--- a/gitnexus/test/unit/doctor-pool-probe.test.ts
+++ b/gitnexus/test/unit/doctor-pool-probe.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const poolMocks = vi.hoisted(() => ({
   closeLbug: vi.fn().mockResolvedValue(undefined),
+  executeQuery: vi.fn().mockResolvedValue([]),
   getPoolCapabilities: vi.fn(),
   initLbugNonRecovering: vi.fn().mockResolvedValue(undefined),
   probePoolConnections: vi.fn().mockResolvedValue(8),
@@ -16,6 +17,7 @@ describe('shared doctor read-pool probe', () => {
     vi.clearAllMocks();
     poolMocks.initLbugNonRecovering.mockResolvedValue(undefined);
     poolMocks.probePoolConnections.mockResolvedValue(8);
+    poolMocks.executeQuery.mockResolvedValue([]);
     poolMocks.getPoolCapabilities.mockReturnValue({
       fts: true,
       vector: true,
@@ -34,10 +36,16 @@ describe('shared doctor read-pool probe', () => {
     expect(result).toEqual({
       fts: true,
       vector: true,
+      vectorIndex: true,
+      vectorIndexReason: null,
       exercisedConnections: 8,
       connectionCount: 8,
       reason: null,
     });
+    expect(poolMocks.executeQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/^doctor:/),
+      expect.stringMatching(/QUERY_VECTOR_INDEX.*code_embedding_idx/s),
+    );
     expect(poolMocks.closeLbug).toHaveBeenCalledOnce();
   });
 
@@ -51,6 +59,25 @@ describe('shared doctor read-pool probe', () => {
     await expect(probeDoctorPool('/repo/.gitnexus/lbug')).resolves.toMatchObject({
       fts: true,
       vector: false,
+      vectorIndex: false,
+      vectorIndexReason: 'vector-extension-unavailable',
+      exercisedConnections: 8,
+      connectionCount: 8,
+      reason: null,
+    });
+    expect(poolMocks.executeQuery).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing named HNSW index without hiding healthy graph and FTS capability', async () => {
+    poolMocks.executeQuery.mockRejectedValue(
+      new Error("Table CodeEmbedding doesn't have an index with name code_embedding_idx"),
+    );
+
+    await expect(probeDoctorPool('/repo/.gitnexus/lbug')).resolves.toEqual({
+      fts: true,
+      vector: true,
+      vectorIndex: false,
+      vectorIndexReason: 'vector-index-missing-or-unqueryable',
       exercisedConnections: 8,
       connectionCount: 8,
       reason: null,

--- a/gitnexus/test/unit/registry-doctor.test.ts
+++ b/gitnexus/test/unit/registry-doctor.test.ts
@@ -99,6 +99,8 @@ describe('doctor --registry read-only report (#133)', () => {
     doctorPoolMocks.probeDoctorPool.mockResolvedValue({
       fts: true,
       vector: true,
+      vectorIndex: true,
+      vectorIndexReason: null,
       exercisedConnections: 8,
       connectionCount: 8,
       reason: null,
@@ -268,6 +270,8 @@ describe('doctor --registry read-only report (#133)', () => {
     const capabilityProbe = vi.fn(async () => ({
       fts: true,
       vector: true,
+      vectorIndex: true,
+      vectorIndexReason: null,
       exercisedConnections: 8,
       connectionCount: 8,
       reason: null,
@@ -330,6 +334,8 @@ describe('doctor --registry read-only report (#133)', () => {
     const capabilityProbe = vi.fn(async () => ({
       fts: false,
       vector: true,
+      vectorIndex: true,
+      vectorIndexReason: null,
       exercisedConnections: 8,
       connectionCount: 8,
       reason: null,
@@ -348,6 +354,40 @@ describe('doctor --registry read-only report (#133)', () => {
       graph: 'available',
       fts: 'unavailable',
       vectorSearch: 'vector-index',
+      vectorSearchReason: null,
+    });
+  });
+
+  it('does not claim vector-index when the live named-index probe fails', async () => {
+    const indexed = await createEntry(
+      fixture.dbPath,
+      'missing-vector-index',
+      'MissingVectorIndex',
+      'https://github.com/owner/missing-vector-index.git',
+      { nodes: 1, edges: 0, embeddings: 25 },
+    );
+    const capabilityProbe = vi.fn(async () => ({
+      fts: true,
+      vector: true,
+      vectorIndex: false,
+      vectorIndexReason: 'vector-index-missing-or-unqueryable' as const,
+      exercisedConnections: 8,
+      connectionCount: 8,
+      reason: null,
+    }));
+
+    const report = await buildRegistryDoctorReport({
+      entries: [indexed.entry],
+      databaseProbe: async () => ({ nodes: 1, edges: 0, embeddings: 25 }),
+      capabilityProbe,
+    });
+
+    expect(report.entries[0]?.capabilities).toEqual({
+      source: 'active-probe',
+      graph: 'available',
+      fts: 'available',
+      vectorSearch: 'unavailable',
+      vectorSearchReason: 'vector-index-missing-or-unqueryable',
     });
   });
 
@@ -362,6 +402,8 @@ describe('doctor --registry read-only report (#133)', () => {
     doctorPoolMocks.probeDoctorPool.mockResolvedValue({
       fts: false,
       vector: false,
+      vectorIndex: false,
+      vectorIndexReason: 'pool-probe-unavailable',
       exercisedConnections: 0,
       connectionCount: 0,
       reason: `native load failed at ${indexed.lbugPath}`,
@@ -379,6 +421,7 @@ describe('doctor --registry read-only report (#133)', () => {
       graph: null,
       fts: null,
       vectorSearch: null,
+      vectorSearchReason: 'pool-probe-unavailable',
     });
     expect(JSON.stringify(report)).not.toContain(indexed.lbugPath);
   });
@@ -394,6 +437,8 @@ describe('doctor --registry read-only report (#133)', () => {
     doctorPoolMocks.probeDoctorPool.mockResolvedValue({
       fts: true,
       vector: true,
+      vectorIndex: true,
+      vectorIndexReason: null,
       exercisedConnections: 7,
       connectionCount: 8,
       reason: null,


### PR DESCRIPTION
Closes #158.

## What changed
- probe the production named HNSW index through the real eight-connection read pool
- distinguish extension availability from a queryable vector index
- expose a stable sanitized reason in registry doctor JSON and standard doctor output
- preserve healthy graph/FTS reporting when the HNSW probe fails
- accept a successful empty-index query as valid vector-index proof

## Focused proof
- `39` doctor unit tests pass
- real LadybugDB missing-index then empty-HNSW regression passes
- `git diff --check` passes
- GitNexus detect_changes reviewed the affected doctor flows

Related runtime evidence: #130. Exact-head CI is the merge gate.