### PR TITLE
fix: rebuild vector index for staged resume

### DIFF
--- a/gitnexus/src/core/embeddings/embedding-pipeline.ts
+++ b/gitnexus/src/core/embeddings/embedding-pipeline.ts
@@ -40,7 +40,7 @@ import {
 } from './config.js';
 import { rankExactEmbeddingRows, type ExactEmbeddingRow } from './exact-search.js';
 import { EMBEDDING_TABLE_NAME, EMBEDDING_INDEX_NAME, STALE_HASH_SENTINEL } from '../lbug/schema.js';
-import { loadVectorExtension, createVectorIndex } from '../lbug/lbug-adapter.js';
+import { loadVectorExtension, createVectorIndex, dropVectorIndex } from '../lbug/lbug-adapter.js';
 import { escapeCypherString } from '../lbug/cypher-escape.js';
 import { isMissingColumnOrTableError } from '../lbug/schema-errors.js';
 import type { ExtensionInstallPolicy } from '../lbug/extension-loader.js';
@@ -364,6 +364,8 @@ export interface EmbeddingPipelineOptions {
   forceReembedNodeIds?: ReadonlySet<string>;
   /** Exact known row identities, keyed by owner node, for PK-safe stale deletion. */
   existingEmbeddingRowIds?: ReadonlyMap<string, readonly string[]>;
+  /** Drop staged HNSW before a checkpoint-window rewrite; rebuilt after inserts. */
+  rebuildVectorIndexBeforeMutation?: boolean;
   /** Load cached node identities for one page; callers must return at most the requested IDs. */
   loadExistingEmbeddingHashes?: (
     nodeIds: readonly string[],
@@ -462,6 +464,14 @@ export const runEmbeddingPipeline = async (
     throwIfCancelled();
     if (!vectorAvailable) {
       logger.warn(vectorUnavailableMessage);
+    }
+    if (pipelineOptions.rebuildVectorIndexBeforeMutation) {
+      if (!vectorAvailable || !(await dropVectorIndex())) {
+        throw new Error(
+          'Cannot safely resume the staged embedding checkpoint because its VECTOR index could not be dropped.',
+        );
+      }
+      throwIfCancelled();
     }
 
     // Phase 1: Load embedding model

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -16,7 +16,9 @@ import {
   REL_TABLE_NAME,
   SCHEMA_QUERIES,
   EMBEDDING_TABLE_NAME,
+  EMBEDDING_INDEX_NAME,
   CREATE_VECTOR_INDEX_QUERY,
+  DROP_VECTOR_INDEX_QUERY,
   STALE_HASH_SENTINEL,
   NodeTableName,
 } from './schema.js';
@@ -2892,6 +2894,43 @@ export const createVectorIndex = async (): Promise<boolean> => {
     // Read-only DB (e.g. the MCP query pool): writable analyze owns creation.
     if (isReadOnlyDbError(e)) return false;
     throw e;
+  }
+};
+
+/**
+ * Drop the HNSW index before replacing rows from an interrupted staged
+ * embedding window. LadybugDB can keep a deleted primary key live in a loaded
+ * HNSW index long enough for an immediate same-key CREATE to fail. Removing the
+ * staged generation's index makes the bounded delete/reinsert window ordinary
+ * table mutation; the embedding pipeline rebuilds HNSW after all rows land.
+ *
+ * Returns true when the index is absent after the call (including when it was
+ * already absent), and false when VECTOR cannot be loaded or the DB is
+ * read-only. Other failures propagate so resume remains fail-closed.
+ */
+export const dropVectorIndex = async (): Promise<boolean> => {
+  if (!conn) {
+    throw new Error('LadybugDB not initialized. Call initLbug first.');
+  }
+  if (!(await loadVectorExtension())) return false;
+
+  const indexes = await executeQuery('CALL SHOW_INDEXES() RETURN *');
+  const exists = indexes.some(
+    (row: Record<string, unknown>) =>
+      row.index_name === EMBEDDING_INDEX_NAME && row.table_name === EMBEDDING_TABLE_NAME,
+  );
+  if (!exists) {
+    vectorIndexEnsured = false;
+    return true;
+  }
+
+  try {
+    await queryAndDrain(conn, DROP_VECTOR_INDEX_QUERY);
+    vectorIndexEnsured = false;
+    return true;
+  } catch (error) {
+    if (isReadOnlyDbError(error)) return false;
+    throw error;
   }
 };
 

--- a/gitnexus/src/core/lbug/schema.ts
+++ b/gitnexus/src/core/lbug/schema.ts
@@ -502,6 +502,11 @@ export const CREATE_VECTOR_INDEX_QUERY = `
 CALL CREATE_VECTOR_INDEX('${EMBEDDING_TABLE_NAME}', '${EMBEDDING_INDEX_NAME}', 'embedding', metric := 'cosine')
 `;
 
+/** Drop the persisted HNSW index before a staged checkpoint-window rewrite. */
+export const DROP_VECTOR_INDEX_QUERY = `
+CALL DROP_VECTOR_INDEX('${EMBEDDING_TABLE_NAME}', '${EMBEDDING_INDEX_NAME}')
+`;
+
 // ============================================================================
 // ALL SCHEMA QUERIES IN ORDER
 // Node tables must be created before relationship tables that reference them

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -2313,6 +2313,8 @@ const runFullAnalysisImpl = async (
         {
           forceReembedNodeIds: pendingEmbeddingNodeIds,
           existingEmbeddingRowIds: restoredEmbeddingRowIds,
+          rebuildVectorIndexBeforeMutation:
+            Boolean(stagedPaths) && resumeEmbeddingCheckpoint && pendingEmbeddingNodeIds.size > 0,
           loadExistingEmbeddingHashes: async (nodeIds) => {
             const hashes = await fetchExistingEmbeddingHashesForNodeIds(executeQuery, nodeIds);
             for (const nodeId of nodeIds) {

--- a/gitnexus/test/integration/lbug-vector-extension.test.ts
+++ b/gitnexus/test/integration/lbug-vector-extension.test.ts
@@ -336,6 +336,55 @@ withTestLbugDB('vector-index-creation', (handle) => {
       )) as Array<{ count: number | bigint }>;
       expect(Number(rows[0]?.count ?? 0)).toBe(0);
     });
+
+    it('drops persisted HNSW before deleting and reinserting the same embedding primary key (#162)', async () => {
+      const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+      const { batchInsertEmbeddings } =
+        await import('../../src/core/embeddings/embedding-pipeline.js');
+      const { EMBEDDING_DIMS, EMBEDDING_INDEX_NAME } =
+        await import('../../src/core/lbug/schema.js');
+      const filePath = 'src/vector-reopen-reinsert.ts';
+      const nodeId = `Function:${filePath}:target:1`;
+      const rowId = `${nodeId}:0`;
+
+      await adapter.executeQuery(
+        `CREATE (:Function {id: '${nodeId}', name: 'target', filePath: '${filePath}', startLine: 1, endLine: 3, isExported: true, content: '', description: ''})`,
+      );
+      await batchInsertEmbeddings(adapter.executeWithReusedStatement, [
+        {
+          nodeId,
+          chunkIndex: 0,
+          startLine: 1,
+          endLine: 3,
+          embedding: new Array(EMBEDDING_DIMS).fill(0),
+        },
+      ]);
+      await adapter.createVectorIndex();
+      await adapter.closeLbug();
+      await adapter.initLbug(handle.dbPath);
+
+      await expect(adapter.dropVectorIndex()).resolves.toBe(true);
+      await adapter.executeWithReusedStatement('MATCH (e:CodeEmbedding {id: $id}) DELETE e', [
+        { id: rowId },
+      ]);
+      await batchInsertEmbeddings(adapter.executeWithReusedStatement, [
+        {
+          nodeId,
+          chunkIndex: 0,
+          startLine: 1,
+          endLine: 3,
+          embedding: new Array(EMBEDDING_DIMS).fill(1),
+        },
+      ]);
+      await expect(adapter.createVectorIndex()).resolves.toBe(true);
+
+      const rows = (await adapter.executeQuery(
+        `MATCH (e:CodeEmbedding {id: '${rowId}'}) RETURN count(e) AS count`,
+      )) as Array<{ count: number | bigint }>;
+      expect(Number(rows[0]?.count ?? 0)).toBe(1);
+      const indexes = await adapter.executeQuery('CALL SHOW_INDEXES() RETURN *');
+      expect(indexes.filter((row: any) => row.index_name === EMBEDDING_INDEX_NAME)).toHaveLength(1);
+    });
   });
 });
 

