### PR TITLE
chore: ship 1.6.10-electric.5

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.4",
+      "version": "1.6.10-electric.5",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.4",
+      "version": "1.6.10-electric.5",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.5.md
+++ b/Documentation/releases/1.6.10-electric.5.md
@@ -1,0 +1,27 @@
+# GitNexus 1.6.10-electric.5
+
+`1.6.10-electric.5` is the immutable follow-up patch required by the held ClawSweeper staged generation and the installed fleet doctor. It does not rebuild healthy repositories or change the approved fleet policy.
+
+## Fixes
+
+- Pending-window checkpoint rows now carry their exact embedding primary identities into regeneration. The pipeline deletes those known rows immediately before the current batch is recreated, preventing a hidden stale `CodeEmbedding.id` from causing a duplicate-key failure while preserving the bounded 5,000-node recovery window.
+- Registry doctor now reads the stored `CodeEmbedding.embedding` column type through its already-open non-recovering diagnostic pool and builds the HNSW probe at that database's actual dimension. Missing, malformed, or implausibly large dimensions remain fail-closed with the sanitized unavailable reason.
+
+## Operational Policy
+
+- Remote Voyage indexing has no host memory, swap, RSS, free-memory, or pressure gate.
+- The shared wrapper admits at most two different normalized remotes. A genuinely large repository runs alone.
+- Invalid MCP repository policy remains fail-closed and agent-visible; there is no unrestricted fallback.
+- Healthy existing indexes are retained. Only named stale, interrupted, onboarding, or identity-migration lanes are changed.
+
+## Known Boundaries
+
+- Distribution is GitHub-only. Public npm dist-tags and container registries remain unchanged.
+- A published artifact does not prove local installation, ClawSweeper recovery, registry equality, or restarted Codex and Claude behavior; those remain separate installed-runtime gates.
+
+## Release Verification
+
+- Included merged PRs: #163 and #165; sprint epic: #130; release tracker: #166.
+- Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.5`.
+- The release gate requires protected exact-head CI, current-head independent review, zero unresolved review threads, the protected Electric Release workflow, verified tarball and `SHA256SUMS`, and a side-by-side installation that preserves `.2`, `.3`, and `.4`.
+- Installed proof must retry the preserved ClawSweeper staged generation, run the raw and Voyage-aware registry doctors, and complete the remaining fleet and live-agent acceptance gates.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.4",
+  "version": "1.6.10-electric.5",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.4",
+  "version": "1.6.10-electric.5",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.5] - 2026-07-21
+
+### Fixed
+
+- **Interrupted staged resumes delete exact pending-window rows before regeneration**, preventing a preserved LadybugDB primary key from colliding with the replacement `CodeEmbedding` row while keeping the delete/reinsert exposure bounded to the current batch (#162, #163)
+- **Registry doctor derives the HNSW query dimension from each database's stored vector column**, so a raw doctor invocation reports healthy 2,048-dimensional Voyage indexes truthfully without requiring provider-specific process environment (#164, #165)
+
+### Changed
+
+- Distribution remains GitHub-only as one tarball plus `SHA256SUMS`; npm and container registries are unchanged.
+- Existing `1.6.10-electric.2`, `.3`, and `.4` installations remain available for rollback.
+
 ## [1.6.10-electric.4] - 2026-07-21
 
 ### Fixed

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.4",
+  "version": "1.6.10-electric.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-electric.4",
+      "version": "1.6.10-electric.5",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.4",
+  "version": "1.6.10-electric.5",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Closes #166.

## What ships

- exact pending-window embedding-row deletion from #163;
- stored-vector-dimension registry doctor probing from #165;
- synchronized package, lockfile, Claude/Codex plugin, marketplace, changelog, and release-note identity.

## Distribution boundary

GitHub release only: one tarball plus `SHA256SUMS`. No npm, container, customer, or public deployment. Existing side-by-side `.2`, `.3`, and `.4` installations remain available for rollback.

## Local proof

- release-policy checker passes;
- all release JSON parses;
- all seven version-bearing entries equal `1.6.10-electric.5`;
- targeted Prettier and `git diff --check` pass;
- the release commit is rebased onto protected `main@0686742b96e79ab3a8d20de71cd9a40d38377b7a`.

Merge is not release or installed-runtime proof. The protected Electric Release workflow, verified artifact, side-by-side install, installed doctor, and ClawSweeper retry remain separate gates.