### PR TITLE
fix: probe stored vector dimensions in doctor

### DIFF
--- a/gitnexus/src/cli/doctor-pool-probe.ts
+++ b/gitnexus/src/cli/doctor-pool-probe.ts
@@ -1,4 +1,4 @@
-import { EMBEDDING_DIMS, EMBEDDING_INDEX_NAME, EMBEDDING_TABLE_NAME } from '../core/lbug/schema.js';
+import { EMBEDDING_INDEX_NAME, EMBEDDING_TABLE_NAME } from '../core/lbug/schema.js';
 
 export interface DoctorPoolProbe {
   fts: boolean;
@@ -27,14 +27,32 @@ interface DoctorPoolAdapter {
 }
 
 export const EXPECTED_POOL_CONNECTIONS = 8;
+const MAX_DOCTOR_VECTOR_DIMENSIONS = 65_536;
+const EMBEDDING_TABLE_INFO_QUERY = `CALL TABLE_INFO('${EMBEDDING_TABLE_NAME}') RETURN *`;
 
-const ZERO_VECTOR = `[${Array.from({ length: EMBEDDING_DIMS }, () => '0').join(',')}]`;
-const VECTOR_INDEX_PROBE_QUERY = `
+const storedEmbeddingDimensions = (rows: unknown[]): number | null => {
+  for (const row of rows) {
+    if (typeof row !== 'object' || row === null) continue;
+    const record = row as Record<string, unknown>;
+    if (record.name !== 'embedding' || typeof record.type !== 'string') continue;
+    const match = /^FLOAT\[([1-9][0-9]*)\]$/.exec(record.type);
+    if (!match) return null;
+    const dimensions = Number(match[1]);
+    if (!Number.isSafeInteger(dimensions) || dimensions > MAX_DOCTOR_VECTOR_DIMENSIONS) return null;
+    return dimensions;
+  }
+  return null;
+};
+
+const vectorIndexProbeQuery = (dimensions: number): string => {
+  const zeroVector = `[${Array.from({ length: dimensions }, () => '0').join(',')}]`;
+  return `
   CALL QUERY_VECTOR_INDEX('${EMBEDDING_TABLE_NAME}', '${EMBEDDING_INDEX_NAME}',
-    CAST(${ZERO_VECTOR} AS FLOAT[${EMBEDDING_DIMS}]), 1)
+    CAST(${zeroVector} AS FLOAT[${dimensions}]), 1)
   YIELD node AS emb, distance
   RETURN distance
 `;
+};
 
 /**
  * Probe the production indexed read pool without invoking a recovery path.
@@ -74,11 +92,14 @@ export async function probeDoctorPool(dbPath: string): Promise<DoctorPoolProbe> 
     let vectorIndexReason: DoctorPoolProbe['vectorIndexReason'] = 'vector-extension-unavailable';
     if (capabilities.vector) {
       try {
+        const tableInfo = await pool.executeQuery(repoId, EMBEDDING_TABLE_INFO_QUERY);
+        const dimensions = storedEmbeddingDimensions(tableInfo);
+        if (dimensions === null) throw new Error('stored embedding dimension is unavailable');
         // A successful zero-result query is still proof that the named HNSW
         // index exists and is queryable. Extension loading alone is not:
         // QUERY_VECTOR_INDEX prepares successfully only when this database has
         // the exact index production semantic retrieval uses.
-        await pool.executeQuery(repoId, VECTOR_INDEX_PROBE_QUERY);
+        await pool.executeQuery(repoId, vectorIndexProbeQuery(dimensions));
         vectorIndex = true;
         vectorIndexReason = null;
       } catch {

--- a/gitnexus/test/unit/doctor-pool-probe.test.ts
+++ b/gitnexus/test/unit/doctor-pool-probe.test.ts
@@ -17,7 +17,9 @@ describe('shared doctor read-pool probe', () => {
     vi.clearAllMocks();
     poolMocks.initLbugNonRecovering.mockResolvedValue(undefined);
     poolMocks.probePoolConnections.mockResolvedValue(8);
-    poolMocks.executeQuery.mockResolvedValue([]);
+    poolMocks.executeQuery.mockImplementation(async (_repoId: string, cypher: string) =>
+      cypher.includes('TABLE_INFO') ? [{ name: 'embedding', type: 'FLOAT[384]' }] : [],
+    );
     poolMocks.getPoolCapabilities.mockReturnValue({
       fts: true,
       vector: true,
@@ -69,9 +71,10 @@ describe('shared doctor read-pool probe', () => {
   });
 
   it('reports a missing named HNSW index without hiding healthy graph and FTS capability', async () => {
-    poolMocks.executeQuery.mockRejectedValue(
-      new Error("Table CodeEmbedding doesn't have an index with name code_embedding_idx"),
-    );
+    poolMocks.executeQuery.mockImplementation(async (_repoId: string, cypher: string) => {
+      if (cypher.includes('TABLE_INFO')) return [{ name: 'embedding', type: 'FLOAT[384]' }];
+      throw new Error("Table CodeEmbedding doesn't have an index with name code_embedding_idx");
+    });
 
     await expect(probeDoctorPool('/repo/.gitnexus/lbug')).resolves.toEqual({
       fts: true,
@@ -82,6 +85,46 @@ describe('shared doctor read-pool probe', () => {
       connectionCount: 8,
       reason: null,
     });
+  });
+
+  it('probes the vector index at the dimension stored in the database', async () => {
+    poolMocks.executeQuery.mockImplementation(async (_repoId: string, cypher: string) =>
+      cypher.includes('TABLE_INFO') ? [{ name: 'embedding', type: 'FLOAT[2048]' }] : [],
+    );
+
+    await expect(probeDoctorPool('/repo/.gitnexus/lbug')).resolves.toMatchObject({
+      vectorIndex: true,
+      vectorIndexReason: null,
+    });
+
+    const vectorCall = poolMocks.executeQuery.mock.calls.find(([, cypher]) =>
+      String(cypher).includes('QUERY_VECTOR_INDEX'),
+    );
+    expect(vectorCall?.[1]).toContain('FLOAT[2048]');
+  });
+
+  it.each([
+    [{ name: 'embedding', type: 'FLOAT[0]' }],
+    [{ name: 'embedding', type: 'FLOAT[65537]' }],
+    [{ name: 'embedding', type: 'FLOAT[not-a-number]' }],
+    [{ name: 'other', type: 'FLOAT[2048]' }],
+  ])('fails closed when the stored embedding dimension is unavailable or invalid', async (rows) => {
+    poolMocks.executeQuery.mockImplementation(async (_repoId: string, cypher: string) =>
+      cypher.includes('TABLE_INFO') ? rows : [],
+    );
+
+    await expect(probeDoctorPool('/repo/.gitnexus/lbug')).resolves.toMatchObject({
+      fts: true,
+      vector: true,
+      vectorIndex: false,
+      vectorIndexReason: 'vector-index-missing-or-unqueryable',
+      reason: null,
+    });
+    expect(
+      poolMocks.executeQuery.mock.calls.some(([, cypher]) =>
+        String(cypher).includes('QUERY_VECTOR_INDEX'),
+      ),
+    ).toBe(false);
   });
 
   it('fails closed and closes the pool when fewer than eight connections are exercised', async () => {


### PR DESCRIPTION
Closes #164

## Problem

Raw `gitnexus doctor --registry` built every HNSW query from process-global `EMBEDDING_DIMS` (384 by default). It therefore marked healthy 2,048-dimensional Voyage indexes unavailable unless the operator happened to launch the doctor through the Voyage wrapper.

## Fix

- inspect `CodeEmbedding.embedding` through the already-open non-recovering diagnostic pool;
- accept only a strict, bounded `FLOAT[positive-integer]` stored type;
- build the zero-vector HNSW probe at that database's actual dimension;
- keep missing/malformed schema fail-closed as `vector-index-missing-or-unqueryable`.

The eight-connection live probe, read-only behavior, and sanitized public status remain unchanged.

## Proof

- red tests proved the pre-fix probe stayed at `FLOAT[384]` for a stored `FLOAT[2048]` column and incorrectly accepted malformed/missing dimensions;
- doctor-focused suites pass 23/23;
- TypeScript, build, changed-file lint/format, and `git diff --check` pass;
- a raw built CLI with no Voyage dimension environment now matches the wrapper doctor: 59 embedding-bearing `vector-index` entries and only the known OpenClaw missing-index result.

Evidence: `/Volumes/LEXAR/Codex/session-notes/2026-07-20/gitnexus-repository-health-sprint/evals/doctor-stored-vector-dimension-live.json`.
