### PR TITLE
chore: ship 1.6.10-electric.6

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.5",
+      "version": "1.6.10-electric.6",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.5",
+      "version": "1.6.10-electric.6",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.6.md
+++ b/Documentation/releases/1.6.10-electric.6.md
@@ -1,0 +1,26 @@
+# GitNexus 1.6.10-electric.6
+
+`1.6.10-electric.6` is the narrow follow-up to the installed `.5` ClawSweeper acceptance failure. It contains no unrelated source or fleet-policy changes.
+
+## Fix
+
+- A staged resume with a persisted HNSW index now drops that staged index before regenerating the interrupted embedding window, then rebuilds HNSW after the bounded delete/reinsert sequence. This prevents LadybugDB from retaining a deleted `CodeEmbedding` primary key long enough to reject its same-key replacement.
+- The operation remains fail-closed when VECTOR cannot be loaded or the staged index cannot be removed. The canonical generation stays readable until normal staged validation and promotion.
+
+## Operational Policy
+
+- Remote Voyage indexing has no host memory, swap, RSS, free-memory, or pressure gate.
+- Invalid MCP repository policy remains fail-closed and agent-visible; there is no unrestricted fallback.
+- Healthy existing indexes are retained. Fleet onboarding and ordinary refreshes remain detached background work.
+
+## Known Boundaries
+
+- Distribution is GitHub-only. Public npm dist-tags and container registries remain unchanged.
+- Publication and installation do not prove ClawSweeper recovery or MCP retrieval; those remain separate installed-runtime gates.
+
+## Release Verification
+
+- Included corrective PR: #168; reopened defect: #162; sprint epic: #130.
+- Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.6`.
+- The release gate requires protected exact-head CI, current-head independent review, zero unresolved review threads, the protected Electric Release workflow, verified tarball and `SHA256SUMS`, and side-by-side installation preserving `.2` through `.5`.
+- Installed proof must resume the preserved ClawSweeper staged generation, require DB/meta/registry count agreement and live `vector-index`, then complete two non-partial MCP semantic queries.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.5",
+  "version": "1.6.10-electric.6",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.5",
+  "version": "1.6.10-electric.6",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.6] - 2026-07-21
+
+### Fixed
+
+- **Interrupted staged embedding resumes rebuild the staged HNSW index around pending-window regeneration**, preventing LadybugDB's live vector index from retaining a deleted primary key long enough to reject its same-key replacement (#162, #168)
+
+### Changed
+
+- Distribution remains GitHub-only as one tarball plus `SHA256SUMS`; npm and container registries are unchanged.
+- Existing `1.6.10-electric.2` through `.5` installations remain available for rollback.
+
 ## [1.6.10-electric.5] - 2026-07-21
 
 ### Fixed

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.5",
+  "version": "1.6.10-electric.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-electric.5",
+      "version": "1.6.10-electric.6",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.5",
+  "version": "1.6.10-electric.6",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Summary

- bump package, lockfile, plugin, and marketplace identities to `1.6.10-electric.6`
- document the single corrective change from #168
- preserve GitHub-only distribution and `.2` through `.5` rollback installs

## Scope

This release contains the bounded #162 corrective fix only. It adds no unrelated source, hardening, fleet, or policy changes.

## Validation

- electric release policy checker
- JSON parse and manifest version agreement
- targeted Prettier
- `git diff --check`
- source and real Ladybug regression gates passed on #168

Release follow-up to #168 and #162.
