### PR TITLE
feat: repair HNSW safely and report zero embeddings truthfully

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -615,6 +615,7 @@ export interface AnalyzeOptions {
   /** Refuse any analyze path that would require a full DB rebuild. */
   incrementalOnly?: boolean;
   repairFts?: boolean;
+  repairVector?: boolean;
   /**
    * Embedding generation toggle. Commander parses `--embeddings [limit]` as:
    *   - `undefined` when the flag is omitted
@@ -1177,9 +1178,31 @@ const analyzeCommandImpl = async (
     return;
   }
 
-  if (options.incrementalOnly && (options.force || options.repairFts || options.skills)) {
+  if (options.repairVector) {
+    const conflicts = [
+      options.force && '--force',
+      options.staged && '--staged',
+      options.incrementalOnly && '--incremental-only',
+      options.repairFts && '--repair-fts',
+      options.embeddings !== undefined && '--embeddings',
+      options.dropEmbeddings && '--drop-embeddings',
+      options.skills && '--skills',
+      options.pdg && '--pdg',
+      options.branch && '--branch',
+    ].filter((value): value is string => typeof value === 'string');
+    if (conflicts.length > 0) {
+      cliError(`  Cannot combine \`--repair-vector\` with ${conflicts.join(', ')}.\n`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  if (
+    options.incrementalOnly &&
+    (options.force || options.repairFts || options.repairVector || options.skills)
+  ) {
     cliError(
-      '  Cannot combine `--incremental-only` with `--force`, `--repair-fts`, or `--skills`. ' +
+      '  Cannot combine `--incremental-only` with `--force`, `--repair-fts`, `--repair-vector`, or `--skills`. ' +
         'The preservation contract refuses every option that can require a full rebuild.\n',
     );
     process.exitCode = 1;
@@ -1390,6 +1413,7 @@ const analyzeCommandImpl = async (
         staged: options.staged,
         incrementalOnly: options.incrementalOnly,
         repairFts: options.repairFts,
+        repairVector: options.repairVector,
         embeddings: embeddingsEnabled,
         embeddingsNodeLimit,
         dropEmbeddings: options.dropEmbeddings,
@@ -1504,6 +1528,28 @@ const analyzeCommandImpl = async (
       console.error = origError;
       bar.stop();
       console.log('  FTS indexes repaired successfully\n');
+      return;
+    }
+
+    if (result.vectorRepairStatus) {
+      clearInterval(elapsedTimer);
+      process.removeListener('SIGINT', sigintHandler);
+      process.removeListener('SIGTERM', sigtermHandler);
+      await emitResourceEvent('complete', 'vector-repair', 100);
+      await closeResourceLog();
+      console.log = origLog;
+      // eslint-disable-next-line no-console -- restoring after intentional progress-bar routing
+      console.warn = origWarn;
+      // eslint-disable-next-line no-console -- restoring after intentional progress-bar routing
+      console.error = origError;
+      bar.stop();
+      if (result.vectorRepairStatus === 'not-indexed') {
+        console.log('  VECTOR: not-indexed (database has zero embeddings; no mutation performed)\n');
+      } else if (result.vectorRepairStatus === 'healthy') {
+        console.log('  VECTOR index already healthy; counts reconciled successfully\n');
+      } else {
+        console.log('  VECTOR index repaired and verified successfully\n');
+      }
       return;
     }
 

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -896,6 +896,28 @@ const analyzeCommandImpl = async (
     return;
   }
 
+  // Reject repair-only conflicts before any embedding runtime setup or
+  // endpoint mutation. Commander represents --embeddings N as a string, so
+  // every defined value except explicit false is a conflicting request.
+  if (options.repairVector) {
+    const conflicts = [
+      options.force && '--force',
+      options.staged && '--staged',
+      options.incrementalOnly && '--incremental-only',
+      options.repairFts && '--repair-fts',
+      options.embeddings !== undefined && options.embeddings !== false && '--embeddings',
+      options.dropEmbeddings && '--drop-embeddings',
+      options.skills && '--skills',
+      options.pdg && '--pdg',
+      options.branch && '--branch',
+    ].filter((value): value is string => typeof value === 'string');
+    if (conflicts.length > 0) {
+      cliError(`  Cannot combine \`--repair-vector\` with ${conflicts.join(', ')}.\n`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+
   if (options.verbose) {
     process.env.GITNEXUS_VERBOSE = '1';
   }
@@ -1176,25 +1198,6 @@ const analyzeCommandImpl = async (
     );
     process.exitCode = 1;
     return;
-  }
-
-  if (options.repairVector) {
-    const conflicts = [
-      options.force && '--force',
-      options.staged && '--staged',
-      options.incrementalOnly && '--incremental-only',
-      options.repairFts && '--repair-fts',
-      options.embeddings === true && '--embeddings',
-      options.dropEmbeddings && '--drop-embeddings',
-      options.skills && '--skills',
-      options.pdg && '--pdg',
-      options.branch && '--branch',
-    ].filter((value): value is string => typeof value === 'string');
-    if (conflicts.length > 0) {
-      cliError(`  Cannot combine \`--repair-vector\` with ${conflicts.join(', ')}.\n`);
-      process.exitCode = 1;
-      return;
-    }
   }
 
   if (

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -1184,7 +1184,7 @@ const analyzeCommandImpl = async (
       options.staged && '--staged',
       options.incrementalOnly && '--incremental-only',
       options.repairFts && '--repair-fts',
-      options.embeddings !== undefined && '--embeddings',
+      options.embeddings === true && '--embeddings',
       options.dropEmbeddings && '--drop-embeddings',
       options.skills && '--skills',
       options.pdg && '--pdg',
@@ -1544,7 +1544,9 @@ const analyzeCommandImpl = async (
       console.error = origError;
       bar.stop();
       if (result.vectorRepairStatus === 'not-indexed') {
-        console.log('  VECTOR: not-indexed (database has zero embeddings; no mutation performed)\n');
+        console.log(
+          '  VECTOR: not-indexed (database has zero embeddings; no mutation performed)\n',
+        );
       } else if (result.vectorRepairStatus === 'healthy') {
         console.log('  VECTOR index already healthy; counts reconciled successfully\n');
       } else {

--- a/gitnexus/src/cli/doctor.ts
+++ b/gitnexus/src/cli/doctor.ts
@@ -169,7 +169,7 @@ export function repoVectorDoctorStatus(
   const rawEmbeddingCount = Number(meta.stats?.embeddings ?? 0);
   const embeddingCount =
     Number.isFinite(rawEmbeddingCount) && rawEmbeddingCount > 0 ? Math.floor(rawEmbeddingCount) : 0;
-  if (embeddingCount <= 0) return { status: 'no embeddings', detail: null };
+  if (embeddingCount <= 0) return { status: 'not-indexed', detail: null };
 
   if (liveProbe) {
     if (liveProbe.vectorIndex) {

--- a/gitnexus/src/cli/help-i18n.ts
+++ b/gitnexus/src/cli/help-i18n.ts
@@ -53,6 +53,7 @@ const OPTION_DESCRIPTION_KEYS = {
   'analyze|-f, --force': 'help.option.analyze.force',
   'analyze|--incremental-only': 'help.option.analyze.incrementalOnly',
   'analyze|--repair-fts': 'help.option.analyze.repairFts',
+  'analyze|--repair-vector': 'help.option.analyze.repairVector',
   'analyze|--embeddings [limit]': 'help.option.analyze.embeddings',
   'analyze|--drop-embeddings': 'help.option.analyze.dropEmbeddings',
   'analyze|--skills': 'help.option.analyze.skills',

--- a/gitnexus/src/cli/i18n/en.ts
+++ b/gitnexus/src/cli/i18n/en.ts
@@ -175,8 +175,7 @@ export const en = {
   'help.option.analyze.incrementalOnly':
     'Refuse recovery, migration, or scale escalation that would require a full rebuild',
   'help.option.analyze.repairFts': 'Repair/rebuild search FTS indexes without full re-analysis',
-  'help.option.analyze.repairVector':
-    'Repair/rebuild HNSW without regenerating embedding rows',
+  'help.option.analyze.repairVector': 'Repair/rebuild HNSW without regenerating embedding rows',
   'help.option.analyze.embeddings':
     'Enable embedding generation for semantic search (off by default). Local models default to a 50,000-node safety cap; remote HTTP providers default uncapped. Optional [limit] sets an explicit cap; pass 0 to disable it.',
   'help.option.analyze.dropEmbeddings':

--- a/gitnexus/src/cli/i18n/en.ts
+++ b/gitnexus/src/cli/i18n/en.ts
@@ -175,6 +175,8 @@ export const en = {
   'help.option.analyze.incrementalOnly':
     'Refuse recovery, migration, or scale escalation that would require a full rebuild',
   'help.option.analyze.repairFts': 'Repair/rebuild search FTS indexes without full re-analysis',
+  'help.option.analyze.repairVector':
+    'Repair/rebuild HNSW without regenerating embedding rows',
   'help.option.analyze.embeddings':
     'Enable embedding generation for semantic search (off by default). Local models default to a 50,000-node safety cap; remote HTTP providers default uncapped. Optional [limit] sets an explicit cap; pass 0 to disable it.',
   'help.option.analyze.dropEmbeddings':

--- a/gitnexus/src/cli/i18n/zh-CN.ts
+++ b/gitnexus/src/cli/i18n/zh-CN.ts
@@ -166,6 +166,7 @@ export const zhCN = {
   'help.option.analyze.force': '即使已是最新也强制完整重建索引',
   'help.option.analyze.incrementalOnly': '拒绝任何需要完整重建的恢复、迁移或规模升级路径',
   'help.option.analyze.repairFts': '修复/重建搜索 FTS 索引，不执行完整重新分析',
+  'help.option.analyze.repairVector': '修复/重建 HNSW，不重新生成嵌入行',
   'help.option.analyze.embeddings':
     '启用语义搜索的嵌入生成（默认关闭）。可选 [limit] 覆盖 50,000 节点安全上限；传 0 可完全禁用上限。',
   'help.option.analyze.dropEmbeddings':

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -63,6 +63,7 @@ program
     'Refuse recovery, migration, or scale escalation that would require a full rebuild',
   )
   .option('--repair-fts', 'Repair/rebuild search FTS indexes without full re-analysis')
+  .option('--repair-vector', 'Repair/rebuild HNSW without regenerating embedding rows')
   .option(
     '--embeddings [limit]',
     'Enable embedding generation for semantic search (off by default). ' +

--- a/gitnexus/src/cli/registry-doctor.ts
+++ b/gitnexus/src/cli/registry-doctor.ts
@@ -332,13 +332,25 @@ const unavailableCapabilities = (): RegistryCapabilityReport => ({
   vectorSearchReason: 'pool-probe-unavailable',
 });
 
-const liveCapabilities = (probe: DoctorPoolProbe): RegistryCapabilityReport => {
+const liveCapabilities = (
+  probe: DoctorPoolProbe,
+  embeddingCount: number,
+): RegistryCapabilityReport => {
   if (
     probe.reason ||
     probe.connectionCount !== EXPECTED_POOL_CONNECTIONS ||
     probe.exercisedConnections !== EXPECTED_POOL_CONNECTIONS
   ) {
     return unavailableCapabilities();
+  }
+  if (embeddingCount === 0) {
+    return {
+      source: 'active-probe',
+      graph: 'available',
+      fts: probe.fts ? 'available' : 'unavailable',
+      vectorSearch: 'not-indexed',
+      vectorSearchReason: null,
+    };
   }
   return {
     source: 'active-probe',
@@ -497,7 +509,10 @@ const inspectEntry = async (
   let capabilities = unavailableCapabilities();
   if (availableCounts) {
     try {
-      capabilities = liveCapabilities(await (options.capabilityProbe ?? probeDoctorPool)(lbugPath));
+      capabilities = liveCapabilities(
+        await (options.capabilityProbe ?? probeDoctorPool)(lbugPath),
+        availableCounts.embeddings,
+      );
     } catch {
       capabilities = unavailableCapabilities();
     }

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -696,22 +696,22 @@ export const initLbug = async (dbPath: string) => {
  */
 export const initLbugForMaintenance = async (dbPath: string) =>
   runWithSessionLock(async () => {
-    if (conn || db) await safeClose();
-    resetOpenConnectionState();
-
-    const state = await fs.lstat(dbPath);
-    if (!state.isFile() || state.isSymbolicLink()) {
-      throw new Error(`Maintenance requires a regular, non-symlink database file at ${dbPath}`);
-    }
-
-    await preflightLbugSidecars(dbPath, {
-      mode: 'write',
-      logger,
-      allowQuarantine: false,
-    });
-
     const releaseInitLock = await acquireInitLock(dbPath);
     try {
+      if (conn || db) await safeClose();
+      resetOpenConnectionState();
+
+      const state = await fs.lstat(dbPath);
+      if (!state.isFile() || state.isSymbolicLink()) {
+        throw new Error(`Maintenance requires a regular, non-symlink database file at ${dbPath}`);
+      }
+
+      await preflightLbugSidecars(dbPath, {
+        mode: 'write',
+        logger,
+        allowQuarantine: false,
+      });
+
       const opened = await openLbugConnection(lbug, dbPath);
       db = opened.db;
       conn = opened.conn;

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -706,11 +706,17 @@ export const initLbugForMaintenance = async (dbPath: string) =>
         throw new Error(`Maintenance requires a regular, non-symlink database file at ${dbPath}`);
       }
 
-      await preflightLbugSidecars(dbPath, {
+      const sidecarState = await preflightLbugSidecars(dbPath, {
         mode: 'write',
         logger,
         allowQuarantine: false,
       });
+      if (sidecarState.kind !== 'clean') {
+        throw new Error(
+          `Maintenance refused: LadybugDB sidecar state is ${sidecarState.kind}; ` +
+            'close the active writer or recover the index before retrying.',
+        );
+      }
 
       const opened = await openLbugConnection(lbug, dbPath);
       db = opened.db;

--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -686,6 +686,44 @@ export const initLbug = async (dbPath: string) => {
 };
 
 /**
+ * Open an existing database for a narrowly-scoped maintenance operation.
+ *
+ * Unlike {@link initLbug}, this path never creates/removes a database, runs
+ * schema DDL, quarantines sidecars, or attempts recovery. Callers must perform
+ * their own storage/metadata preflight before entering this function. The
+ * init lock only closes the race with another LadybugDB opener; it is not a
+ * recovery mechanism.
+ */
+export const initLbugForMaintenance = async (dbPath: string) =>
+  runWithSessionLock(async () => {
+    if (conn || db) await safeClose();
+    resetOpenConnectionState();
+
+    const state = await fs.lstat(dbPath);
+    if (!state.isFile() || state.isSymbolicLink()) {
+      throw new Error(`Maintenance requires a regular, non-symlink database file at ${dbPath}`);
+    }
+
+    await preflightLbugSidecars(dbPath, {
+      mode: 'write',
+      logger,
+      allowQuarantine: false,
+    });
+
+    const releaseInitLock = await acquireInitLock(dbPath);
+    try {
+      const opened = await openLbugConnection(lbug, dbPath);
+      db = opened.db;
+      conn = opened.conn;
+      currentDbPath = dbPath;
+      currentDbReadOnly = false;
+      return { db, conn };
+    } finally {
+      await releaseInitLock();
+    }
+  });
+
+/**
  * Execute multiple queries against one repo DB atomically.
  * While the callback runs, no other request can switch the active DB.
  *

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -130,6 +130,7 @@ import {
 import { generateAIContextFiles } from '../cli/ai-context.js';
 import { sanitizeDetectedBranch } from '../cli/analyze-config.js';
 import { EMBEDDING_TABLE_NAME, STALE_HASH_SENTINEL } from './lbug/schema.js';
+import { isMissingColumnOrTableError } from './lbug/schema-errors.js';
 import {
   discardStagedWorkspace,
   getStagedAnalyzePaths,
@@ -793,6 +794,24 @@ const runFullAnalysisImpl = async (
     const { probeDoctorPool, EXPECTED_POOL_CONNECTIONS } =
       await import('../cli/doctor-pool-probe.js');
     const beforeProbe = await probeDoctorPool(canonicalPaths.lbugPath);
+    const readEmbeddingCount = async (): Promise<number> => {
+      let rows: Awaited<ReturnType<typeof executeQuery>>;
+      try {
+        rows = await executeQuery(
+          `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (isMissingColumnOrTableError(message)) return 0;
+        throw error;
+      }
+      const row = rows[0];
+      const count = Number(row?.cnt ?? row?.[0] ?? 0);
+      if (!Number.isSafeInteger(count) || count < 0) {
+        throw new Error('Cannot repair VECTOR: database returned an invalid embedding count.');
+      }
+      return count;
+    };
     let stats: { nodes: number; edges: number } = { nodes: 0, edges: 0 };
     let embeddingCountBefore = 0;
     let repairStatus: AnalyzeResult['vectorRepairStatus'] = 'healthy';
@@ -800,12 +819,7 @@ const runFullAnalysisImpl = async (
     try {
       await initLbugForMaintenance(canonicalPaths.lbugPath);
       stats = await getLbugStats();
-      const rows = await executeQuery(`MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`);
-      const row = rows[0];
-      embeddingCountBefore = Number(row?.cnt ?? row?.[0] ?? 0);
-      if (!Number.isSafeInteger(embeddingCountBefore) || embeddingCountBefore < 0) {
-        throw new Error('Cannot repair VECTOR: database returned an invalid embedding count.');
-      }
+      embeddingCountBefore = await readEmbeddingCount();
 
       if (embeddingCountBefore === 0) {
         progress('done', 100, 'No embeddings are indexed; VECTOR repair was not needed.');
@@ -818,6 +832,13 @@ const runFullAnalysisImpl = async (
           stats: { ...existingMeta.stats, nodes: stats.nodes, edges: stats.edges, embeddings: 0 },
           vectorRepairStatus: 'not-indexed',
         };
+      }
+
+      if (beforeProbe.reason || !beforeProbe.vector) {
+        throw new Error(
+          'Cannot repair VECTOR: the production pool could not prove VECTOR availability ' +
+            `(${beforeProbe.vectorIndexReason ?? beforeProbe.reason ?? 'vector-extension-unavailable'}).`,
+        );
       }
 
       const vectorAvailable = await loadVectorExtension(undefined, {
@@ -843,11 +864,7 @@ const runFullAnalysisImpl = async (
         repairStatus = 'repaired';
       }
 
-      const afterRows = await executeQuery(
-        `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`,
-      );
-      const afterRow = afterRows[0];
-      const embeddingCountAfter = Number(afterRow?.cnt ?? afterRow?.[0] ?? 0);
+      const embeddingCountAfter = await readEmbeddingCount();
       if (embeddingCountAfter !== embeddingCountBefore) {
         throw new Error(
           `VECTOR repair changed embedding rows (${embeddingCountBefore} before, ` +
@@ -874,34 +891,49 @@ const runFullAnalysisImpl = async (
 
     const { getRuntimeCapabilities } = await import('./platform/capabilities.js');
     const runtimeCapabilities = getRuntimeCapabilities();
-    const repairedMeta: RepoMeta = {
-      ...existingMeta,
-      repoPath,
-      remoteUrl: repositoryRemoteUrl ?? existingMeta.remoteUrl,
-      stats: {
-        ...existingMeta.stats,
-        nodes: stats.nodes,
-        edges: stats.edges,
-        embeddings: embeddingCountBefore,
-      },
-      capabilities: {
-        graph: { provider: 'ladybugdb', status: 'available' },
-        fts: {
-          provider: 'ladybugdb-fts',
-          status: afterProbe.fts ? 'available' : 'unavailable',
+    let repairedMeta: RepoMeta;
+    let projectName: string;
+    await initLbugForMaintenance(canonicalPaths.lbugPath);
+    try {
+      const committedStats = await getLbugStats();
+      const committedEmbeddingCount = await readEmbeddingCount();
+      if (committedEmbeddingCount !== embeddingCountBefore) {
+        throw new Error(
+          `VECTOR repair database changed before metadata commit (${embeddingCountBefore} ` +
+            `verified, ${committedEmbeddingCount} current); metadata and registry were not updated.`,
+        );
+      }
+      repairedMeta = {
+        ...existingMeta,
+        repoPath,
+        remoteUrl: repositoryRemoteUrl ?? existingMeta.remoteUrl,
+        stats: {
+          ...existingMeta.stats,
+          nodes: committedStats.nodes,
+          edges: committedStats.edges,
+          embeddings: committedEmbeddingCount,
         },
-        vectorSearch: {
-          provider: 'ladybugdb-vector',
-          status: 'vector-index',
-          exactScanLimit: runtimeCapabilities.exactScanLimit,
+        capabilities: {
+          graph: { provider: 'ladybugdb', status: 'available' },
+          fts: {
+            provider: 'ladybugdb-fts',
+            status: afterProbe.fts ? 'available' : 'unavailable',
+          },
+          vectorSearch: {
+            provider: 'ladybugdb-vector',
+            status: 'vector-index',
+            exactScanLimit: runtimeCapabilities.exactScanLimit,
+          },
         },
-      },
-    };
-    await saveMeta(canonicalMetaDir, repairedMeta);
-    const projectName = await registerRepo(repoPath, repairedMeta, {
-      name: options.registryName,
-      allowDuplicateName: options.allowDuplicateName,
-    });
+      };
+      await saveMeta(canonicalMetaDir, repairedMeta);
+      projectName = await registerRepo(repoPath, repairedMeta, {
+        name: options.registryName,
+        allowDuplicateName: options.allowDuplicateName,
+      });
+    } finally {
+      await closeLbug().catch(() => {});
+    }
     progress('done', 100, 'VECTOR index verified through all eight pooled connections.');
     return {
       repoName: projectName,

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -16,6 +16,7 @@ import { runPipelineFromRepo } from './ingestion/pipeline.js';
 import { resetDegradedParseCounter } from './tree-sitter/safe-parse.js';
 import {
   initLbug,
+  initLbugForMaintenance,
   loadGraphToLbug,
   getLbugStats,
   executeQuery,
@@ -31,6 +32,9 @@ import {
   deleteAllInjects,
   queryImportersBatch,
   loadFTSExtension,
+  loadVectorExtension,
+  createVectorIndex,
+  dropVectorIndex,
   wipeLbugDbFiles,
   LbugWipeError,
   DELETE_FILES_CHUNK_SIZE,
@@ -170,6 +174,8 @@ export interface AnalyzeOptions {
   incrementalOnly?: boolean;
   /** Repair only search indexes without re-running full parsing/indexing. */
   repairFts?: boolean;
+  /** Rebuild only the named HNSW index while preserving every embedding row. */
+  repairVector?: boolean;
   /** Emit per-index FTS create logs. */
   verbose?: boolean;
   embeddings?: boolean;
@@ -317,6 +323,87 @@ const resolveEmbeddingIdentity = async (): Promise<EmbeddingIdentity> => {
   };
 };
 
+const pathKind = (state: Awaited<ReturnType<typeof fs.lstat>>): string => {
+  if (state.isSymbolicLink()) return 'a symbolic link';
+  if (state.isDirectory()) return 'a directory';
+  if (state.isSocket()) return 'a socket';
+  if (state.isFIFO()) return 'a FIFO';
+  if (state.isBlockDevice()) return 'a block device';
+  if (state.isCharacterDevice()) return 'a character device';
+  return 'not a regular file';
+};
+
+const lstatIfPresent = async (targetPath: string) => {
+  try {
+    return await fs.lstat(targetPath);
+  } catch (error) {
+    if (isMissingFilesystemError(error)) return null;
+    throw error;
+  }
+};
+
+/**
+ * Read-only gate for VECTOR maintenance. It deliberately runs before the
+ * analyzer ownership lock creates any file, and refuses rather than recovering
+ * stale state. A second writer that appears after this check is still excluded
+ * by the ownership/init/database locks.
+ */
+export const assertVectorRepairPreflight = async (repoPath: string): Promise<RepoMeta> => {
+  const paths = getStoragePaths(repoPath);
+  const storageState = await lstatIfPresent(paths.storagePath);
+  if (!storageState) {
+    throw new Error('Cannot repair VECTOR: this repository has not been analyzed yet.');
+  }
+  if (!storageState.isDirectory() || storageState.isSymbolicLink()) {
+    throw new Error(
+      `Cannot repair VECTOR: storage at ${paths.storagePath} is ${pathKind(storageState)}; ` +
+        'expected a regular directory.',
+    );
+  }
+
+  const databaseState = await lstatIfPresent(paths.lbugPath);
+  if (!databaseState) {
+    throw new Error(`Cannot repair VECTOR: graph store at ${paths.lbugPath} is missing.`);
+  }
+  if (!databaseState.isFile() || databaseState.isSymbolicLink()) {
+    throw new Error(
+      `Cannot repair VECTOR: graph store at ${paths.lbugPath} is ${pathKind(databaseState)}; ` +
+        'expected a regular file.',
+    );
+  }
+
+  const promotion = getStagedAnalyzePaths(paths.lbugPath, path.dirname(paths.metaPath));
+  const blockedArtifacts = [
+    path.join(paths.storagePath, 'analyze-staged.lock'),
+    `${paths.lbugPath}.init.lock`,
+    `${paths.lbugPath}.lock`,
+    `${paths.lbugPath}.wal`,
+    `${paths.lbugPath}.shadow`,
+    `${paths.lbugPath}.wal.checkpoint`,
+    promotion.journalPath,
+    promotion.stageIntentPath,
+    promotion.stageRoot,
+    promotion.backupLbugPath,
+  ];
+  for (const artifact of blockedArtifacts) {
+    if (await lstatIfPresent(artifact)) {
+      throw new Error(
+        `Cannot repair VECTOR while lock or recovery state is present at ${artifact}. ` +
+          'Resolve it with the normal analyze/recovery workflow first.',
+      );
+    }
+  }
+
+  const meta = await loadMeta(path.dirname(paths.metaPath));
+  if (!meta) throw new Error('Cannot repair VECTOR: index metadata is missing.');
+  if (meta.incrementalInProgress || meta.embeddingCheckpoint) {
+    throw new Error(
+      'Cannot repair VECTOR while index metadata records an incomplete analysis or embedding checkpoint.',
+    );
+  }
+  return meta;
+};
+
 export interface AnalyzeResult {
   repoName: string;
   repoPath: string;
@@ -333,6 +420,8 @@ export interface AnalyzeResult {
   pipelineResult?: any;
   /** True when analyze only repaired FTS indexes and skipped pipeline re-analysis. */
   ftsRepairedOnly?: boolean;
+  /** Terminal outcome for a VECTOR-only maintenance run. */
+  vectorRepairStatus?: 'repaired' | 'healthy' | 'not-indexed';
   /**
    * True when the FTS extension was unavailable so search-index creation was
    * skipped (offline-first degradation). The graph is fully queryable; only
@@ -688,6 +777,139 @@ const runFullAnalysisImpl = async (
       branch: placement.branch,
     });
   };
+
+  // ── VECTOR-only repair path ──────────────────────────────────────────
+  // The outer entry point has already performed the read-only storage,
+  // recovery, lock, and metadata preflight before acquiring our ownership
+  // lock. This branch intentionally precedes staged-promotion recovery so a
+  // maintenance command never mutates or chooses between recovery artifacts.
+  if (options.repairVector) {
+    const existingMeta = await loadMeta(canonicalMetaDir);
+    if (!existingMeta) throw new Error('Cannot repair VECTOR: index metadata is missing.');
+
+    const { probeDoctorPool, EXPECTED_POOL_CONNECTIONS } = await import(
+      '../cli/doctor-pool-probe.js'
+    );
+    const beforeProbe = await probeDoctorPool(canonicalPaths.lbugPath);
+    let stats: { nodes: number; edges: number } = { nodes: 0, edges: 0 };
+    let embeddingCountBefore = 0;
+    let repairStatus: AnalyzeResult['vectorRepairStatus'] = 'healthy';
+
+    try {
+      await initLbugForMaintenance(canonicalPaths.lbugPath);
+      stats = await getLbugStats();
+      const rows = await executeQuery(
+        `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`,
+      );
+      const row = rows[0];
+      embeddingCountBefore = Number(row?.cnt ?? row?.[0] ?? 0);
+      if (!Number.isSafeInteger(embeddingCountBefore) || embeddingCountBefore < 0) {
+        throw new Error('Cannot repair VECTOR: database returned an invalid embedding count.');
+      }
+
+      if (embeddingCountBefore === 0) {
+        progress('done', 100, 'No embeddings are indexed; VECTOR repair was not needed.');
+        return {
+          repoName:
+            options.registryName ??
+            getInferredRepoName(repoPath) ??
+            path.basename(resolveRepoIdentityRoot(repoPath)),
+          repoPath,
+          stats: { ...existingMeta.stats, nodes: stats.nodes, edges: stats.edges, embeddings: 0 },
+          vectorRepairStatus: 'not-indexed',
+        };
+      }
+
+      const vectorAvailable = await loadVectorExtension(undefined, {
+        policy: resolveAnalyzeInstallPolicy(),
+      });
+      if (!vectorAvailable) {
+        const rawReason = getExtensionCapabilities().find((c) => c.name === 'vector')?.reason;
+        throw new Error(
+          'Cannot repair VECTOR: the LadybugDB VECTOR extension is unavailable' +
+            (rawReason ? ` — ${rawReason.replace(/\.$/, '')}` : '') +
+            '.',
+        );
+      }
+
+      if (!beforeProbe.vectorIndex) {
+        progress('vector', 85, 'Rebuilding the HNSW vector index...');
+        if (!(await dropVectorIndex())) {
+          throw new Error('Cannot repair VECTOR: the existing HNSW index could not be removed.');
+        }
+        if (!(await createVectorIndex())) {
+          throw new Error('Cannot repair VECTOR: the HNSW index could not be created.');
+        }
+        repairStatus = 'repaired';
+      }
+
+      const afterRows = await executeQuery(
+        `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`,
+      );
+      const afterRow = afterRows[0];
+      const embeddingCountAfter = Number(afterRow?.cnt ?? afterRow?.[0] ?? 0);
+      if (embeddingCountAfter !== embeddingCountBefore) {
+        throw new Error(
+          `VECTOR repair changed embedding rows (${embeddingCountBefore} before, ` +
+            `${embeddingCountAfter} after); metadata and registry were not updated.`,
+        );
+      }
+    } finally {
+      await closeLbug().catch(() => {});
+    }
+
+    const afterProbe = await probeDoctorPool(canonicalPaths.lbugPath);
+    if (
+      afterProbe.reason ||
+      !afterProbe.vector ||
+      !afterProbe.vectorIndex ||
+      afterProbe.connectionCount !== EXPECTED_POOL_CONNECTIONS ||
+      afterProbe.exercisedConnections !== EXPECTED_POOL_CONNECTIONS
+    ) {
+      throw new Error(
+        'VECTOR repair did not pass the eight-connection production-pool probe; ' +
+          `metadata and registry were not updated (${afterProbe.vectorIndexReason ?? afterProbe.reason ?? 'pool-probe-unavailable'}).`,
+      );
+    }
+
+    const { getRuntimeCapabilities } = await import('./platform/capabilities.js');
+    const runtimeCapabilities = getRuntimeCapabilities();
+    const repairedMeta: RepoMeta = {
+      ...existingMeta,
+      repoPath,
+      remoteUrl: repositoryRemoteUrl ?? existingMeta.remoteUrl,
+      stats: {
+        ...existingMeta.stats,
+        nodes: stats.nodes,
+        edges: stats.edges,
+        embeddings: embeddingCountBefore,
+      },
+      capabilities: {
+        graph: { provider: 'ladybugdb', status: 'available' },
+        fts: {
+          provider: 'ladybugdb-fts',
+          status: afterProbe.fts ? 'available' : 'unavailable',
+        },
+        vectorSearch: {
+          provider: 'ladybugdb-vector',
+          status: 'vector-index',
+          exactScanLimit: runtimeCapabilities.exactScanLimit,
+        },
+      },
+    };
+    await saveMeta(canonicalMetaDir, repairedMeta);
+    const projectName = await registerRepo(repoPath, repairedMeta, {
+      name: options.registryName,
+      allowDuplicateName: options.allowDuplicateName,
+    });
+    progress('done', 100, 'VECTOR index verified through all eight pooled connections.');
+    return {
+      repoName: projectName,
+      repoPath,
+      stats: repairedMeta.stats ?? {},
+      vectorRepairStatus: repairStatus,
+    };
+  }
 
   const promoteValidatedStage = async (paths: StagedAnalyzePaths): Promise<string | undefined> => {
     const stagedMeta = await validateStagedGeneration(paths);
@@ -2657,6 +2879,23 @@ export async function runFullAnalysis(
   options: AnalyzeOptions,
   callbacks: AnalyzeCallbacks,
 ): Promise<AnalyzeResult> {
+  if (options.repairVector) {
+    const conflicts = [
+      options.force && '--force',
+      options.staged && '--staged',
+      options.incrementalOnly && '--incremental-only',
+      options.repairFts && '--repair-fts',
+      options.embeddings && '--embeddings',
+      options.embeddingsNodeLimit !== undefined && '--embeddings',
+      options.dropEmbeddings && '--drop-embeddings',
+      options.pdg && '--pdg',
+      options.branch && '--branch',
+    ].filter((value): value is string => typeof value === 'string');
+    if (conflicts.length > 0) {
+      throw new Error(`Cannot combine \`--repair-vector\` with ${conflicts.join(', ')}.`);
+    }
+  }
+
   // Repository identity is the first gate. It must run before the analyzer
   // ownership lock creates its storage directory, as well as before metadata,
   // sidecar, or database mutation. registerRepo repeats the check at commit
@@ -2664,6 +2903,7 @@ export async function runFullAnalysis(
   const repoHasGit = hasGitDir(repoPath);
   const repositoryRemoteUrl = repoHasGit ? getRemoteUrl(repoPath) : undefined;
   await assertCanonicalRepositoryIdentity(repoPath, repositoryRemoteUrl);
+  if (options.repairVector) await assertVectorRepairPreflight(repoPath);
 
   const { storagePath } = getStoragePaths(repoPath);
   return withAnalyzeOwnershipLock(storagePath, () =>

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -348,7 +348,10 @@ const lstatIfPresent = async (targetPath: string) => {
  * stale state. A second writer that appears after this check is still excluded
  * by the ownership/init/database locks.
  */
-export const assertVectorRepairPreflight = async (repoPath: string): Promise<RepoMeta> => {
+export const assertVectorRepairPreflight = async (
+  repoPath: string,
+  options: { allowAnalyzeOwnershipLock?: boolean } = {},
+): Promise<RepoMeta> => {
   const paths = getStoragePaths(repoPath);
   const storageState = await lstatIfPresent(paths.storagePath);
   if (!storageState) {
@@ -374,7 +377,7 @@ export const assertVectorRepairPreflight = async (repoPath: string): Promise<Rep
 
   const promotion = getStagedAnalyzePaths(paths.lbugPath, path.dirname(paths.metaPath));
   const blockedArtifacts = [
-    path.join(paths.storagePath, 'analyze-staged.lock'),
+    !options.allowAnalyzeOwnershipLock && path.join(paths.storagePath, 'analyze-staged.lock'),
     `${paths.lbugPath}.init.lock`,
     `${paths.lbugPath}.lock`,
     `${paths.lbugPath}.wal`,
@@ -384,7 +387,7 @@ export const assertVectorRepairPreflight = async (repoPath: string): Promise<Rep
     promotion.stageIntentPath,
     promotion.stageRoot,
     promotion.backupLbugPath,
-  ];
+  ].filter((artifact): artifact is string => typeof artifact === 'string');
   for (const artifact of blockedArtifacts) {
     if (await lstatIfPresent(artifact)) {
       throw new Error(
@@ -2907,7 +2910,9 @@ export async function runFullAnalysis(
     // The first preflight avoids creating an ownership lock for a known-dirty
     // index. Repeat it after lock acquisition because a writer may have run
     // while this command was waiting and left new recovery or dirty state.
-    if (options.repairVector) await assertVectorRepairPreflight(repoPath);
+    if (options.repairVector) {
+      await assertVectorRepairPreflight(repoPath, { allowAnalyzeOwnershipLock: true });
+    }
     return runFullAnalysisImpl(repoPath, options, callbacks, {
       repoHasGit,
       remoteUrl: repositoryRemoteUrl,

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -787,9 +787,8 @@ const runFullAnalysisImpl = async (
     const existingMeta = await loadMeta(canonicalMetaDir);
     if (!existingMeta) throw new Error('Cannot repair VECTOR: index metadata is missing.');
 
-    const { probeDoctorPool, EXPECTED_POOL_CONNECTIONS } = await import(
-      '../cli/doctor-pool-probe.js'
-    );
+    const { probeDoctorPool, EXPECTED_POOL_CONNECTIONS } =
+      await import('../cli/doctor-pool-probe.js');
     const beforeProbe = await probeDoctorPool(canonicalPaths.lbugPath);
     let stats: { nodes: number; edges: number } = { nodes: 0, edges: 0 };
     let embeddingCountBefore = 0;
@@ -798,9 +797,7 @@ const runFullAnalysisImpl = async (
     try {
       await initLbugForMaintenance(canonicalPaths.lbugPath);
       stats = await getLbugStats();
-      const rows = await executeQuery(
-        `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`,
-      );
+      const rows = await executeQuery(`MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`);
       const row = rows[0];
       embeddingCountBefore = Number(row?.cnt ?? row?.[0] ?? 0);
       if (!Number.isSafeInteger(embeddingCountBefore) || embeddingCountBefore < 0) {
@@ -2906,10 +2903,14 @@ export async function runFullAnalysis(
   if (options.repairVector) await assertVectorRepairPreflight(repoPath);
 
   const { storagePath } = getStoragePaths(repoPath);
-  return withAnalyzeOwnershipLock(storagePath, () =>
-    runFullAnalysisImpl(repoPath, options, callbacks, {
+  return withAnalyzeOwnershipLock(storagePath, async () => {
+    // The first preflight avoids creating an ownership lock for a known-dirty
+    // index. Repeat it after lock acquisition because a writer may have run
+    // while this command was waiting and left new recovery or dirty state.
+    if (options.repairVector) await assertVectorRepairPreflight(repoPath);
+    return runFullAnalysisImpl(repoPath, options, callbacks, {
       repoHasGit,
       remoteUrl: repositoryRemoteUrl,
-    }),
-  );
+    });
+  });
 }

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -797,9 +797,7 @@ const runFullAnalysisImpl = async (
     const readEmbeddingCount = async (): Promise<number> => {
       let rows: Awaited<ReturnType<typeof executeQuery>>;
       try {
-        rows = await executeQuery(
-          `MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`,
-        );
+        rows = await executeQuery(`MATCH (e:${EMBEDDING_TABLE_NAME}) RETURN count(e) AS cnt`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (isMissingColumnOrTableError(message)) return 0;

--- a/gitnexus/test/unit/analyze-no-stats-bridge.test.ts
+++ b/gitnexus/test/unit/analyze-no-stats-bridge.test.ts
@@ -137,6 +137,19 @@ describe('analyzeCommand commander → runFullAnalysis noStats bridge (#1477)', 
     expect(opts.repairVector).toBe(true);
   });
 
+  it('allows --repair-vector when repository config disables embeddings', async () => {
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+
+    await analyzeCommand(undefined, { repairVector: true, embeddings: false });
+
+    expect(process.exitCode).not.toBe(1);
+    expect(runFullAnalysisMock).toHaveBeenCalledOnce();
+    expect(runFullAnalysisMock.mock.calls[0][1]).toMatchObject({
+      repairVector: true,
+      embeddings: false,
+    });
+  });
+
   it.each([
     ['--force', { force: true }],
     ['--staged', { staged: true }],

--- a/gitnexus/test/unit/analyze-no-stats-bridge.test.ts
+++ b/gitnexus/test/unit/analyze-no-stats-bridge.test.ts
@@ -1,21 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { runFullAnalysisMock, generateAIContextFilesMock, generateSkillFilesMock, cliErrorMock } =
-  vi.hoisted(() => {
-    const runFullAnalysisMock = vi.fn();
-    const generateAIContextFilesMock = vi.fn(async () => ({ files: [] as string[] }));
-    const generateSkillFilesMock = vi.fn(async () => ({
-      skills: [{ name: 'c', label: 'Community', symbolCount: 1, fileCount: 1 }],
-      outputPath: '/repo/.claude/skills/generated',
-    }));
-    const cliErrorMock = vi.fn();
-    return {
-      runFullAnalysisMock,
-      generateAIContextFilesMock,
-      generateSkillFilesMock,
-      cliErrorMock,
-    };
-  });
+const {
+  runFullAnalysisMock,
+  generateAIContextFilesMock,
+  generateSkillFilesMock,
+  cliErrorMock,
+  installEmbeddingRuntimeMock,
+} = vi.hoisted(() => {
+  const runFullAnalysisMock = vi.fn();
+  const generateAIContextFilesMock = vi.fn(async () => ({ files: [] as string[] }));
+  const generateSkillFilesMock = vi.fn(async () => ({
+    skills: [{ name: 'c', label: 'Community', symbolCount: 1, fileCount: 1 }],
+    outputPath: '/repo/.claude/skills/generated',
+  }));
+  const cliErrorMock = vi.fn();
+  const installEmbeddingRuntimeMock = vi.fn();
+  return {
+    runFullAnalysisMock,
+    generateAIContextFilesMock,
+    generateSkillFilesMock,
+    cliErrorMock,
+    installEmbeddingRuntimeMock,
+  };
+});
 
 vi.mock('../../src/core/run-analyze.js', () => ({
   runFullAnalysis: runFullAnalysisMock,
@@ -31,6 +38,15 @@ vi.mock('../../src/cli/skill-gen.js', () => ({
 
 vi.mock('../../src/cli/cli-message.js', () => ({
   cliError: cliErrorMock,
+}));
+
+vi.mock('../../src/core/embeddings/runtime-install.js', () => ({
+  ANALYZE_EMBEDDING_INSTALL_TIMEOUT_MS: 30_000,
+  getEmbeddingInstallTimeoutMs: vi.fn(() => 30_000),
+  getEmbeddingRuntimeDir: vi.fn(() => '/tmp/gitnexus-embedding-runtime'),
+  installEmbeddingRuntime: installEmbeddingRuntimeMock,
+  isPrefixRuntimeLoadable: vi.fn(() => true),
+  resolveEmbeddingRuntime: vi.fn(() => null),
 }));
 
 vi.mock('../../src/core/lbug/lbug-adapter.js', () => ({
@@ -77,6 +93,7 @@ describe('analyzeCommand commander → runFullAnalysis noStats bridge (#1477)', 
       outputPath: '/repo/.claude/skills/generated',
     });
     cliErrorMock.mockReset();
+    installEmbeddingRuntimeMock.mockReset();
     process.exitCode = undefined;
     process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --max-old-space-size=8192`.trim();
   });
@@ -156,6 +173,7 @@ describe('analyzeCommand commander → runFullAnalysis noStats bridge (#1477)', 
     ['--incremental-only', { incrementalOnly: true }],
     ['--repair-fts', { repairFts: true }],
     ['--embeddings', { embeddings: true }],
+    ['--embeddings 100', { embeddings: '100' }],
     ['--drop-embeddings', { dropEmbeddings: true }],
     ['--skills', { skills: true }],
     ['--pdg', { pdg: true }],
@@ -170,6 +188,7 @@ describe('analyzeCommand commander → runFullAnalysis noStats bridge (#1477)', 
       expect.stringMatching(/cannot combine `--repair-vector`/i),
     );
     expect(runFullAnalysisMock).not.toHaveBeenCalled();
+    expect(installEmbeddingRuntimeMock).not.toHaveBeenCalled();
   });
 
   it('passes --incremental-only through to runFullAnalysis', async () => {

--- a/gitnexus/test/unit/analyze-no-stats-bridge.test.ts
+++ b/gitnexus/test/unit/analyze-no-stats-bridge.test.ts
@@ -128,6 +128,37 @@ describe('analyzeCommand commander → runFullAnalysis noStats bridge (#1477)', 
     expect(opts.repairFts).toBe(true);
   });
 
+  it('passes --repair-vector through to runFullAnalysis', async () => {
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+
+    await analyzeCommand(undefined, { repairVector: true });
+
+    const opts = runFullAnalysisMock.mock.calls[0][1];
+    expect(opts.repairVector).toBe(true);
+  });
+
+  it.each([
+    ['--force', { force: true }],
+    ['--staged', { staged: true }],
+    ['--incremental-only', { incrementalOnly: true }],
+    ['--repair-fts', { repairFts: true }],
+    ['--embeddings', { embeddings: true }],
+    ['--drop-embeddings', { dropEmbeddings: true }],
+    ['--skills', { skills: true }],
+    ['--pdg', { pdg: true }],
+    ['--branch', { branch: 'main' }],
+  ])('rejects combining --repair-vector with %s', async (_label, conflicting) => {
+    const { analyzeCommand } = await import('../../src/cli/analyze.js');
+
+    await analyzeCommand(undefined, { repairVector: true, ...conflicting });
+
+    expect(process.exitCode).toBe(1);
+    expect(cliErrorMock).toHaveBeenCalledWith(
+      expect.stringMatching(/cannot combine `--repair-vector`/i),
+    );
+    expect(runFullAnalysisMock).not.toHaveBeenCalled();
+  });
+
   it('passes --incremental-only through to runFullAnalysis', async () => {
     const { analyzeCommand } = await import('../../src/cli/analyze.js');
 

--- a/gitnexus/test/unit/doctor-format.test.ts
+++ b/gitnexus/test/unit/doctor-format.test.ts
@@ -167,6 +167,13 @@ describe('doctor page-size lines (#1231, #2424 review)', () => {
 });
 
 describe('doctor current-repository VECTOR status', () => {
+  it('reports zero embeddings as not-indexed rather than broken VECTOR', () => {
+    expect(repoVectorDoctorStatus({ stats: { embeddings: 0 } } as RepoMeta)).toEqual({
+      status: 'not-indexed',
+      detail: null,
+    });
+  });
+
   it('distinguishes a persisted HNSW index from platform support', () => {
     expect(
       repoVectorDoctorStatus({

--- a/gitnexus/test/unit/lbug-maintenance-lock.test.ts
+++ b/gitnexus/test/unit/lbug-maintenance-lock.test.ts
@@ -22,6 +22,7 @@ describe('LadybugDB maintenance open', () => {
     const preflightLbugSidecars = vi.fn(async () => {
       const record = JSON.parse(await fs.readFile(lockPath, 'utf8'));
       expect(record.pid).toBe(process.pid);
+      return { kind: 'clean' as const };
     });
     const closeLbugConnection = vi.fn(async () => undefined);
 

--- a/gitnexus/test/unit/lbug-maintenance-lock.test.ts
+++ b/gitnexus/test/unit/lbug-maintenance-lock.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTempDir } from '../helpers/test-db.js';
+
+vi.mock('@ladybugdb/core', () => ({ default: {} }));
+
+describe('LadybugDB maintenance open', () => {
+  afterEach(() => {
+    vi.doUnmock('../../src/core/lbug/lbug-config.js');
+    vi.doUnmock('../../src/core/lbug/sidecar-recovery.js');
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('holds the init lock while running the non-recovering sidecar preflight', async () => {
+    const fixture = await createTempDir('gitnexus-maintenance-lock-');
+    const dbPath = path.join(fixture.dbPath, 'lbug');
+    const lockPath = `${dbPath}.init.lock`;
+    await fs.writeFile(dbPath, 'fixture');
+
+    const preflightLbugSidecars = vi.fn(async () => {
+      const record = JSON.parse(await fs.readFile(lockPath, 'utf8'));
+      expect(record.pid).toBe(process.pid);
+    });
+    const closeLbugConnection = vi.fn(async () => undefined);
+
+    vi.doMock('../../src/core/lbug/lbug-config.js', async (importActual) => ({
+      ...(await importActual<typeof import('../../src/core/lbug/lbug-config.js')>()),
+      openLbugConnection: vi.fn(async () => ({ db: {}, conn: {} })),
+      closeLbugConnection,
+    }));
+    vi.doMock('../../src/core/lbug/sidecar-recovery.js', async (importActual) => ({
+      ...(await importActual<typeof import('../../src/core/lbug/sidecar-recovery.js')>()),
+      preflightLbugSidecars,
+    }));
+
+    try {
+      const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+      await adapter.initLbugForMaintenance(dbPath);
+
+      expect(preflightLbugSidecars).toHaveBeenCalledWith(dbPath, {
+        mode: 'write',
+        logger: expect.anything(),
+        allowQuarantine: false,
+      });
+      await expect(fs.access(lockPath)).rejects.toThrow();
+      await adapter.closeLbug();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});

--- a/gitnexus/test/unit/registry-doctor.test.ts
+++ b/gitnexus/test/unit/registry-doctor.test.ts
@@ -391,6 +391,39 @@ describe('doctor --registry read-only report (#133)', () => {
     });
   });
 
+  it('reports a readable zero-embedding database as not-indexed', async () => {
+    const indexed = await createEntry(
+      fixture.dbPath,
+      'zero-embeddings',
+      'ZeroEmbeddings',
+      'https://github.com/owner/zero-embeddings.git',
+      { nodes: 1, edges: 0, embeddings: 0 },
+    );
+    const capabilityProbe = vi.fn(async () => ({
+      fts: true,
+      vector: true,
+      vectorIndex: false,
+      vectorIndexReason: 'vector-index-missing-or-unqueryable' as const,
+      exercisedConnections: 8,
+      connectionCount: 8,
+      reason: null,
+    }));
+
+    const report = await buildRegistryDoctorReport({
+      entries: [indexed.entry],
+      databaseProbe: async () => ({ nodes: 1, edges: 0, embeddings: 0 }),
+      capabilityProbe,
+    });
+
+    expect(report.entries[0]?.capabilities).toEqual({
+      source: 'active-probe',
+      graph: 'available',
+      fts: 'available',
+      vectorSearch: 'not-indexed',
+      vectorSearchReason: null,
+    });
+  });
+
   it('lets a failed default live probe override optimistic recorded metadata', async () => {
     const indexed = await createEntry(
       fixture.dbPath,

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -1,11 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  getStoragePaths,
-  saveMeta,
-  type RepoMeta,
-} from '../../src/storage/repo-manager.js';
+import { getStoragePaths, saveMeta, type RepoMeta } from '../../src/storage/repo-manager.js';
 import { createTempDir } from '../helpers/test-db.js';
 
 const healthyProbe = {
@@ -53,6 +49,7 @@ async function importRepairSubject(options: {
   probes?: Array<typeof healthyProbe | typeof brokenProbe>;
   vectorAvailable?: boolean;
   createError?: Error;
+  afterInitialPreflight?: () => Promise<void> | void;
 }) {
   const counts = [...(options.counts ?? [3, 3])];
   const probes = [...(options.probes ?? [brokenProbe, healthyProbe])];
@@ -85,6 +82,16 @@ async function importRepairSubject(options: {
     EXPECTED_POOL_CONNECTIONS: 8,
     probeDoctorPool,
   }));
+  vi.doMock('../../src/core/staged-promotion.js', async (importActual) => {
+    const actual = await importActual<typeof import('../../src/core/staged-promotion.js')>();
+    return {
+      ...actual,
+      withAnalyzeOwnershipLock: vi.fn(async (_storagePath, callback) => {
+        await options.afterInitialPreflight?.();
+        return callback();
+      }),
+    };
+  });
   vi.doMock('../../src/storage/repo-manager.js', async (importActual) => ({
     ...(await importActual<typeof import('../../src/storage/repo-manager.js')>()),
     registerRepo,
@@ -110,6 +117,7 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
   afterEach(() => {
     vi.doUnmock('../../src/core/lbug/lbug-adapter.js');
     vi.doUnmock('../../src/cli/doctor-pool-probe.js');
+    vi.doUnmock('../../src/core/staged-promotion.js');
     vi.doUnmock('../../src/storage/repo-manager.js');
     vi.resetModules();
     vi.clearAllMocks();
@@ -161,7 +169,9 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       expect(mocks.dropVectorIndex).not.toHaveBeenCalled();
       expect(mocks.createVectorIndex).not.toHaveBeenCalled();
       expect(mocks.registerRepo).not.toHaveBeenCalled();
-      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(before);
+      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(
+        before,
+      );
     } finally {
       await indexed.fixture.cleanup();
     }
@@ -173,16 +183,14 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       const before = await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'));
       const { runFullAnalysis, mocks } = await importRepairSubject({ vectorAvailable: false });
       await expect(
-        runFullAnalysis(
-          indexed.fixture.dbPath,
-          { repairVector: true },
-          { onProgress: () => {} },
-        ),
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
       ).rejects.toThrow(/VECTOR extension is unavailable/i);
       expect(mocks.dropVectorIndex).not.toHaveBeenCalled();
       expect(mocks.createVectorIndex).not.toHaveBeenCalled();
       expect(mocks.registerRepo).not.toHaveBeenCalled();
-      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(before);
+      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(
+        before,
+      );
     } finally {
       await indexed.fixture.cleanup();
     }
@@ -196,14 +204,12 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
         createError: new Error('simulated HNSW failure'),
       });
       await expect(
-        runFullAnalysis(
-          indexed.fixture.dbPath,
-          { repairVector: true },
-          { onProgress: () => {} },
-        ),
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
       ).rejects.toThrow(/simulated HNSW failure/);
       expect(mocks.registerRepo).not.toHaveBeenCalled();
-      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(before);
+      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(
+        before,
+      );
     } finally {
       await indexed.fixture.cleanup();
     }
@@ -235,11 +241,24 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       await fs.writeFile(`${indexed.paths.lbugPath}.wal`, 'unresolved');
       const { runFullAnalysis, mocks } = await importRepairSubject({});
       await expect(
-        runFullAnalysis(
-          indexed.fixture.dbPath,
-          { repairVector: true },
-          { onProgress: () => {} },
-        ),
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
+      ).rejects.toThrow(/lock or recovery state is present/i);
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('rechecks recovery state after acquiring analyze ownership', async () => {
+    const indexed = await createIndexedFixture();
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({
+        afterInitialPreflight: async () => {
+          await fs.writeFile(`${indexed.paths.lbugPath}.wal`, 'intervening-writer');
+        },
+      });
+      await expect(
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
       ).rejects.toThrow(/lock or recovery state is present/i);
       expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
     } finally {

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -87,8 +87,14 @@ async function importRepairSubject(options: {
     return {
       ...actual,
       withAnalyzeOwnershipLock: vi.fn(async (_storagePath, callback) => {
-        await options.afterInitialPreflight?.();
-        return callback();
+        const ownershipLock = path.join(_storagePath, 'analyze-staged.lock');
+        await fs.writeFile(ownershipLock, 'owned-by-test');
+        try {
+          await options.afterInitialPreflight?.();
+          return await callback();
+        } finally {
+          await fs.rm(ownershipLock, { force: true });
+        }
       }),
     };
   });

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -49,9 +49,10 @@ async function importRepairSubject(options: {
   probes?: Array<typeof healthyProbe | typeof brokenProbe>;
   vectorAvailable?: boolean;
   createError?: Error;
+  missingEmbeddingTable?: boolean;
   afterInitialPreflight?: () => Promise<void> | void;
 }) {
-  const counts = [...(options.counts ?? [3, 3])];
+  const counts = [...(options.counts ?? [3, 3, 3])];
   const probes = [...(options.probes ?? [brokenProbe, healthyProbe])];
   const initLbugForMaintenance = vi.fn(async () => undefined);
   const loadVectorExtension = vi.fn(async () => options.vectorAvailable ?? true);
@@ -61,8 +62,13 @@ async function importRepairSubject(options: {
     return true;
   });
   const closeLbug = vi.fn(async () => undefined);
+  let embeddingCountQueries = 0;
   const executeQuery = vi.fn(async (query: string) => {
     if (!query.includes('CodeEmbedding')) return [];
+    embeddingCountQueries++;
+    if (options.missingEmbeddingTable && embeddingCountQueries === 1) {
+      throw new Error('Binder exception: Table CodeEmbedding does not exist.');
+    }
     return [{ cnt: counts.shift() ?? 0 }];
   });
   const registerRepo = vi.fn(async () => 'fixture-repo');
@@ -146,6 +152,7 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       expect(mocks.executeQuery.mock.calls.map(([query]) => query)).toEqual([
         expect.stringMatching(/MATCH \(e:CodeEmbedding\).*count/i),
         expect.stringMatching(/MATCH \(e:CodeEmbedding\).*count/i),
+        expect.stringMatching(/MATCH \(e:CodeEmbedding\).*count/i),
       ]);
       expect(mocks.registerRepo).toHaveBeenCalledOnce();
 
@@ -178,6 +185,51 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(
         before,
       );
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('treats a missing CodeEmbedding table as not indexed without mutation', async () => {
+    const indexed = await createIndexedFixture(0);
+    try {
+      const before = await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'));
+      const { runFullAnalysis, mocks } = await importRepairSubject({
+        missingEmbeddingTable: true,
+      });
+      const result = await runFullAnalysis(
+        indexed.fixture.dbPath,
+        { repairVector: true },
+        { onProgress: () => {} },
+      );
+      expect(result.vectorRepairStatus).toBe('not-indexed');
+      expect(mocks.dropVectorIndex).not.toHaveBeenCalled();
+      expect(mocks.registerRepo).not.toHaveBeenCalled();
+      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(
+        before,
+      );
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('fails closed when the production pool cannot prove VECTOR before repair', async () => {
+    const indexed = await createIndexedFixture();
+    try {
+      const unavailableProbe = {
+        ...brokenProbe,
+        vector: false,
+        reason: 'vector-extension-unavailable',
+      };
+      const { runFullAnalysis, mocks } = await importRepairSubject({
+        probes: [unavailableProbe],
+      });
+      await expect(
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
+      ).rejects.toThrow(/could not prove VECTOR availability/i);
+      expect(mocks.dropVectorIndex).not.toHaveBeenCalled();
+      expect(mocks.createVectorIndex).not.toHaveBeenCalled();
+      expect(mocks.registerRepo).not.toHaveBeenCalled();
     } finally {
       await indexed.fixture.cleanup();
     }

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -1,0 +1,249 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getStoragePaths,
+  saveMeta,
+  type RepoMeta,
+} from '../../src/storage/repo-manager.js';
+import { createTempDir } from '../helpers/test-db.js';
+
+const healthyProbe = {
+  fts: true,
+  vector: true,
+  vectorIndex: true,
+  vectorIndexReason: null,
+  exercisedConnections: 8,
+  connectionCount: 8,
+  reason: null,
+} as const;
+
+const brokenProbe = {
+  ...healthyProbe,
+  vectorIndex: false,
+  vectorIndexReason: 'vector-index-missing-or-unqueryable' as const,
+};
+
+async function createIndexedFixture(embeddings = 3) {
+  const fixture = await createTempDir('gitnexus-vector-repair-');
+  const paths = getStoragePaths(fixture.dbPath);
+  await fs.mkdir(paths.storagePath, { recursive: true });
+  await fs.writeFile(paths.lbugPath, 'fixture');
+  const meta: RepoMeta = {
+    repoPath: fixture.dbPath,
+    lastCommit: '',
+    indexedAt: '2026-07-22T00:00:00.000Z',
+    stats: { files: 2, nodes: 5, edges: 4, embeddings },
+    capabilities: {
+      graph: { provider: 'ladybugdb', status: 'available' },
+      fts: { provider: 'ladybugdb-fts', status: 'available' },
+      vectorSearch: {
+        provider: 'exact-scan',
+        status: 'exact-scan',
+        exactScanLimit: 20_000,
+      },
+    },
+  };
+  await saveMeta(paths.storagePath, meta);
+  return { fixture, paths, meta };
+}
+
+async function importRepairSubject(options: {
+  counts?: number[];
+  probes?: Array<typeof healthyProbe | typeof brokenProbe>;
+  vectorAvailable?: boolean;
+  createError?: Error;
+}) {
+  const counts = [...(options.counts ?? [3, 3])];
+  const probes = [...(options.probes ?? [brokenProbe, healthyProbe])];
+  const initLbugForMaintenance = vi.fn(async () => undefined);
+  const loadVectorExtension = vi.fn(async () => options.vectorAvailable ?? true);
+  const dropVectorIndex = vi.fn(async () => true);
+  const createVectorIndex = vi.fn(async () => {
+    if (options.createError) throw options.createError;
+    return true;
+  });
+  const closeLbug = vi.fn(async () => undefined);
+  const executeQuery = vi.fn(async (query: string) => {
+    if (!query.includes('CodeEmbedding')) return [];
+    return [{ cnt: counts.shift() ?? 0 }];
+  });
+  const registerRepo = vi.fn(async () => 'fixture-repo');
+  const probeDoctorPool = vi.fn(async () => probes.shift() ?? healthyProbe);
+
+  vi.doMock('../../src/core/lbug/lbug-adapter.js', async (importActual) => ({
+    ...(await importActual<typeof import('../../src/core/lbug/lbug-adapter.js')>()),
+    initLbugForMaintenance,
+    loadVectorExtension,
+    dropVectorIndex,
+    createVectorIndex,
+    closeLbug,
+    getLbugStats: vi.fn(async () => ({ nodes: 5, edges: 4 })),
+    executeQuery,
+  }));
+  vi.doMock('../../src/cli/doctor-pool-probe.js', () => ({
+    EXPECTED_POOL_CONNECTIONS: 8,
+    probeDoctorPool,
+  }));
+  vi.doMock('../../src/storage/repo-manager.js', async (importActual) => ({
+    ...(await importActual<typeof import('../../src/storage/repo-manager.js')>()),
+    registerRepo,
+  }));
+
+  const subject = await import('../../src/core/run-analyze.js');
+  return {
+    ...subject,
+    mocks: {
+      initLbugForMaintenance,
+      loadVectorExtension,
+      dropVectorIndex,
+      createVectorIndex,
+      closeLbug,
+      executeQuery,
+      registerRepo,
+      probeDoctorPool,
+    },
+  };
+}
+
+describe('runFullAnalysis VECTOR-only repair (#170)', () => {
+  afterEach(() => {
+    vi.doUnmock('../../src/core/lbug/lbug-adapter.js');
+    vi.doUnmock('../../src/cli/doctor-pool-probe.js');
+    vi.doUnmock('../../src/storage/repo-manager.js');
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('rebuilds only HNSW, preserves the embedding count, then reconciles metadata', async () => {
+    const indexed = await createIndexedFixture();
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({});
+      const result = await runFullAnalysis(
+        indexed.fixture.dbPath,
+        { repairVector: true },
+        { onProgress: () => {} },
+      );
+
+      expect(result.vectorRepairStatus).toBe('repaired');
+      expect(mocks.dropVectorIndex).toHaveBeenCalledOnce();
+      expect(mocks.createVectorIndex).toHaveBeenCalledOnce();
+      expect(mocks.probeDoctorPool).toHaveBeenCalledTimes(2);
+      expect(mocks.executeQuery.mock.calls.map(([query]) => query)).toEqual([
+        expect.stringMatching(/MATCH \(e:CodeEmbedding\).*count/i),
+        expect.stringMatching(/MATCH \(e:CodeEmbedding\).*count/i),
+      ]);
+      expect(mocks.registerRepo).toHaveBeenCalledOnce();
+
+      const repaired = JSON.parse(
+        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
+      );
+      expect(repaired.stats).toMatchObject({ nodes: 5, edges: 4, embeddings: 3 });
+      expect(repaired.capabilities.vectorSearch.status).toBe('vector-index');
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('returns not-indexed without rebuilding or changing metadata when there are zero rows', async () => {
+    const indexed = await createIndexedFixture(0);
+    try {
+      const before = await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'));
+      const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [0] });
+      const result = await runFullAnalysis(
+        indexed.fixture.dbPath,
+        { repairVector: true },
+        { onProgress: () => {} },
+      );
+
+      expect(result.vectorRepairStatus).toBe('not-indexed');
+      expect(mocks.loadVectorExtension).not.toHaveBeenCalled();
+      expect(mocks.dropVectorIndex).not.toHaveBeenCalled();
+      expect(mocks.createVectorIndex).not.toHaveBeenCalled();
+      expect(mocks.registerRepo).not.toHaveBeenCalled();
+      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(before);
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('does not drop HNSW when VECTOR support is unavailable', async () => {
+    const indexed = await createIndexedFixture();
+    try {
+      const before = await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'));
+      const { runFullAnalysis, mocks } = await importRepairSubject({ vectorAvailable: false });
+      await expect(
+        runFullAnalysis(
+          indexed.fixture.dbPath,
+          { repairVector: true },
+          { onProgress: () => {} },
+        ),
+      ).rejects.toThrow(/VECTOR extension is unavailable/i);
+      expect(mocks.dropVectorIndex).not.toHaveBeenCalled();
+      expect(mocks.createVectorIndex).not.toHaveBeenCalled();
+      expect(mocks.registerRepo).not.toHaveBeenCalled();
+      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(before);
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('leaves metadata and registry untouched when HNSW recreation fails', async () => {
+    const indexed = await createIndexedFixture();
+    try {
+      const before = await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'));
+      const { runFullAnalysis, mocks } = await importRepairSubject({
+        createError: new Error('simulated HNSW failure'),
+      });
+      await expect(
+        runFullAnalysis(
+          indexed.fixture.dbPath,
+          { repairVector: true },
+          { onProgress: () => {} },
+        ),
+      ).rejects.toThrow(/simulated HNSW failure/);
+      expect(mocks.registerRepo).not.toHaveBeenCalled();
+      expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(before);
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('does not rebuild a healthy HNSW index but still verifies and reconciles counts', async () => {
+    const indexed = await createIndexedFixture();
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({
+        probes: [healthyProbe, healthyProbe],
+      });
+      const result = await runFullAnalysis(
+        indexed.fixture.dbPath,
+        { repairVector: true },
+        { onProgress: () => {} },
+      );
+      expect(result.vectorRepairStatus).toBe('healthy');
+      expect(mocks.dropVectorIndex).not.toHaveBeenCalled();
+      expect(mocks.createVectorIndex).not.toHaveBeenCalled();
+      expect(mocks.registerRepo).toHaveBeenCalledOnce();
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('refuses active recovery sidecars before opening the database', async () => {
+    const indexed = await createIndexedFixture();
+    try {
+      await fs.writeFile(`${indexed.paths.lbugPath}.wal`, 'unresolved');
+      const { runFullAnalysis, mocks } = await importRepairSubject({});
+      await expect(
+        runFullAnalysis(
+          indexed.fixture.dbPath,
+          { repairVector: true },
+          { onProgress: () => {} },
+        ),
+      ).rejects.toThrow(/lock or recovery state is present/i);
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Closes #170

## Summary
- add `analyze --repair-vector` with fail-closed storage, lock, recovery, and metadata preflight
- preserve every `CodeEmbedding` row while rebuilding only the named HNSW index
- require the production eight-connection pool probe before reconciling metadata and registry counts
- report readable zero-embedding indexes as `not-indexed`

## Proof
- `npm run build`
- `npx vitest run test/unit/run-analyze-vector-repair.test.ts test/unit/analyze-no-stats-bridge.test.ts test/unit/doctor-format.test.ts test/unit/registry-doctor.test.ts test/unit/cli-index-help.test.ts` (78 passed)
- GitNexus detect_changes reviewed; the high aggregate reflects CLI/adapter shared surfaces, while the adapter change is additive and the maintenance path is isolated behind a new flag.