--- a/gitnexus/test/unit/embedding-pipeline.test.ts
+++ b/gitnexus/test/unit/embedding-pipeline.test.ts
@@ -205,6 +205,7 @@ describe('runEmbeddingPipeline incremental filter', () => {
   // it was invoked instead of asserting CREATE_VECTOR_INDEX flowed through the
   // injected (prepared) executeQuery, which it must NOT.
   let vectorIndexMock: ReturnType<typeof vi.fn>;
+  let vectorIndexDropMock: ReturnType<typeof vi.fn>;
 
   // Helper node
   const makeNode = (overrides: Partial<EmbeddableNode> = {}): EmbeddableNode => ({
@@ -239,11 +240,13 @@ describe('runEmbeddingPipeline incremental filter', () => {
     }));
 
     // Mock the adapter (avoids needing the native lbug module). The pipeline
-    // imports both loadVectorExtension and createVectorIndex from here.
+    // imports vector-index lifecycle functions from here.
     vectorIndexMock = vi.fn().mockResolvedValue(true);
+    vectorIndexDropMock = vi.fn().mockResolvedValue(true);
     vi.doMock('../../src/core/lbug/lbug-adapter.js', () => ({
       loadVectorExtension: vi.fn().mockResolvedValue(true),
       createVectorIndex: vectorIndexMock,
+      dropVectorIndex: vectorIndexDropMock,
     }));
   };
 
@@ -639,7 +642,7 @@ describe('runEmbeddingPipeline incremental filter', () => {
     expect(createCalls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('deletes a persisted pending-window row by exact primary key before regeneration (#162)', async () => {
+  it('drops staged HNSW before deleting and regenerating a persisted pending-window row (#162)', async () => {
     mockEmbedderSetup();
 
     const node = makeNode({
@@ -666,15 +669,20 @@ describe('runEmbeddingPipeline incremental filter', () => {
       {
         forceReembedNodeIds: new Set([node.id]),
         existingEmbeddingRowIds,
+        rebuildVectorIndexBeforeMutation: true,
       },
     );
 
     const mutationCalls = stmtCalls.filter(
       (call) => call.cypher.includes('DELETE') || call.cypher.includes('CREATE'),
     );
+    expect(vectorIndexDropMock).toHaveBeenCalledOnce();
     expect(mutationCalls[0].cypher).toContain('MATCH (e:CodeEmbedding {id: $id}) DELETE e');
     expect(mutationCalls[0].params).toEqual([{ id: `${node.id}:0` }]);
     expect(mutationCalls.some((call) => call.cypher.includes('CREATE'))).toBe(true);
+    expect(vectorIndexDropMock.mock.invocationCallOrder[0]).toBeLessThan(
+      vectorIndexMock.mock.invocationCallOrder[0],
+    );
   });
 
   it('treats STALE_HASH_SENTINEL as stale — triggers re-embed', async () => {


### PR DESCRIPTION
## Summary

- drop the staged generation's persisted HNSW index before regenerating an interrupted embedding checkpoint window
- keep the mutation fail-closed when VECTOR cannot be loaded or the index cannot be removed
- rebuild HNSW after the bounded delete/reinsert sequence completes
- add real Ladybug coverage for drop → same-primary-key delete/reinsert → index rebuild

## Release acceptance failure

Installed `1.6.10-electric.5` reproduced #162 on the preserved ClawSweeper staged generation: exact-PK deletion alone did not make the key immediately reusable while the persisted HNSW index remained loaded. The failure occurred before promotion; canonical storage and registry were untouched.

## Validation

- `npm --prefix gitnexus run build`
- `npx vitest run test/unit/embedding-pipeline.test.ts test/unit/run-analyze-fts-repair.test.ts` (60 passed)
- `npx vitest run test/integration/lbug-vector-extension.test.ts` (12 passed, 1 platform skip)
- targeted Prettier
- `git diff --check`

Closes #162
