### PR TITLE
chore: ship 1.6.10-electric.4

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.3",
+      "version": "1.6.10-electric.4",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.3",
+      "version": "1.6.10-electric.4",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.4.md
+++ b/Documentation/releases/1.6.10-electric.4.md
@@ -1,0 +1,30 @@
+# GitNexus 1.6.10-electric.4
+
+`1.6.10-electric.4` is the post-`.3` repair patch for interrupted staged resumes, large Swift repositories, and truthful live vector-index diagnosis. It contains the exact merged fixes required to resume the held fleet safely without rebuilding healthy indexes.
+
+## Fixes
+
+- Staged embedding resume records restored row identities and content hashes, then deletes stale restored rows by exact `(nodeId, chunkIndex)` primary identity before regeneration. Vectors continue to stream in batches of at most 256.
+- Registry doctor now probes the production named HNSW index through the real eight-connection read pool. A loaded VECTOR extension without a queryable index reports unavailable with a stable sanitized reason; healthy graph and FTS reporting remains available.
+- Swift target-wide definitions and type bindings are stored once and shared by sibling modules instead of being copied into every module. Local-first lookup and SwiftPM target isolation remain unchanged.
+- Recovery planning accepts valid legacy metadata whose nested FTS capability is absent and reports that capability as unknown instead of throwing.
+
+## Operational Policy
+
+- Remote Voyage indexing has no host memory, swap, RSS, free-memory, or pressure gate.
+- The shared wrapper admits at most two different normalized remotes. A genuinely large repository uses the exclusive queue lane and runs alone.
+- Invalid MCP repository policy remains fail-closed and agent-visible; this patch does not weaken allowlists or add unrestricted fallback.
+- Healthy existing indexes are not blanket-rebuilt. Interrupted or stale repositories receive only their named staged repair or onboarding action.
+
+## Known Boundaries
+
+- Distribution is GitHub-only. Public npm dist-tags and container registries remain unchanged.
+- Worktree branch-overlay indexing remains out of scope.
+- A published artifact does not by itself prove local installation, held-generation recovery, registry cleanup, or restarted Codex and Claude behavior. Those remain separate installed-runtime gates.
+
+## Release Verification
+
+- Included merged PRs: #154, #156, #157, and #159; sprint epic: #130; release tracker: #160.
+- Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.4`.
+- The release gate requires protected exact-head CI, resolved review findings, the protected Electric Release workflow, verified tarball and `SHA256SUMS`, and a side-by-side installation that preserves `1.6.10-electric.3`.
+- Installed proof must resume ClawSweeper safely, verify OpenClaw, NeonDiff, and GitNexus repair, run live registry doctor, and complete restarted Codex and Claude semantic queries.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.3",
+  "version": "1.6.10-electric.4",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.3",
+  "version": "1.6.10-electric.4",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.4] - 2026-07-21
+
+### Fixed
+
+- **Interrupted staged embedding resumes delete stale restored rows by exact primary identity** before regeneration, preventing hidden stale rows from causing duplicate `CodeEmbedding` creates while vectors continue to stream in bounded batches (#155, #156)
+- **Registry doctor proves that the named HNSW index is queryable through the real eight-connection pool**, distinguishing extension availability from a usable vector index and returning a stable sanitized reason when the live probe fails (#158, #159)
+- **Large Swift targets share target-wide definitions and type bindings once** instead of copying them into every sibling module, keeping namespace memory bounded while preserving local-first lookup and SwiftPM target isolation (#132, #157)
+- **Valid legacy metadata with a missing nested FTS capability remains recoverable**, reporting the capability as unknown instead of throwing during recovery planning (#153, #154)
+
+### Changed
+
+- Remote Voyage fleet work may use at most two different-remote slots. A genuinely large repository runs alone through the exclusive queue lane; no host memory, swap, RSS, free-memory, or pressure gate applies to Voyage.
+- Distribution remains GitHub-only as one tarball plus `SHA256SUMS`; npm and container registries are unchanged.
+
 ## [1.6.10-electric.3] - 2026-07-20
 
 ### Added

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.3",
+  "version": "1.6.10-electric.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-electric.3",
+      "version": "1.6.10-electric.4",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.3",
+  "version": "1.6.10-electric.4",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Closes #160.

## What ships
- exact restored-embedding identity cleanup from #156
- bounded Swift target namespace sharing from #157
- truthful live HNSW doctor probing from #159
- legacy recovery-capability compatibility from #154
- synchronized package, lockfile, Claude/Codex plugin, marketplace, changelog, and release-note identity

## Distribution boundary
GitHub release only: one tarball plus `SHA256SUMS`. No npm or container publication. The existing `1.6.10-electric.3` installation remains available for rollback.

## Local proof
- all release JSON parses
- all seven version-bearing manifest/package entries equal `1.6.10-electric.4`
- `git diff --check`
- GitNexus change detection: metadata/docs only, low risk

The dependency-backed release-policy checker and broad suites are left to exact-head GitHub CI because this fresh worktree has no installed dependencies. Merge is not release proof; the protected Electric Release workflow, verified asset, side-by-side install, held-generation recovery, and live agents remain separate gates.