### PR TITLE
fix: delete pending embeddings before resume regeneration

### DIFF
--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -362,7 +362,7 @@ export interface EmbeddingPipelineOptions {
   signal?: AbortSignal;
   checkpointEveryNodes?: number;
   forceReembedNodeIds?: ReadonlySet<string>;
-  /** Exact restored row identities, keyed by owner node, for PK-safe stale deletion. */
+  /** Exact known row identities, keyed by owner node, for PK-safe stale deletion. */
   existingEmbeddingRowIds?: ReadonlyMap<string, readonly string[]>;
   /** Load cached node identities for one page; callers must return at most the requested IDs. */
   loadExistingEmbeddingHashes?: (
@@ -669,7 +669,10 @@ export const runEmbeddingPipeline = async (
         }
 
         const batchStaleIds = batch
-          .filter((node) => pageHashes.has(node.id))
+          .filter(
+            (node) =>
+              pageHashes.has(node.id) || pipelineOptions.existingEmbeddingRowIds?.has(node.id),
+          )
           .map((node) => node.id);
         await deleteStaleEmbeddingRows(
           executeWithReusedStatement,

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -2047,7 +2047,7 @@ const runFullAnalysisImpl = async (
     // would finalize metadata with fewer vectors than the preserved snapshot.
     let restoredEmbeddingCount = 0;
     let skippedPendingEmbeddingRows = 0;
-    // Keep only restored row identities and one hash per owner node; vectors
+    // Keep exact known row identities and one restored hash per owner node; vectors
     // still stream through the bounded 256-row snapshot batches above. The
     // exact row IDs are required because LadybugDB can make freshly restored
     // non-PK nodeId predicates temporarily miss rows even while the PK sees
@@ -2086,6 +2086,14 @@ const runFullAnalysisImpl = async (
               // force-selected by runEmbeddingPipeline before finalization.
               if (resumeEmbeddingCheckpoint && pendingEmbeddingNodeIds.has(embedding.nodeId)) {
                 skippedPendingEmbeddingRows += 1;
+                // The staged database can already contain this row from the
+                // interrupted window even though its non-PK nodeId lookup is
+                // temporarily invisible behind LadybugDB's live VECTOR index.
+                // Carry the exact primary key without its reusable hash so the
+                // pipeline deletes it immediately before regenerating the batch.
+                const rowIds = restoredEmbeddingRowIds.get(embedding.nodeId) ?? [];
+                rowIds.push(`${embedding.nodeId}:${embedding.chunkIndex}`);
+                restoredEmbeddingRowIds.set(embedding.nodeId, rowIds);
                 continue;
               }
               const liveNode = pipelineResult.graph.getNode(embedding.nodeId);

--- a/gitnexus/test/unit/embedding-pipeline.test.ts
+++ b/gitnexus/test/unit/embedding-pipeline.test.ts
@@ -639,6 +639,44 @@ describe('runEmbeddingPipeline incremental filter', () => {
     expect(createCalls.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('deletes a persisted pending-window row by exact primary key before regeneration (#162)', async () => {
+    mockEmbedderSetup();
+
+    const node = makeNode({
+      id: 'Function:pending:src/pending.ts',
+      name: 'pending',
+      filePath: 'src/pending.ts',
+    });
+    const existingEmbeddingRowIds = new Map<string, readonly string[]>([
+      [node.id, [`${node.id}:0`]],
+    ]);
+    const executeQuery = mockExecuteQuery([node]);
+    const executeWithReusedStatement = mockExecuteWithReusedStatement();
+
+    const { runEmbeddingPipeline } =
+      await import('../../src/core/embeddings/embedding-pipeline.js');
+
+    await runEmbeddingPipeline(
+      executeQuery,
+      executeWithReusedStatement,
+      onProgress,
+      {},
+      undefined,
+      undefined,
+      {
+        forceReembedNodeIds: new Set([node.id]),
+        existingEmbeddingRowIds,
+      },
+    );
+
+    const mutationCalls = stmtCalls.filter(
+      (call) => call.cypher.includes('DELETE') || call.cypher.includes('CREATE'),
+    );
+    expect(mutationCalls[0].cypher).toContain('MATCH (e:CodeEmbedding {id: $id}) DELETE e');
+    expect(mutationCalls[0].params).toEqual([{ id: `${node.id}:0` }]);
+    expect(mutationCalls.some((call) => call.cypher.includes('CREATE'))).toBe(true);
+  });
+
   it('treats STALE_HASH_SENTINEL as stale — triggers re-embed', async () => {
     mockEmbedderSetup();
 

--- a/gitnexus/test/unit/run-analyze-fts-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-fts-repair.test.ts
@@ -1,6 +1,11 @@
 import fs from 'fs/promises';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getStoragePaths, saveMeta, type RepoMeta } from '../../src/storage/repo-manager.js';
+import {
+  getStoragePaths,
+  INCREMENTAL_SCHEMA_VERSION,
+  saveMeta,
+  type RepoMeta,
+} from '../../src/storage/repo-manager.js';
 import { EMBEDDING_DIMS } from '../../src/core/lbug/schema.js';
 import { createTempDir } from '../helpers/test-db.js';
 
@@ -815,14 +820,29 @@ describe('runFullAnalysis wipe-and-restore vector-index stamp (tri-review 466951
     }
   });
 
-  it('passes restored hashes and exact row identities to the embedding pipeline (#155)', async () => {
+  it('passes restored and skipped-pending exact row identities to the embedding pipeline (#155, #162)', async () => {
     const restoredNodeId = 'Function:src/app.ts:handler';
-    const stubNode = {
-      id: restoredNodeId,
-      label: 'Function',
-      name: 'handler',
-      properties: { filePath: 'src/app.ts' },
-    };
+    const pendingNodeId = 'Function:src/pending.ts:resume';
+    const stubNodes = new Map([
+      [
+        restoredNodeId,
+        {
+          id: restoredNodeId,
+          label: 'Function',
+          name: 'handler',
+          properties: { filePath: 'src/app.ts' },
+        },
+      ],
+      [
+        pendingNodeId,
+        {
+          id: pendingNodeId,
+          label: 'Function',
+          name: 'resume',
+          properties: { filePath: 'src/pending.ts' },
+        },
+      ],
+    ]);
     const runEmbeddingPipeline = vi.fn(async () => ({
       nodesProcessed: 1,
       chunksProcessed: 1,
@@ -833,23 +853,25 @@ describe('runFullAnalysis wipe-and-restore vector-index stamp (tri-review 466951
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       initLbug: vi.fn(async () => undefined),
       loadGraphToLbug: vi.fn(async () => undefined),
-      getLbugStats: vi.fn(async () => ({ nodes: 1, edges: 0, communities: 0, processes: 0 })),
+      getLbugStats: vi.fn(async () => ({ nodes: 2, edges: 0, communities: 0, processes: 0 })),
       executeQuery: vi.fn(async (cypher: string) =>
-        /RETURN count\(e\) AS cnt/.test(cypher) ? [{ cnt: 2 }] : [],
+        /RETURN count\(e\) AS cnt/.test(cypher) ? [{ cnt: 4 }] : [],
       ),
       executeWithReusedStatement: vi.fn(async () => undefined),
       closeLbug: vi.fn(async () => undefined),
       wipeLbugDbFiles: vi.fn(async () => undefined),
       loadCachedEmbeddings: vi.fn(async () => ({
-        embeddingNodeIds: new Set([restoredNodeId]),
-        embeddings: [0, 1].map((chunkIndex) => ({
-          nodeId: restoredNodeId,
-          chunkIndex,
-          startLine: chunkIndex + 1,
-          endLine: chunkIndex + 2,
-          embedding: new Array(EMBEDDING_DIMS).fill(0),
-          contentHash: 'restored-hash',
-        })),
+        embeddingNodeIds: new Set([restoredNodeId, pendingNodeId]),
+        embeddings: [restoredNodeId, pendingNodeId].flatMap((nodeId) =>
+          [0, 1].map((chunkIndex) => ({
+            nodeId,
+            chunkIndex,
+            startLine: chunkIndex + 1,
+            endLine: chunkIndex + 2,
+            embedding: new Array(EMBEDDING_DIMS).fill(0),
+            contentHash: nodeId === restoredNodeId ? 'restored-hash' : 'pending-hash',
+          })),
+        ),
       })),
       fetchExistingEmbeddingHashesForNodeIds,
       deleteNodesForFiles: vi.fn(async () => undefined),
@@ -866,10 +888,12 @@ describe('runFullAnalysis wipe-and-restore vector-index stamp (tri-review 466951
     vi.doMock('../../src/core/ingestion/pipeline.js', () => ({
       runPipelineFromRepo: vi.fn(async (repoPath: string) => ({
         repoPath,
-        totalFileCount: 1,
+        totalFileCount: 2,
         graph: {
-          forEachNode: (fn: (node: typeof stubNode) => void) => fn(stubNode),
-          getNode: (id: string) => (id === restoredNodeId ? stubNode : undefined),
+          forEachNode: (
+            fn: (node: typeof stubNodes extends Map<string, infer T> ? T : never) => void,
+          ) => stubNodes.forEach((node) => fn(node)),
+          getNode: (id: string) => stubNodes.get(id),
         },
       })),
     }));
@@ -892,13 +916,28 @@ describe('runFullAnalysis wipe-and-restore vector-index stamp (tri-review 466951
         repoPath: tmpRepo.dbPath,
         lastCommit: '',
         indexedAt: new Date().toISOString(),
-        stats: { embeddings: 2 },
+        schemaVersion: INCREMENTAL_SCHEMA_VERSION,
+        stats: { embeddings: 4 },
+        incrementalInProgress: {
+          startedAt: Date.now(),
+          toWriteCount: 2,
+          phase: 'embedding-window',
+        },
+        embeddingCheckpoint: {
+          at: new Date().toISOString(),
+          nodesProcessed: 0,
+          totalNodes: 2,
+          chunksProcessed: 0,
+          model: 'Snowflake/snowflake-arctic-embed-xs',
+          dimensions: EMBEDDING_DIMS,
+          pendingNodeIds: [pendingNodeId],
+        },
       });
 
       const { runFullAnalysis } = await import('../../src/core/run-analyze.js');
       await runFullAnalysis(
         tmpRepo.dbPath,
-        { force: true, embeddings: true, embeddingsNodeLimit: 0 },
+        { embeddings: true, embeddingsNodeLimit: 0 },
         { onProgress: () => {} },
       );
 
@@ -908,10 +947,19 @@ describe('runFullAnalysis wipe-and-restore vector-index stamp (tri-review 466951
         `${restoredNodeId}:0`,
         `${restoredNodeId}:1`,
       ]);
-      const hashes = await pipelineOptions.loadExistingEmbeddingHashes([restoredNodeId]);
+      expect(pipelineOptions.existingEmbeddingRowIds.get(pendingNodeId)).toEqual([
+        `${pendingNodeId}:0`,
+        `${pendingNodeId}:1`,
+      ]);
+      const hashes = await pipelineOptions.loadExistingEmbeddingHashes([
+        restoredNodeId,
+        pendingNodeId,
+      ]);
       expect(hashes.get(restoredNodeId)).toBe('restored-hash');
+      expect(hashes.has(pendingNodeId)).toBe(false);
       expect(fetchExistingEmbeddingHashesForNodeIds).toHaveBeenCalledWith(expect.any(Function), [
         restoredNodeId,
+        pendingNodeId,
       ]);
     } finally {
       await tmpRepo.cleanup();


### PR DESCRIPTION
Closes #162

## Problem

The preserved ClawSweeper `.4` staged resume skipped pending-window snapshot rows, but the staged LadybugDB database already contained one of those rows. Its non-PK hash lookup returned no row while the primary key remained live, so regeneration attempted `CREATE` and failed with a duplicate `CodeEmbedding.id`.

## Fix

- retain exact primary-key identities for skipped pending-window rows without reusing their hashes;
- treat any selected node with a known exact row identity as stale;
- delete those exact IDs immediately before the current embedding batch is regenerated.

This keeps delete/reinsert exposure bounded to one batch and preserves the existing at-most-5,000-node checkpoint window.

## Proof

- red regression failed before the patch: pending node went directly to `CREATE` with no exact delete;
- focused suites: 60/60 passed;
- real run-analyze checkpoint resume plus both new regressions: 3/3 passed;
- TypeScript, production build, changed-file ESLint (warnings only), Prettier, and `git diff --check` passed;
- GitNexus `detect_changes` reports low risk and no affected execution flows.

The ClawSweeper staged generation remains preserved and will not be retried on `.4`. Installed runtime and release proof remain separate from this source PR.
