### PR TITLE
feat: safely refresh Claude hooks and diagnose integrations

### DIFF
--- a/gitnexus-claude-plugin/hooks/hook-lock.js
+++ b/gitnexus-claude-plugin/hooks/hook-lock.js
@@ -1,12 +1,14 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const HOOK_LOCK_SUBDIR = '.hook-locks';
 const HOOK_LOCK_MAX_INFLIGHT = 3;
+const HOOK_GLOBAL_LOCK_SUBDIR = '.hook-locks-global';
+const HOOK_GLOBAL_MAX_INFLIGHT = 8;
 const HOOK_LOCK_STALE_MS = 30000;
 
-function acquireHookSlot(gitNexusDir) {
-  const lockDir = path.join(gitNexusDir, HOOK_LOCK_SUBDIR);
+function acquireSlotInDir(lockDir, maxInflight) {
   try {
     fs.mkdirSync(lockDir, { recursive: true });
   } catch {
@@ -19,7 +21,7 @@ function acquireHookSlot(gitNexusDir) {
 
   const myPidStr = String(process.pid);
 
-  for (let slot = 0; slot < HOOK_LOCK_MAX_INFLIGHT; slot++) {
+  for (let slot = 0; slot < maxInflight; slot++) {
     const slotPath = path.join(lockDir, `slot-${slot}.lock`);
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
@@ -111,9 +113,42 @@ function acquireHookSlot(gitNexusDir) {
   return null;
 }
 
+function globalHookLockDir() {
+  const override = process.env.GITNEXUS_HOOK_GLOBAL_LOCK_DIR;
+  if (override && path.isAbsolute(override)) return override;
+  return path.join(os.homedir(), '.gitnexus', HOOK_GLOBAL_LOCK_SUBDIR);
+}
+
+function acquireHookSlot(gitNexusDir) {
+  const releaseGlobal = acquireSlotInDir(globalHookLockDir(), HOOK_GLOBAL_MAX_INFLIGHT);
+  if (!releaseGlobal) return null;
+
+  const releaseRepository = acquireSlotInDir(
+    path.join(gitNexusDir, HOOK_LOCK_SUBDIR),
+    HOOK_LOCK_MAX_INFLIGHT,
+  );
+  if (!releaseRepository) {
+    releaseGlobal();
+    return null;
+  }
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    releaseRepository();
+    releaseGlobal();
+  };
+  process.on('exit', release);
+  return release;
+}
+
 module.exports = {
   HOOK_LOCK_SUBDIR,
   HOOK_LOCK_MAX_INFLIGHT,
+  HOOK_GLOBAL_LOCK_SUBDIR,
+  HOOK_GLOBAL_MAX_INFLIGHT,
   HOOK_LOCK_STALE_MS,
+  globalHookLockDir,
   acquireHookSlot,
 };

--- a/gitnexus/hooks/claude/hook-lock.cjs
+++ b/gitnexus/hooks/claude/hook-lock.cjs
@@ -1,12 +1,14 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const HOOK_LOCK_SUBDIR = '.hook-locks';
 const HOOK_LOCK_MAX_INFLIGHT = 3;
+const HOOK_GLOBAL_LOCK_SUBDIR = '.hook-locks-global';
+const HOOK_GLOBAL_MAX_INFLIGHT = 8;
 const HOOK_LOCK_STALE_MS = 30000;
 
-function acquireHookSlot(gitNexusDir) {
-  const lockDir = path.join(gitNexusDir, HOOK_LOCK_SUBDIR);
+function acquireSlotInDir(lockDir, maxInflight) {
   try {
     fs.mkdirSync(lockDir, { recursive: true });
   } catch {
@@ -19,7 +21,7 @@ function acquireHookSlot(gitNexusDir) {
 
   const myPidStr = String(process.pid);
 
-  for (let slot = 0; slot < HOOK_LOCK_MAX_INFLIGHT; slot++) {
+  for (let slot = 0; slot < maxInflight; slot++) {
     const slotPath = path.join(lockDir, `slot-${slot}.lock`);
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
@@ -111,9 +113,48 @@ function acquireHookSlot(gitNexusDir) {
   return null;
 }
 
+function globalHookLockDir() {
+  const override = process.env.GITNEXUS_HOOK_GLOBAL_LOCK_DIR;
+  if (override && path.isAbsolute(override)) return override;
+  return path.join(os.homedir(), '.gitnexus', HOOK_GLOBAL_LOCK_SUBDIR);
+}
+
+/**
+ * Acquire both the user-global machine slot and the per-repository slot.
+ * Global admission is first so bursts across many repositories cannot exceed
+ * eight augment children in aggregate. If repository admission is saturated,
+ * the global slot is released immediately.
+ */
+function acquireHookSlot(gitNexusDir) {
+  const releaseGlobal = acquireSlotInDir(globalHookLockDir(), HOOK_GLOBAL_MAX_INFLIGHT);
+  if (!releaseGlobal) return null;
+
+  const releaseRepository = acquireSlotInDir(
+    path.join(gitNexusDir, HOOK_LOCK_SUBDIR),
+    HOOK_LOCK_MAX_INFLIGHT,
+  );
+  if (!releaseRepository) {
+    releaseGlobal();
+    return null;
+  }
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    releaseRepository();
+    releaseGlobal();
+  };
+  process.on('exit', release);
+  return release;
+}
+
 module.exports = {
   HOOK_LOCK_SUBDIR,
   HOOK_LOCK_MAX_INFLIGHT,
+  HOOK_GLOBAL_LOCK_SUBDIR,
+  HOOK_GLOBAL_MAX_INFLIGHT,
   HOOK_LOCK_STALE_MS,
+  globalHookLockDir,
   acquireHookSlot,
 };

--- a/gitnexus/src/cli/claude-hook-bundle.ts
+++ b/gitnexus/src/cli/claude-hook-bundle.ts
@@ -1,0 +1,28 @@
+export const CLAUDE_HOOK_ADAPTER = 'gitnexus-hook.cjs';
+
+export const CLAUDE_HOOK_HELPERS = [
+  'hook-lock.cjs',
+  'hook-db-lock-probe.cjs',
+  'win-rm-list-json.ps1',
+  'resolve-analyze-cmd.cjs',
+] as const;
+
+export const BEST_EFFORT_CLAUDE_HOOK_HELPERS = new Set<string>(['win-rm-list-json.ps1']);
+
+// Exact source line shipped by the adapter and replaced during installation.
+export const CLAUDE_HOOK_CLI_PATH_LITERAL =
+  "let cliPath = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');";
+
+export function patchClaudeHookCliPath(
+  source: string,
+  absoluteCliPath: string,
+): { content: string; sourceLiteralFound: boolean } {
+  const normalizedCli = absoluteCliPath.replace(/\\/g, '/');
+  return {
+    content: source.replace(
+      CLAUDE_HOOK_CLI_PATH_LITERAL,
+      `let cliPath = ${JSON.stringify(normalizedCli)};`,
+    ),
+    sourceLiteralFound: source.includes(CLAUDE_HOOK_CLI_PATH_LITERAL),
+  };
+}

--- a/gitnexus/src/cli/claude-hook-bundle.ts
+++ b/gitnexus/src/cli/claude-hook-bundle.ts
@@ -13,6 +13,17 @@ export const BEST_EFFORT_CLAUDE_HOOK_HELPERS = new Set<string>(['win-rm-list-jso
 export const CLAUDE_HOOK_CLI_PATH_LITERAL =
   "let cliPath = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');";
 
+export function formatHookCommand(
+  hookPath: string,
+  isWindows = process.platform === 'win32',
+): string {
+  if (isWindows) {
+    const escaped = hookPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    return `node "${escaped}"`;
+  }
+  return `node '${hookPath.replace(/'/g, "'\\''")}'`;
+}
+
 export function patchClaudeHookCliPath(
   source: string,
   absoluteCliPath: string,

--- a/gitnexus/src/cli/doctor.ts
+++ b/gitnexus/src/cli/doctor.ts
@@ -224,21 +224,48 @@ export const doctorCommand = async (
     recoveryPlan?: boolean;
     mcpConfig?: boolean;
     registry?: boolean;
+    integrations?: boolean;
     json?: boolean;
     showPaths?: boolean;
   } = {},
 ) => {
-  const selectedModes = [options.recoveryPlan, options.mcpConfig, options.registry].filter(
-    Boolean,
-  ).length;
+  const selectedModes = [
+    options.recoveryPlan,
+    options.mcpConfig,
+    options.registry,
+    options.integrations,
+  ].filter(Boolean).length;
   if (selectedModes > 1) {
-    throw new Error('--recovery-plan, --mcp-config, and --registry are mutually exclusive');
+    throw new Error(
+      '--recovery-plan, --mcp-config, --registry, and --integrations are mutually exclusive',
+    );
   }
   if (options.showPaths && !options.registry) {
     throw new Error('--show-paths may only be used with --registry');
   }
-  if (options.json && !options.mcpConfig && !options.registry) {
-    throw new Error('--json may only be used with --mcp-config or --registry');
+  if (options.json && !options.mcpConfig && !options.registry && !options.integrations) {
+    throw new Error('--json may only be used with --mcp-config, --registry, or --integrations');
+  }
+
+  if (options.integrations) {
+    const { buildIntegrationDoctorReport } = await import('./integration-doctor.js');
+    const report = await buildIntegrationDoctorReport();
+    if (options.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      console.log('GitNexus integration doctor (read-only)');
+      console.log(`  selected CLI:         ${report.selectedCli.version}`);
+      console.log(`  Codex/Claude MCP:     ${report.mcp.status}`);
+      console.log(`  Claude MCP entries:   ${report.mcp.claudeConfiguredEntries}`);
+      console.log(`  Claude hooks:         ${report.hooks.claude}`);
+      console.log(
+        `  legacy SessionStart:  ${report.hooks.obsoleteSessionStart ? 'present' : 'absent'}`,
+      );
+    }
+    if (report.mcp.status !== 'consistent' || report.hooks.claude !== 'current') {
+      process.exitCode = 1;
+    }
+    return;
   }
 
   if (options.recoveryPlan) {

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -31,6 +31,10 @@ program
     'Configure only these coding agents (comma-separated or repeatable)',
     collectCodingAgents,
   )
+  .option(
+    '--hooks-only',
+    'Refresh only Claude Code hook scripts and registrations; leave MCP and skills unchanged',
+  )
   .action(createLazyAction(() => import('./setup.js'), 'setupCommand'));
 
 program
@@ -250,6 +254,7 @@ program
   .option('--recovery-plan', 'Print a read-only interrupted-analysis recovery plan and exit')
   .option('--mcp-config', 'Validate MCP repository policy without binding or opening an index')
   .option('--registry', 'Inspect registry identities, metadata, sidecars, and database counts')
+  .option('--integrations', 'Inspect Codex/Claude MCP consistency and Claude hook freshness')
   .option('--json', 'Print machine-readable output (only with --mcp-config or --registry)')
   .option('--show-paths', 'Reveal absolute registry paths (only with --registry)')
   .action(createLazyAction(() => import('./doctor.js'), 'doctorCommand'));

--- a/gitnexus/src/cli/integration-doctor.ts
+++ b/gitnexus/src/cli/integration-doctor.ts
@@ -110,9 +110,7 @@ const codexMcpFingerprint = (raw: string): string | null => {
     }
   }
   const env: Record<string, string> = {};
-  const envMatch = raw.match(
-    /(?:^|\n)\[mcp_servers\.gitnexus\.env\]\s*\n([\s\S]*?)(?=\n\[|$)/,
-  );
+  const envMatch = raw.match(/(?:^|\n)\[mcp_servers\.gitnexus\.env\]\s*\n([\s\S]*?)(?=\n\[|$)/);
   if (envMatch) {
     for (const line of envMatch[1].split('\n')) {
       if (/^\s*(?:#.*)?$/.test(line)) continue;
@@ -120,9 +118,7 @@ const codexMcpFingerprint = (raw: string): string | null => {
         /^\s*([A-Za-z_][A-Za-z0-9_]*|"(?:[^"\\]|\\.)*")\s*=\s*("(?:[^"\\]|\\.)*")\s*(?:#.*)?$/,
       );
       if (!assignment) return null;
-      const key = assignment[1].startsWith('"')
-        ? parseTomlString(assignment[1])
-        : assignment[1];
+      const key = assignment[1].startsWith('"') ? parseTomlString(assignment[1]) : assignment[1];
       const value = parseTomlString(assignment[2]);
       if (key === null || value === null) return null;
       env[key] = value;

--- a/gitnexus/src/cli/integration-doctor.ts
+++ b/gitnexus/src/cli/integration-doctor.ts
@@ -9,6 +9,7 @@ import { getEditorTargets, hookTarget, mcpTarget } from './editor-targets.js';
 import {
   CLAUDE_HOOK_ADAPTER,
   CLAUDE_HOOK_HELPERS,
+  formatHookCommand,
   patchClaudeHookCliPath,
 } from './claude-hook-bundle.js';
 
@@ -103,26 +104,32 @@ const codexMcpFingerprint = (raw: string): string | null => {
   return entryFingerprint({ command, args });
 };
 
-const hookCommandPresent = (hooks: unknown, eventName: string): boolean => {
-  if (!hooks || typeof hooks !== 'object') return false;
+const hasCodexGitnexusSection = (raw: string): boolean =>
+  /(?:^|\n)\[mcp_servers\.gitnexus\]\s*(?:\n|$)/.test(raw);
+
+const gitnexusHookCommands = (hooks: unknown, eventName: string): string[] => {
+  if (!hooks || typeof hooks !== 'object') return [];
   const entries = (hooks as Record<string, unknown>)[eventName];
-  if (!Array.isArray(entries)) return false;
-  return entries.some(
-    (entry) =>
-      entry &&
-      typeof entry === 'object' &&
-      Array.isArray((entry as { hooks?: unknown }).hooks) &&
-      ((entry as { hooks: unknown[] }).hooks as unknown[]).some(
-        (hook) =>
-          hook &&
-          typeof hook === 'object' &&
-          typeof (hook as { command?: unknown }).command === 'string' &&
-          (hook as { command: string }).command.includes('gitnexus-hook'),
-      ),
-  );
+  if (!Array.isArray(entries)) return [];
+  const commands: string[] = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    const nested = (entry as { hooks?: unknown }).hooks;
+    if (!Array.isArray(nested)) continue;
+    for (const hook of nested) {
+      if (!hook || typeof hook !== 'object') continue;
+      const command = (hook as { command?: unknown }).command;
+      if (typeof command === 'string' && command.includes('gitnexus-hook')) {
+        commands.push(command);
+      }
+    }
+  }
+  return commands;
 };
 
-const claudeHookStatus = async (home: string): Promise<{
+const claudeHookStatus = async (
+  home: string,
+): Promise<{
   status: HookStatus;
   obsoleteSessionStart: boolean;
 }> => {
@@ -135,9 +142,20 @@ const claudeHookStatus = async (home: string): Promise<{
     return { status: 'missing', obsoleteSessionStart: false };
   }
   const hooks = (settings as { hooks?: unknown }).hooks;
-  const obsoleteSessionStart = hookCommandPresent(hooks, 'SessionStart');
-  if (!hookCommandPresent(hooks, 'PreToolUse') || !hookCommandPresent(hooks, 'PostToolUse')) {
+  const obsoleteSessionStart = gitnexusHookCommands(hooks, 'SessionStart').length > 0;
+  const preCommands = gitnexusHookCommands(hooks, 'PreToolUse');
+  const postCommands = gitnexusHookCommands(hooks, 'PostToolUse');
+  if (preCommands.length === 0 || postCommands.length === 0) {
     return { status: 'missing', obsoleteSessionStart };
+  }
+
+  const expectedHookPath = path.join(target.scriptDir, CLAUDE_HOOK_ADAPTER).replace(/\\/g, '/');
+  const expectedCommand = formatHookCommand(expectedHookPath);
+  if (
+    preCommands.some((command) => command !== expectedCommand) ||
+    postCommands.some((command) => command !== expectedCommand)
+  ) {
+    return { status: 'stale', obsoleteSessionStart };
   }
 
   const sourceDir = path.join(__dirname, '..', '..', 'hooks', 'claude');
@@ -177,7 +195,7 @@ export async function buildIntegrationDoctorReport(
   const claudeFingerprints = claudeEntries.map(entryFingerprint);
   invalid ||=
     (claudeEntries.length > 0 && claudeFingerprints.some((fingerprint) => fingerprint === null)) ||
-    (codexRaw !== null && codexFingerprint === null);
+    (codexRaw !== null && hasCodexGitnexusSection(codexRaw) && codexFingerprint === null);
   if (invalid) {
     status = 'invalid';
   } else if (codexFingerprint && claudeFingerprints.length > 0) {

--- a/gitnexus/src/cli/integration-doctor.ts
+++ b/gitnexus/src/cli/integration-doctor.ts
@@ -1,0 +1,199 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { parse as parseJsonc, type ParseError } from 'jsonc-parser';
+import { getEditorTargets, hookTarget, mcpTarget } from './editor-targets.js';
+import {
+  CLAUDE_HOOK_ADAPTER,
+  CLAUDE_HOOK_HELPERS,
+  patchClaudeHookCliPath,
+} from './claude-hook-bundle.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const pkg = require('../../package.json') as { version: string };
+
+type HookStatus = 'current' | 'stale' | 'missing';
+type McpStatus = 'consistent' | 'mismatch' | 'missing' | 'invalid';
+
+export interface IntegrationDoctorReport {
+  selectedCli: { version: string };
+  mcp: {
+    status: McpStatus;
+    codexConfigured: boolean;
+    claudeConfiguredEntries: number;
+  };
+  hooks: {
+    claude: HookStatus;
+    obsoleteSessionStart: boolean;
+  };
+}
+
+const digest = (content: string | Buffer): string =>
+  createHash('sha256').update(content).digest('hex');
+
+const readOptional = async (filePath: string): Promise<string | null> => {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+};
+
+const entryFingerprint = (entry: unknown): string | null => {
+  if (!entry || typeof entry !== 'object') return null;
+  const record = entry as { command?: unknown; args?: unknown };
+  if (typeof record.command !== 'string') return null;
+  const args = Array.isArray(record.args) ? record.args : [];
+  if (!args.every((arg) => typeof arg === 'string')) return null;
+  return JSON.stringify({ command: record.command, args });
+};
+
+const collectClaudeMcpEntries = (root: unknown): unknown[] => {
+  const found: unknown[] = [];
+  const seen = new Set<object>();
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== 'object' || seen.has(value as object)) return;
+    seen.add(value as object);
+    const record = value as Record<string, unknown>;
+    const servers = record.mcpServers;
+    if (servers && typeof servers === 'object') {
+      const gitnexus = (servers as Record<string, unknown>).gitnexus;
+      if (gitnexus !== undefined) found.push(gitnexus);
+    }
+    for (const child of Object.values(record)) visit(child);
+  };
+  visit(root);
+  return found;
+};
+
+const parseTomlString = (raw: string): string | null => {
+  try {
+    const value = JSON.parse(raw);
+    return typeof value === 'string' ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+const codexMcpFingerprint = (raw: string): string | null => {
+  const sectionMatch = raw.match(
+    /(?:^|\n)\[mcp_servers\.gitnexus\]\s*\n([\s\S]*?)(?=\n\[(?!mcp_servers\.gitnexus\.env\])|$)/,
+  );
+  if (!sectionMatch) return null;
+  const body = sectionMatch[1];
+  const commandMatch = body.match(/^\s*command\s*=\s*("(?:[^"\\]|\\.)*")\s*$/m);
+  if (!commandMatch) return null;
+  const command = parseTomlString(commandMatch[1]);
+  if (command === null) return null;
+  const argsMatch = body.match(/^\s*args\s*=\s*(\[[^\n]*\])\s*$/m);
+  let args: unknown = [];
+  if (argsMatch) {
+    try {
+      args = JSON.parse(argsMatch[1]);
+    } catch {
+      return null;
+    }
+  }
+  return entryFingerprint({ command, args });
+};
+
+const hookCommandPresent = (hooks: unknown, eventName: string): boolean => {
+  if (!hooks || typeof hooks !== 'object') return false;
+  const entries = (hooks as Record<string, unknown>)[eventName];
+  if (!Array.isArray(entries)) return false;
+  return entries.some(
+    (entry) =>
+      entry &&
+      typeof entry === 'object' &&
+      Array.isArray((entry as { hooks?: unknown }).hooks) &&
+      ((entry as { hooks: unknown[] }).hooks as unknown[]).some(
+        (hook) =>
+          hook &&
+          typeof hook === 'object' &&
+          typeof (hook as { command?: unknown }).command === 'string' &&
+          (hook as { command: string }).command.includes('gitnexus-hook'),
+      ),
+  );
+};
+
+const claudeHookStatus = async (home: string): Promise<{
+  status: HookStatus;
+  obsoleteSessionStart: boolean;
+}> => {
+  const target = hookTarget('claude', home);
+  const settingsRaw = await readOptional(target.settingsFile);
+  if (settingsRaw === null) return { status: 'missing', obsoleteSessionStart: false };
+  const errors: ParseError[] = [];
+  const settings = parseJsonc(settingsRaw, errors);
+  if (errors.length > 0 || !settings || typeof settings !== 'object') {
+    return { status: 'missing', obsoleteSessionStart: false };
+  }
+  const hooks = (settings as { hooks?: unknown }).hooks;
+  const obsoleteSessionStart = hookCommandPresent(hooks, 'SessionStart');
+  if (!hookCommandPresent(hooks, 'PreToolUse') || !hookCommandPresent(hooks, 'PostToolUse')) {
+    return { status: 'missing', obsoleteSessionStart };
+  }
+
+  const sourceDir = path.join(__dirname, '..', '..', 'hooks', 'claude');
+  const cliPath = path.resolve(path.join(__dirname, '..', 'cli', 'index.js'));
+  for (const fileName of [CLAUDE_HOOK_ADAPTER, ...CLAUDE_HOOK_HELPERS]) {
+    const source = await readOptional(path.join(sourceDir, fileName));
+    const installed = await readOptional(path.join(target.scriptDir, fileName));
+    if (source === null || installed === null) return { status: 'missing', obsoleteSessionStart };
+    const expected =
+      fileName === CLAUDE_HOOK_ADAPTER ? patchClaudeHookCliPath(source, cliPath).content : source;
+    if (digest(expected) !== digest(installed)) {
+      return { status: 'stale', obsoleteSessionStart };
+    }
+  }
+  return { status: 'current', obsoleteSessionStart };
+};
+
+export async function buildIntegrationDoctorReport(
+  home: string = os.homedir(),
+): Promise<IntegrationDoctorReport> {
+  const targets = getEditorTargets(home);
+  const claudeRaw = await readOptional(mcpTarget('claude', home).file);
+  const codexRaw = await readOptional(targets.codex.configFile);
+  let status: McpStatus = 'missing';
+  let claudeEntries: unknown[] = [];
+  let codexFingerprint: string | null = null;
+  let invalid = false;
+
+  if (claudeRaw !== null) {
+    const errors: ParseError[] = [];
+    const parsed = parseJsonc(claudeRaw, errors);
+    invalid ||= errors.length > 0 || !parsed;
+    if (!invalid) claudeEntries = collectClaudeMcpEntries(parsed);
+  }
+  if (codexRaw !== null) codexFingerprint = codexMcpFingerprint(codexRaw);
+
+  const claudeFingerprints = claudeEntries.map(entryFingerprint);
+  invalid ||=
+    (claudeEntries.length > 0 && claudeFingerprints.some((fingerprint) => fingerprint === null)) ||
+    (codexRaw !== null && codexFingerprint === null);
+  if (invalid) {
+    status = 'invalid';
+  } else if (codexFingerprint && claudeFingerprints.length > 0) {
+    status = claudeFingerprints.every((fingerprint) => fingerprint === codexFingerprint)
+      ? 'consistent'
+      : 'mismatch';
+  }
+
+  const hook = await claudeHookStatus(home);
+  return {
+    selectedCli: { version: pkg.version },
+    mcp: {
+      status,
+      codexConfigured: codexFingerprint !== null,
+      claudeConfiguredEntries: claudeEntries.length,
+    },
+    hooks: { claude: hook.status, obsoleteSessionStart: hook.obsoleteSessionStart },
+  };
+}

--- a/gitnexus/src/cli/integration-doctor.ts
+++ b/gitnexus/src/cli/integration-doctor.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { parse as parseJsonc, type ParseError } from 'jsonc-parser';
 import { getEditorTargets, hookTarget, mcpTarget } from './editor-targets.js';
 import {
+  BEST_EFFORT_CLAUDE_HOOK_HELPERS,
   CLAUDE_HOOK_ADAPTER,
   CLAUDE_HOOK_HELPERS,
   formatHookCommand,
@@ -119,7 +120,11 @@ const gitnexusHookCommands = (hooks: unknown, eventName: string): string[] => {
     for (const hook of nested) {
       if (!hook || typeof hook !== 'object') continue;
       const command = (hook as { command?: unknown }).command;
-      if (typeof command === 'string' && command.includes('gitnexus-hook')) {
+      if (
+        typeof command === 'string' &&
+        (command.includes('gitnexus-hook') ||
+          (eventName === 'SessionStart' && command.includes('gitnexus session-context')))
+      ) {
         commands.push(command);
       }
     }
@@ -160,7 +165,11 @@ const claudeHookStatus = async (
 
   const sourceDir = path.join(__dirname, '..', '..', 'hooks', 'claude');
   const cliPath = path.resolve(path.join(__dirname, '..', 'cli', 'index.js'));
-  for (const fileName of [CLAUDE_HOOK_ADAPTER, ...CLAUDE_HOOK_HELPERS]) {
+  const freshnessFiles = [
+    CLAUDE_HOOK_ADAPTER,
+    ...CLAUDE_HOOK_HELPERS.filter((fileName) => !BEST_EFFORT_CLAUDE_HOOK_HELPERS.has(fileName)),
+  ];
+  for (const fileName of freshnessFiles) {
     const source = await readOptional(path.join(sourceDir, fileName));
     const installed = await readOptional(path.join(target.scriptDir, fileName));
     if (source === null || installed === null) return { status: 'missing', obsoleteSessionStart };
@@ -184,7 +193,7 @@ export async function buildIntegrationDoctorReport(
   let codexFingerprint: string | null = null;
   let invalid = false;
 
-  if (claudeRaw !== null) {
+  if (claudeRaw !== null && claudeRaw.trim().length > 0) {
     const errors: ParseError[] = [];
     const parsed = parseJsonc(claudeRaw, errors);
     invalid ||= errors.length > 0 || !parsed;

--- a/gitnexus/src/cli/integration-doctor.ts
+++ b/gitnexus/src/cli/integration-doctor.ts
@@ -49,11 +49,18 @@ const readOptional = async (filePath: string): Promise<string | null> => {
 
 const entryFingerprint = (entry: unknown): string | null => {
   if (!entry || typeof entry !== 'object') return null;
-  const record = entry as { command?: unknown; args?: unknown };
+  const record = entry as { command?: unknown; args?: unknown; env?: unknown };
   if (typeof record.command !== 'string') return null;
   const args = Array.isArray(record.args) ? record.args : [];
   if (!args.every((arg) => typeof arg === 'string')) return null;
-  return JSON.stringify({ command: record.command, args });
+  const envValue = record.env ?? {};
+  if (!envValue || typeof envValue !== 'object' || Array.isArray(envValue)) return null;
+  const envEntries = Object.entries(envValue as Record<string, unknown>);
+  if (envEntries.some(([, value]) => typeof value !== 'string')) return null;
+  const env = Object.fromEntries(
+    envEntries.sort(([left], [right]) => left.localeCompare(right)) as Array<[string, string]>,
+  );
+  return JSON.stringify({ command: record.command, args, env });
 };
 
 const collectClaudeMcpEntries = (root: unknown): unknown[] => {
@@ -102,7 +109,26 @@ const codexMcpFingerprint = (raw: string): string | null => {
       return null;
     }
   }
-  return entryFingerprint({ command, args });
+  const env: Record<string, string> = {};
+  const envMatch = raw.match(
+    /(?:^|\n)\[mcp_servers\.gitnexus\.env\]\s*\n([\s\S]*?)(?=\n\[|$)/,
+  );
+  if (envMatch) {
+    for (const line of envMatch[1].split('\n')) {
+      if (/^\s*(?:#.*)?$/.test(line)) continue;
+      const assignment = line.match(
+        /^\s*([A-Za-z_][A-Za-z0-9_]*|"(?:[^"\\]|\\.)*")\s*=\s*("(?:[^"\\]|\\.)*")\s*(?:#.*)?$/,
+      );
+      if (!assignment) return null;
+      const key = assignment[1].startsWith('"')
+        ? parseTomlString(assignment[1])
+        : assignment[1];
+      const value = parseTomlString(assignment[2]);
+      if (key === null || value === null) return null;
+      env[key] = value;
+    }
+  }
+  return entryFingerprint({ command, args, env });
 };
 
 const hasCodexGitnexusSection = (raw: string): boolean =>

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -28,8 +28,10 @@ import {
   BEST_EFFORT_CLAUDE_HOOK_HELPERS,
   CLAUDE_HOOK_ADAPTER,
   CLAUDE_HOOK_HELPERS,
+  formatHookCommand,
   patchClaudeHookCliPath,
 } from './claude-hook-bundle.js';
+export { formatHookCommand } from './claude-hook-bundle.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -68,17 +70,6 @@ const MCP_PINNED_REF = `gitnexus@${_pkg.version}`;
  * is forward-slashed, so keep the double-quoted form with backslash-then-quote
  * escaping (CodeQL js/incomplete-sanitization safe ordering).
  */
-export function formatHookCommand(
-  hookPath: string,
-  isWindows = process.platform === 'win32',
-): string {
-  if (isWindows) {
-    const escaped = hookPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    return `node "${escaped}"`;
-  }
-  return `node '${hookPath.replace(/'/g, "'\\''")}'`;
-}
-
 // The exact source line each hook adapter ships, rewritten at install time to
 // point cliPath at the installed CLI. Kept as a named constant so the install
 // patch and its drift guard reference one string — if the adapter source ever
@@ -447,6 +438,59 @@ async function mergeHooksJsonc(
   return true;
 }
 
+/** Replace only existing GitNexus hook commands, preserving matchers and unrelated hooks. */
+async function refreshGitnexusHookCommands(
+  filePath: string,
+  command: string,
+  commandFragment = 'gitnexus-hook',
+): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch (error) {
+    if (isEnoent(error)) return true;
+    throw error;
+  }
+  if (raw.trim().length === 0) return true;
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(raw, errors);
+  if (errors.length > 0 || !parsed || typeof parsed !== 'object') return false;
+
+  const formattingOptions = detectIndentation(raw);
+  let current = raw;
+  for (const eventName of ['PreToolUse', 'PostToolUse']) {
+    const entries = parsed.hooks?.[eventName];
+    if (!Array.isArray(entries)) continue;
+    for (let entryIndex = entries.length - 1; entryIndex >= 0; entryIndex--) {
+      const hooks = entries[entryIndex]?.hooks;
+      if (!Array.isArray(hooks)) continue;
+      for (let hookIndex = hooks.length - 1; hookIndex >= 0; hookIndex--) {
+        const existing = hooks[hookIndex]?.command;
+        if (
+          typeof existing !== 'string' ||
+          !existing.includes(commandFragment) ||
+          existing === command
+        ) {
+          continue;
+        }
+        current = applyEdits(
+          current,
+          modify(
+            current,
+            ['hooks', eventName, entryIndex, 'hooks', hookIndex, 'command'],
+            command,
+            {
+              formattingOptions,
+            },
+          ),
+        );
+      }
+    }
+  }
+  if (current !== raw) await fs.writeFile(filePath, current, 'utf-8');
+  return true;
+}
+
 /** Remove only GitNexus commands from the obsolete Claude SessionStart event. */
 export async function removeObsoleteGitnexusSessionStart(
   settingsPath: string,
@@ -459,6 +503,8 @@ export async function removeObsoleteGitnexusSessionStart(
     if (isEnoent(error)) return true;
     throw error;
   }
+
+  if (raw.trim().length === 0) return true;
 
   const errors: ParseError[] = [];
   const parsed = parseJsonc(raw, errors);
@@ -612,6 +658,13 @@ async function installClaudeSchemaHooks(
 
     const hookPath = path.join(destHooksDir, 'gitnexus-hook.cjs').replace(/\\/g, '/');
     const hookCmd = formatHookCommand(hookPath);
+
+    if (!(await refreshGitnexusHookCommands(settingsPath, hookCmd, hookCfg.needle))) {
+      result.errors.push(
+        `${label}: ${path.basename(settingsPath)} is corrupt — existing hook commands were not changed`,
+      );
+      return;
+    }
 
     // Check which hook events need entries (idempotent: skip if already registered)
     const parsed = await (async () => {
@@ -1251,6 +1304,9 @@ export const setupCommand = async (options?: {
 
   if (options?.hooksOnly) {
     await installClaudeSchemaHooks(result, 'claude');
+    if (result.configured.length === 0 && result.errors.length === 0) {
+      result.errors.push('Claude Code hooks: Claude config directory is missing');
+    }
     if (result.configured.length > 0) {
       console.log('  Configured:');
       for (const name of result.configured) console.log(`    + ${name}`);

--- a/gitnexus/src/cli/setup.ts
+++ b/gitnexus/src/cli/setup.ts
@@ -24,6 +24,12 @@ import {
   isEnoent,
   type EditorId,
 } from './editor-targets.js';
+import {
+  BEST_EFFORT_CLAUDE_HOOK_HELPERS,
+  CLAUDE_HOOK_ADAPTER,
+  CLAUDE_HOOK_HELPERS,
+  patchClaudeHookCliPath,
+} from './claude-hook-bundle.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -78,9 +84,6 @@ export function formatHookCommand(
 // patch and its drift guard reference one string — if the adapter source ever
 // changes this literal, the guard records an actionable error instead of
 // silently shipping a hook with an unresolved relative cliPath.
-const CLI_PATH_SOURCE_LITERAL =
-  "let cliPath = path.resolve(__dirname, '..', '..', 'dist', 'cli', 'index.js');";
-
 interface SetupResult {
   configured: string[];
   skipped: string[];
@@ -444,20 +447,67 @@ async function mergeHooksJsonc(
   return true;
 }
 
-const HOOK_HELPERS = [
-  'hook-lock.cjs',
-  'hook-db-lock-probe.cjs',
-  'win-rm-list-json.ps1',
-  'resolve-analyze-cmd.cjs',
-] as const;
+/** Remove only GitNexus commands from the obsolete Claude SessionStart event. */
+export async function removeObsoleteGitnexusSessionStart(
+  settingsPath: string,
+  commandFragment = 'gitnexus-hook',
+): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(settingsPath, 'utf-8');
+  } catch (error) {
+    if (isEnoent(error)) return true;
+    throw error;
+  }
+
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(raw, errors);
+  if (errors.length > 0 || !parsed || typeof parsed !== 'object') return false;
+  const sessionEntries = parsed.hooks?.SessionStart;
+  if (!Array.isArray(sessionEntries)) return true;
+
+  const formattingOptions = detectIndentation(raw);
+  let current = raw;
+  for (let index = sessionEntries.length - 1; index >= 0; index--) {
+    const entry = sessionEntries[index];
+    if (!entry || !Array.isArray(entry.hooks)) continue;
+    const remaining = entry.hooks.filter(
+      (hook: unknown) =>
+        !(
+          hook &&
+          typeof hook === 'object' &&
+          typeof (hook as { command?: unknown }).command === 'string' &&
+          ((hook as { command: string }).command.includes(commandFragment) ||
+            (hook as { command: string }).command.includes('gitnexus session-context'))
+        ),
+    );
+    if (remaining.length === entry.hooks.length) continue;
+    const editPath =
+      remaining.length === 0
+        ? ['hooks', 'SessionStart', index]
+        : ['hooks', 'SessionStart', index, 'hooks'];
+    const edits = modify(current, editPath, remaining.length === 0 ? undefined : remaining, {
+      formattingOptions,
+    });
+    current = applyEdits(current, edits);
+  }
+
+  const after = parseJsonc(current);
+  if (Array.isArray(after?.hooks?.SessionStart) && after.hooks.SessionStart.length === 0) {
+    current = applyEdits(
+      current,
+      modify(current, ['hooks', 'SessionStart'], undefined, { formattingOptions }),
+    );
+  }
+  if (current !== raw) await fs.writeFile(settingsPath, current, 'utf-8');
+  return true;
+}
 
 // win-rm-list-json.ps1 is best-effort: it is read (not require()'d) by
 // hook-db-lock-probe.cjs only on Windows, and that probe fails open when the
 // script is absent. Every other helper is top-level require()'d by the adapters,
 // so its absence crashes the installed hook — those are the ones a failed copy
 // must gate hook registration on (see copyHookHelpers' return value).
-const BEST_EFFORT_HOOK_HELPERS = new Set<string>(['win-rm-list-json.ps1']);
-
 /**
  * Copy the shared hook helpers from `srcDir` into `destDir`. The adapters
  * top-level `require()` the `.cjs` helpers, so a missing required helper makes
@@ -475,12 +525,12 @@ export async function copyHookHelpers(
   result: SetupResult,
 ): Promise<string[]> {
   const failedRequired: string[] = [];
-  for (const helper of HOOK_HELPERS) {
+  for (const helper of CLAUDE_HOOK_HELPERS) {
     try {
       await fs.copyFile(path.join(srcDir, helper), path.join(destDir, helper));
     } catch {
       result.errors.push(`${label}: failed to copy ${helper} — hook may crash at runtime`);
-      if (!BEST_EFFORT_HOOK_HELPERS.has(helper)) failedRequired.push(helper);
+      if (!BEST_EFFORT_CLAUDE_HOOK_HELPERS.has(helper)) failedRequired.push(helper);
     }
   }
   return failedRequired;
@@ -516,20 +566,18 @@ async function installClaudeSchemaHooks(
   try {
     await fs.mkdir(destHooksDir, { recursive: true });
 
-    const src = path.join(pluginHooksPath, 'gitnexus-hook.cjs');
-    const dest = path.join(destHooksDir, 'gitnexus-hook.cjs');
+    const src = path.join(pluginHooksPath, CLAUDE_HOOK_ADAPTER);
+    const dest = path.join(destHooksDir, CLAUDE_HOOK_ADAPTER);
     try {
-      let content = await fs.readFile(src, 'utf-8');
+      const content = await fs.readFile(src, 'utf-8');
       const resolvedCli = path.join(__dirname, '..', 'cli', 'index.js');
-      const normalizedCli = path.resolve(resolvedCli).replace(/\\/g, '/');
-      const jsonCli = JSON.stringify(normalizedCli);
-      if (!content.includes(CLI_PATH_SOURCE_LITERAL)) {
+      const patched = patchClaudeHookCliPath(content, path.resolve(resolvedCli));
+      if (!patched.sourceLiteralFound) {
         result.errors.push(
-          `${label}: gitnexus-hook.cjs no longer contains the cliPath literal to patch — the installed hook may fail to resolve the CLI. Update CLI_PATH_SOURCE_LITERAL in setup.ts.`,
+          `${label}: gitnexus-hook.cjs no longer contains the cliPath literal to patch — the installed hook may fail to resolve the CLI. Update CLAUDE_HOOK_CLI_PATH_LITERAL.`,
         );
       }
-      content = content.replace(CLI_PATH_SOURCE_LITERAL, `let cliPath = ${jsonCli};`);
-      await fs.writeFile(dest, content, 'utf-8');
+      await fs.writeFile(dest, patched.content, 'utf-8');
     } catch {
       // Script not found in source — skip
     }
@@ -550,6 +598,16 @@ async function installClaudeSchemaHooks(
         `${label}: required helper(s) ${failedRequired.join(', ')} failed to copy — skipping hook registration`,
       );
       return;
+    }
+
+    if (id === 'claude') {
+      const removed = await removeObsoleteGitnexusSessionStart(settingsPath, hookCfg.needle);
+      if (!removed) {
+        result.errors.push(
+          `${label}: ${path.basename(settingsPath)} is corrupt — obsolete SessionStart entry was not changed`,
+        );
+        return;
+      }
     }
 
     const hookPath = path.join(destHooksDir, 'gitnexus-hook.cjs').replace(/\\/g, '/');
@@ -713,17 +771,15 @@ async function installAntigravityHooks(result: SetupResult): Promise<void> {
     const adapterSrc = path.join(pluginAntigravityDir, 'gitnexus-antigravity-hook.cjs');
     const adapterDest = path.join(destHooksDir, 'gitnexus-antigravity-hook.cjs');
     try {
-      let content = await fs.readFile(adapterSrc, 'utf-8');
+      const content = await fs.readFile(adapterSrc, 'utf-8');
       const resolvedCli = path.join(__dirname, '..', 'cli', 'index.js');
-      const normalizedCli = path.resolve(resolvedCli).replace(/\\/g, '/');
-      const jsonCli = JSON.stringify(normalizedCli);
-      if (!content.includes(CLI_PATH_SOURCE_LITERAL)) {
+      const patched = patchClaudeHookCliPath(content, path.resolve(resolvedCli));
+      if (!patched.sourceLiteralFound) {
         result.errors.push(
-          'Antigravity hooks: gitnexus-antigravity-hook.cjs no longer contains the cliPath literal to patch — the installed hook may fail to resolve the CLI. Update CLI_PATH_SOURCE_LITERAL in setup.ts.',
+          'Antigravity hooks: gitnexus-antigravity-hook.cjs no longer contains the cliPath literal to patch — the installed hook may fail to resolve the CLI. Update CLAUDE_HOOK_CLI_PATH_LITERAL.',
         );
       }
-      content = content.replace(CLI_PATH_SOURCE_LITERAL, `let cliPath = ${jsonCli};`);
-      await fs.writeFile(adapterDest, content, 'utf-8');
+      await fs.writeFile(adapterDest, patched.content, 'utf-8');
     } catch {
       // Adapter not found in source — skip
     }
@@ -1169,25 +1225,49 @@ async function installCodexSkills(result: SetupResult): Promise<void> {
 
 // ─── Main command ──────────────────────────────────────────────────
 
-export const setupCommand = async (options?: { codingAgent?: string[] | string }) => {
+export const setupCommand = async (options?: {
+  codingAgent?: string[] | string;
+  hooksOnly?: boolean;
+}) => {
   const explicitSelection = options?.codingAgent != null;
   const selected = selectedCodingAgents(options?.codingAgent);
   if (!selected) return;
+  if (options?.hooksOnly && (selected.size !== 1 || !selected.has('claude'))) {
+    process.stderr.write('`--hooks-only` requires exactly `--coding-agent claude`.\n');
+    process.exitCode = 1;
+    return;
+  }
 
   console.log('');
   console.log('  GitNexus Setup');
   console.log('  ==============');
   console.log('');
 
-  // Ensure global directory exists
-  const globalDir = getGlobalDir();
-  await fs.mkdir(globalDir, { recursive: true });
-
   const result: SetupResult = {
     configured: [],
     skipped: [],
     errors: [],
   };
+
+  if (options?.hooksOnly) {
+    await installClaudeSchemaHooks(result, 'claude');
+    if (result.configured.length > 0) {
+      console.log('  Configured:');
+      for (const name of result.configured) console.log(`    + ${name}`);
+    }
+    if (result.errors.length > 0) {
+      console.log('  Errors:');
+      for (const error of result.errors) console.log(`    ! ${error}`);
+      process.exitCode = 1;
+    }
+    console.log('');
+    return;
+  }
+
+  // Full setup owns the global registry/config directory. Hooks-only mode
+  // returns above and therefore cannot create or touch it.
+  const globalDir = getGlobalDir();
+  await fs.mkdir(globalDir, { recursive: true });
 
   // Detect and configure each editor's MCP
   if (selected.has('cursor')) await setupCursor(result);

--- a/gitnexus/test/unit/cursor-hook.test.ts
+++ b/gitnexus/test/unit/cursor-hook.test.ts
@@ -433,9 +433,12 @@ describe('Cursor hook concurrency guard', () => {
 
   it('uses atomic fixed-name slot files (hard cap, not soft TOCTOU cap)', () => {
     expect(lockSource).toMatch(/slot-\$\{slot\}\.lock|`slot-/);
+    const slotFunctionName = lockSource.includes('function acquireSlotInDir')
+      ? 'function acquireSlotInDir'
+      : 'function acquireHookSlot';
     const slotFn = lockSource.slice(
-      lockSource.indexOf('function acquireHookSlot'),
-      lockSource.indexOf('function', lockSource.indexOf('function acquireHookSlot') + 1),
+      lockSource.indexOf(slotFunctionName),
+      lockSource.indexOf('function', lockSource.indexOf(slotFunctionName) + 1),
     );
     expect(slotFn).not.toContain('readdirSync');
   });
@@ -444,9 +447,12 @@ describe('Cursor hook concurrency guard', () => {
     // Regression: see hooks.test.ts. The mkdirSync catch must return null
     // (skip augment) rather than `() => {}` (proceed unguarded), so that
     // a read-only or cross-user `.gitnexus/` cannot reintroduce #1486.
+    const slotFunctionName = lockSource.includes('function acquireSlotInDir')
+      ? 'function acquireSlotInDir'
+      : 'function acquireHookSlot';
     const slotFn = lockSource.slice(
-      lockSource.indexOf('function acquireHookSlot'),
-      lockSource.indexOf('function', lockSource.indexOf('function acquireHookSlot') + 1),
+      lockSource.indexOf(slotFunctionName),
+      lockSource.indexOf('function', lockSource.indexOf(slotFunctionName) + 1),
     );
     const mkdirCatch = slotFn.slice(
       slotFn.indexOf('fs.mkdirSync(lockDir'),

--- a/gitnexus/test/unit/hook-global-lock.test.ts
+++ b/gitnexus/test/unit/hook-global-lock.test.ts
@@ -5,6 +5,15 @@ import { spawn } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const helperPath = path.resolve(__dirname, '..', '..', 'hooks', 'claude', 'hook-lock.cjs');
+const pluginHelperPath = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'gitnexus-claude-plugin',
+  'hooks',
+  'hook-lock.js',
+);
 
 describe('Claude hook machine-global concurrency cap', () => {
   const roots: string[] = [];
@@ -90,4 +99,42 @@ describe('Claude hook machine-global concurrency cap', () => {
       expect(orphaned).toEqual([]);
     }
   }, 30_000);
+
+  it('applies the same eight-slot global cap to the standalone Claude plugin helper', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-plugin-hook-global-cap-'));
+    roots.push(root);
+    const globalDir = path.join(root, 'global-locks');
+    const script = `
+      const fs = require('fs');
+      const path = require('path');
+      const { acquireHookSlot } = require(${JSON.stringify(pluginHelperPath)});
+      const releases = [];
+      for (let index = 0; index < 9; index++) {
+        const repo = path.join(process.argv[1], 'repo-' + index, '.gitnexus');
+        fs.mkdirSync(repo, { recursive: true });
+        const release = acquireHookSlot(repo);
+        if (release) releases.push(release);
+      }
+      process.stdout.write(String(releases.length));
+      for (const release of releases) release();
+    `;
+    const outcome = await new Promise<string>((resolve, reject) => {
+      const child = spawn(process.execPath, ['-e', script, root], {
+        env: { ...process.env, GITNEXUS_HOOK_GLOBAL_LOCK_DIR: globalDir },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+      child.stderr.on('data', (chunk) => (stderr += String(chunk)));
+      child.on('error', reject);
+      child.on('exit', (code) => {
+        if (code !== 0) reject(new Error(stderr || `child exited ${code}`));
+        else resolve(stdout.trim());
+      });
+    });
+
+    expect(outcome).toBe('8');
+    expect(fs.readdirSync(globalDir).filter((entry) => entry.endsWith('.lock'))).toEqual([]);
+  });
 });

--- a/gitnexus/test/unit/hook-global-lock.test.ts
+++ b/gitnexus/test/unit/hook-global-lock.test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const helperPath = path.resolve(__dirname, '..', '..', 'hooks', 'claude', 'hook-lock.cjs');
+
+describe('Claude hook machine-global concurrency cap', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('admits no more than eight of 64 simultaneous calls across repositories', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-hook-global-cap-'));
+    roots.push(root);
+    const globalDir = path.join(root, 'global-locks');
+    const repos = Array.from({ length: 24 }, (_, index) => {
+      const gitnexusDir = path.join(root, `repo-${index}`, '.gitnexus');
+      fs.mkdirSync(gitnexusDir, { recursive: true });
+      return gitnexusDir;
+    });
+    const script = `
+      const { acquireHookSlot } = require(${JSON.stringify(helperPath)});
+      const release = acquireHookSlot(process.argv[1]);
+      if (!release) { process.stdout.write('denied\\n'); process.exit(0); }
+      process.stdout.write('acquired\\n');
+      // Keep the admitted wave alive long enough for all 64 processes to
+      // contend at once, while remaining below Claude's 10-second hook timeout.
+      setTimeout(() => { release(); process.exit(0); }, 6000);
+    `;
+
+    const children: ChildProcessWithoutNullStreams[] = [];
+    for (let index = 0; index < 64; index++) {
+      children.push(
+        spawn(process.execPath, ['-e', script, repos[index % repos.length]], {
+          env: { ...process.env, GITNEXUS_HOOK_GLOBAL_LOCK_DIR: globalDir },
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }),
+      );
+    }
+
+    const outcomes = await Promise.all(
+      children.map(
+        (child) =>
+          new Promise<string>((resolve, reject) => {
+            let stdout = '';
+            let stderr = '';
+            child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+            child.stderr.on('data', (chunk) => (stderr += String(chunk)));
+            child.on('error', reject);
+            child.on('exit', (code) => {
+              if (code !== 0) reject(new Error(stderr || `child exited ${code}`));
+              else resolve(stdout.trim());
+            });
+          }),
+      ),
+    );
+
+    const acquired = outcomes.filter((outcome) => outcome === 'acquired').length;
+    expect(acquired).toBeGreaterThan(0);
+    expect(acquired).toBeLessThanOrEqual(8);
+    expect(outcomes.filter((outcome) => outcome === 'denied')).toHaveLength(64 - acquired);
+    const remainingLocks = fs.existsSync(globalDir)
+      ? fs.readdirSync(globalDir).filter((entry) => entry.endsWith('.lock'))
+      : [];
+    expect(remainingLocks).toEqual([]);
+    for (const repo of repos) {
+      const perRepo = path.join(repo, '.hook-locks');
+      const orphaned = fs.existsSync(perRepo)
+        ? fs.readdirSync(perRepo).filter((entry) => entry.endsWith('.lock'))
+        : [];
+      expect(orphaned).toEqual([]);
+    }
+  }, 20_000);
+});

--- a/gitnexus/test/unit/hook-global-lock.test.ts
+++ b/gitnexus/test/unit/hook-global-lock.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const helperPath = path.resolve(__dirname, '..', '..', 'hooks', 'claude', 'hook-lock.cjs');
@@ -17,47 +17,62 @@ describe('Claude hook machine-global concurrency cap', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gitnexus-hook-global-cap-'));
     roots.push(root);
     const globalDir = path.join(root, 'global-locks');
+    const readyDir = path.join(root, 'ready');
+    const startGate = path.join(root, 'start');
+    fs.mkdirSync(readyDir);
     const repos = Array.from({ length: 24 }, (_, index) => {
       const gitnexusDir = path.join(root, `repo-${index}`, '.gitnexus');
       fs.mkdirSync(gitnexusDir, { recursive: true });
       return gitnexusDir;
     });
     const script = `
+      const fs = require('fs');
+      const path = require('path');
       const { acquireHookSlot } = require(${JSON.stringify(helperPath)});
-      const release = acquireHookSlot(process.argv[1]);
-      if (!release) { process.stdout.write('denied\\n'); process.exit(0); }
-      process.stdout.write('acquired\\n');
-      // Keep the admitted wave alive long enough for all 64 processes to
-      // contend at once, while remaining below Claude's 10-second hook timeout.
-      setTimeout(() => { release(); process.exit(0); }, 6000);
+      fs.writeFileSync(path.join(process.argv[2], String(process.pid)), 'ready');
+      const waitForGate = () => {
+        if (!fs.existsSync(process.argv[3])) { setTimeout(waitForGate, 10); return; }
+        const release = acquireHookSlot(process.argv[1]);
+        if (!release) { process.stdout.write('denied\\n'); process.exit(0); }
+        process.stdout.write('acquired\\n');
+        setTimeout(() => { release(); process.exit(0); }, 2000);
+      };
+      waitForGate();
     `;
 
-    const children: ChildProcessWithoutNullStreams[] = [];
+    const outcomePromises: Array<Promise<string>> = [];
     for (let index = 0; index < 64; index++) {
-      children.push(
-        spawn(process.execPath, ['-e', script, repos[index % repos.length]], {
+      const child = spawn(
+        process.execPath,
+        ['-e', script, repos[index % repos.length], readyDir, startGate],
+        {
           env: { ...process.env, GITNEXUS_HOOK_GLOBAL_LOCK_DIR: globalDir },
           stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
+      outcomePromises.push(
+        new Promise<string>((resolve, reject) => {
+          let stdout = '';
+          let stderr = '';
+          child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+          child.stderr.on('data', (chunk) => (stderr += String(chunk)));
+          child.on('error', reject);
+          child.on('exit', (code) => {
+            if (code !== 0) reject(new Error(stderr || `child exited ${code}`));
+            else resolve(stdout.trim());
+          });
         }),
       );
     }
 
-    const outcomes = await Promise.all(
-      children.map(
-        (child) =>
-          new Promise<string>((resolve, reject) => {
-            let stdout = '';
-            let stderr = '';
-            child.stdout.on('data', (chunk) => (stdout += String(chunk)));
-            child.stderr.on('data', (chunk) => (stderr += String(chunk)));
-            child.on('error', reject);
-            child.on('exit', (code) => {
-              if (code !== 0) reject(new Error(stderr || `child exited ${code}`));
-              else resolve(stdout.trim());
-            });
-          }),
-      ),
-    );
+    const readyDeadline = Date.now() + 15_000;
+    while (fs.readdirSync(readyDir).length < 64 && Date.now() < readyDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(fs.readdirSync(readyDir)).toHaveLength(64);
+    fs.writeFileSync(startGate, 'go');
+
+    const outcomes = await Promise.all(outcomePromises);
 
     const acquired = outcomes.filter((outcome) => outcome === 'acquired').length;
     expect(acquired).toBeGreaterThan(0);
@@ -74,5 +89,5 @@ describe('Claude hook machine-global concurrency cap', () => {
         : [];
       expect(orphaned).toEqual([]);
     }
-  }, 20_000);
+  }, 30_000);
 });

--- a/gitnexus/test/unit/hooks.test.ts
+++ b/gitnexus/test/unit/hooks.test.ts
@@ -652,9 +652,12 @@ describe('PreToolUse concurrency guard', () => {
       const source = fs.readFileSync(lockPath, 'utf-8');
       expect(source).toMatch(/slot-\$\{slot\}\.lock|`slot-/);
       // And no longer reads the lock dir to count active hooks.
+      const slotFunctionName = source.includes('function acquireSlotInDir')
+        ? 'function acquireSlotInDir'
+        : 'function acquireHookSlot';
       const slotFn = source.slice(
-        source.indexOf('function acquireHookSlot'),
-        source.indexOf('function', source.indexOf('function acquireHookSlot') + 1),
+        source.indexOf(slotFunctionName),
+        source.indexOf('function', source.indexOf(slotFunctionName) + 1),
       );
       expect(slotFn).not.toContain('readdirSync');
     });
@@ -665,9 +668,12 @@ describe('PreToolUse concurrency guard', () => {
       // proceed unguarded and reintroduce the #1486 fan-out on read-only or
       // cross-user `.gitnexus/` setups. The guard must fail closed (null).
       const source = fs.readFileSync(lockPath, 'utf-8');
+      const slotFunctionName = source.includes('function acquireSlotInDir')
+        ? 'function acquireSlotInDir'
+        : 'function acquireHookSlot';
       const slotFn = source.slice(
-        source.indexOf('function acquireHookSlot'),
-        source.indexOf('function', source.indexOf('function acquireHookSlot') + 1),
+        source.indexOf(slotFunctionName),
+        source.indexOf('function', source.indexOf(slotFunctionName) + 1),
       );
       const mkdirCatch = slotFn.slice(
         slotFn.indexOf('fs.mkdirSync(lockDir'),

--- a/gitnexus/test/unit/integration-doctor.test.ts
+++ b/gitnexus/test/unit/integration-doctor.test.ts
@@ -162,4 +162,17 @@ describe('doctor --integrations', () => {
     expect(report.mcp.status).toBe('mismatch');
     expect(JSON.stringify(report)).not.toContain('/other-runtime');
   });
+
+  it('detects environment-only MCP mismatches without exposing their values', async () => {
+    await writeMatchingMcp();
+    const claudePath = path.join(home, '.claude.json');
+    const config = JSON.parse(await fs.readFile(claudePath, 'utf8'));
+    config.projects['/repo'].mcpServers.gitnexus.env.SECRET = 'different-secret';
+    await fs.writeFile(claudePath, JSON.stringify(config));
+    const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
+    const report = await buildIntegrationDoctorReport(home);
+    expect(report.mcp.status).toBe('mismatch');
+    expect(JSON.stringify(report)).not.toContain('different-secret');
+    expect(JSON.stringify(report)).not.toContain('hidden');
+  });
 });

--- a/gitnexus/test/unit/integration-doctor.test.ts
+++ b/gitnexus/test/unit/integration-doctor.test.ts
@@ -87,6 +87,30 @@ describe('doctor --integrations', () => {
     });
   });
 
+  it('reports stale when settings still invoke an old hook path', async () => {
+    await writeMatchingMcp();
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand({ codingAgent: ['claude'], hooksOnly: true });
+    const settingsPath = path.join(home, '.claude', 'settings.json');
+    const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+    settings.hooks.PreToolUse[0].hooks[0].command = 'node /old/gitnexus-hook.cjs';
+    await fs.writeFile(settingsPath, JSON.stringify(settings));
+    const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
+
+    await expect(buildIntegrationDoctorReport(home)).resolves.toMatchObject({
+      hooks: { claude: 'stale' },
+    });
+  });
+
+  it('treats an unrelated Codex config as a missing MCP integration', async () => {
+    await fs.writeFile(path.join(home, '.codex', 'config.toml'), 'model = "gpt-5"\n');
+    const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
+
+    await expect(buildIntegrationDoctorReport(home)).resolves.toMatchObject({
+      mcp: { status: 'missing', codexConfigured: false },
+    });
+  });
+
   it('reports a sanitized MCP mismatch without returning config values', async () => {
     await writeMatchingMcp();
     const claudePath = path.join(home, '.claude.json');

--- a/gitnexus/test/unit/integration-doctor.test.ts
+++ b/gitnexus/test/unit/integration-doctor.test.ts
@@ -102,12 +102,52 @@ describe('doctor --integrations', () => {
     });
   });
 
+  it('detects the legacy session-context hook while current tool hooks are installed', async () => {
+    await writeMatchingMcp();
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand({ codingAgent: ['claude'], hooksOnly: true });
+    const settingsPath = path.join(home, '.claude', 'settings.json');
+    const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+    settings.hooks.SessionStart = [
+      { hooks: [{ type: 'command', command: 'gitnexus session-context' }] },
+    ];
+    await fs.writeFile(settingsPath, JSON.stringify(settings));
+    const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
+
+    await expect(buildIntegrationDoctorReport(home)).resolves.toMatchObject({
+      hooks: { claude: 'current', obsoleteSessionStart: true },
+    });
+  });
+
+  it('ignores a missing best-effort hook helper when judging freshness', async () => {
+    await writeMatchingMcp();
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand({ codingAgent: ['claude'], hooksOnly: true });
+    await fs.rm(path.join(home, '.claude', 'hooks', 'gitnexus', 'win-rm-list-json.ps1'), {
+      force: true,
+    });
+    const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
+
+    await expect(buildIntegrationDoctorReport(home)).resolves.toMatchObject({
+      hooks: { claude: 'current' },
+    });
+  });
+
   it('treats an unrelated Codex config as a missing MCP integration', async () => {
     await fs.writeFile(path.join(home, '.codex', 'config.toml'), 'model = "gpt-5"\n');
     const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
 
     await expect(buildIntegrationDoctorReport(home)).resolves.toMatchObject({
       mcp: { status: 'missing', codexConfigured: false },
+    });
+  });
+
+  it('treats an empty Claude config as a missing MCP integration', async () => {
+    await fs.writeFile(path.join(home, '.claude.json'), '  \n');
+    const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
+
+    await expect(buildIntegrationDoctorReport(home)).resolves.toMatchObject({
+      mcp: { status: 'missing', claudeConfiguredEntries: 0 },
     });
   });
 

--- a/gitnexus/test/unit/integration-doctor.test.ts
+++ b/gitnexus/test/unit/integration-doctor.test.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn((...args: unknown[]) => {
+    const callback = args.at(-1);
+    if (typeof callback === 'function') callback(null, '', '');
+  }),
+  execFileSync: vi.fn(() => {
+    throw new Error('not found');
+  }),
+}));
+
+describe('doctor --integrations', () => {
+  let home: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'gitnexus-integration-doctor-'));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    await Promise.all([
+      fs.mkdir(path.join(home, '.claude'), { recursive: true }),
+      fs.mkdir(path.join(home, '.codex'), { recursive: true }),
+    ]);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalUserProfile;
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  async function writeMatchingMcp() {
+    const entry = { command: '/opt/gitnexus-wrapper', args: ['mcp'], env: { SECRET: 'hidden' } };
+    await fs.writeFile(
+      path.join(home, '.claude.json'),
+      JSON.stringify({
+        mcpServers: { gitnexus: entry },
+        projects: { '/repo': { mcpServers: { gitnexus: entry } } },
+      }),
+    );
+    await fs.writeFile(
+      path.join(home, '.codex', 'config.toml'),
+      '[mcp_servers.gitnexus]\ncommand = "/opt/gitnexus-wrapper"\nargs = ["mcp"]\n\n[mcp_servers.gitnexus.env]\nSECRET = "hidden"\n',
+    );
+  }
+
+  it('reports matching MCP entries and a freshly installed Claude hook bundle as current', async () => {
+    await writeMatchingMcp();
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand({ codingAgent: ['claude'], hooksOnly: true });
+    const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
+    const report = await buildIntegrationDoctorReport(home);
+
+    expect(report.mcp).toEqual({
+      status: 'consistent',
+      codexConfigured: true,
+      claudeConfiguredEntries: 2,
+    });
+    expect(report.hooks).toEqual({ claude: 'current', obsoleteSessionStart: false });
+    expect(JSON.stringify(report)).not.toContain('/opt/gitnexus-wrapper');
+    expect(JSON.stringify(report)).not.toContain('hidden');
+  });
+
+  it('distinguishes a stale hook from a missing hook', async () => {
+    await writeMatchingMcp();
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand({ codingAgent: ['claude'], hooksOnly: true });
+    const adapter = path.join(home, '.claude', 'hooks', 'gitnexus', 'gitnexus-hook.cjs');
+    await fs.appendFile(adapter, '\n// stale\n');
+    const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
+    await expect(buildIntegrationDoctorReport(home)).resolves.toMatchObject({
+      hooks: { claude: 'stale' },
+    });
+    await fs.rm(adapter);
+    await expect(buildIntegrationDoctorReport(home)).resolves.toMatchObject({
+      hooks: { claude: 'missing' },
+    });
+  });
+
+  it('reports a sanitized MCP mismatch without returning config values', async () => {
+    await writeMatchingMcp();
+    const claudePath = path.join(home, '.claude.json');
+    const config = JSON.parse(await fs.readFile(claudePath, 'utf8'));
+    config.projects['/repo'].mcpServers.gitnexus.command = '/other-runtime';
+    await fs.writeFile(claudePath, JSON.stringify(config));
+    const { buildIntegrationDoctorReport } = await import('../../src/cli/integration-doctor.js');
+    const report = await buildIntegrationDoctorReport(home);
+    expect(report.mcp.status).toBe('mismatch');
+    expect(JSON.stringify(report)).not.toContain('/other-runtime');
+  });
+});

--- a/gitnexus/test/unit/setup-selection.test.ts
+++ b/gitnexus/test/unit/setup-selection.test.ts
@@ -153,7 +153,8 @@ describe('setupCommand coding-agent selection', () => {
     const claudeJsonPath = path.join(tempHome, '.claude.json');
     const skillsPath = path.join(tempHome, '.claude', 'skills', 'keep', 'SKILL.md');
     const settingsPath = path.join(tempHome, '.claude', 'settings.json');
-    const claudeJson = '{"mcpServers":{"gitnexus":{"command":"curated-wrapper","env":{"KEEP":"1"}}}}\n';
+    const claudeJson =
+      '{"mcpServers":{"gitnexus":{"command":"curated-wrapper","env":{"KEEP":"1"}}}}\n';
     await fs.mkdir(path.dirname(skillsPath), { recursive: true });
     await fs.writeFile(claudeJsonPath, claudeJson);
     await fs.writeFile(skillsPath, 'keep me');
@@ -166,7 +167,15 @@ describe('setupCommand coding-agent selection', () => {
               { hooks: [{ type: 'command', command: 'node /old/gitnexus-hook.cjs' }] },
               { hooks: [{ type: 'command', command: 'echo keep-session' }] },
             ],
-            PreToolUse: [{ hooks: [{ type: 'command', command: 'echo keep-pre' }] }],
+            PreToolUse: [
+              {
+                hooks: [
+                  { type: 'command', command: 'echo keep-pre' },
+                  { type: 'command', command: 'node /old/gitnexus-hook.cjs' },
+                ],
+              },
+            ],
+            PostToolUse: [{ hooks: [{ type: 'command', command: 'node /old/gitnexus-hook.cjs' }] }],
           },
           permissions: { allow: ['Read'] },
         },
@@ -187,6 +196,7 @@ describe('setupCommand coding-agent selection', () => {
     expect(JSON.stringify(settings.hooks.PreToolUse)).toContain('keep-pre');
     expect(JSON.stringify(settings.hooks.PreToolUse)).toContain('gitnexus-hook');
     expect(JSON.stringify(settings.hooks.PostToolUse)).toContain('gitnexus-hook');
+    expect(JSON.stringify(settings.hooks)).not.toContain('/old/gitnexus-hook.cjs');
     for (const file of [
       'gitnexus-hook.cjs',
       'hook-lock.cjs',
@@ -200,6 +210,31 @@ describe('setupCommand coding-agent selection', () => {
     }
   });
 
+  it('hooks-only initializes a blank Claude settings file', async () => {
+    const settingsPath = path.join(tempHome, '.claude', 'settings.json');
+    await fs.writeFile(settingsPath, '  \n');
+    const { setupCommand } = await import('../../src/cli/setup.js');
+
+    await setupCommand({ codingAgent: ['claude'], hooksOnly: true });
+
+    expect(process.exitCode).not.toBe(1);
+    const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+    expect(JSON.stringify(settings.hooks.PreToolUse)).toContain('gitnexus-hook');
+    expect(JSON.stringify(settings.hooks.PostToolUse)).toContain('gitnexus-hook');
+  });
+
+  it('hooks-only fails when Claude is not installed', async () => {
+    await fs.rm(path.join(tempHome, '.claude'), { recursive: true, force: true });
+    const { setupCommand } = await import('../../src/cli/setup.js');
+
+    await setupCommand({ codingAgent: ['claude'], hooksOnly: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(console.log).mock.calls.flat().join('\n')).toContain(
+      'Claude config directory is missing',
+    );
+  });
+
   it('hooks-only requires exactly Claude and performs no writes on invalid selection', async () => {
     const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     const { setupCommand } = await import('../../src/cli/setup.js');
@@ -208,8 +243,6 @@ describe('setupCommand coding-agent selection', () => {
     expect(stderr).toHaveBeenCalledWith(
       '`--hooks-only` requires exactly `--coding-agent claude`.\n',
     );
-    await expect(
-      fs.access(path.join(tempHome, '.codex', 'hooks', 'gitnexus')),
-    ).rejects.toThrow();
+    await expect(fs.access(path.join(tempHome, '.codex', 'hooks', 'gitnexus'))).rejects.toThrow();
   });
 });

--- a/gitnexus/test/unit/setup-selection.test.ts
+++ b/gitnexus/test/unit/setup-selection.test.ts
@@ -148,4 +148,68 @@ describe('setupCommand coding-agent selection', () => {
       fs.access(path.join(tempHome, '.config', 'opencode', 'opencode.json')),
     ).resolves.toBeUndefined();
   });
+
+  it('hooks-only refreshes Claude hooks without touching MCP, skills, or unrelated hooks', async () => {
+    const claudeJsonPath = path.join(tempHome, '.claude.json');
+    const skillsPath = path.join(tempHome, '.claude', 'skills', 'keep', 'SKILL.md');
+    const settingsPath = path.join(tempHome, '.claude', 'settings.json');
+    const claudeJson = '{"mcpServers":{"gitnexus":{"command":"curated-wrapper","env":{"KEEP":"1"}}}}\n';
+    await fs.mkdir(path.dirname(skillsPath), { recursive: true });
+    await fs.writeFile(claudeJsonPath, claudeJson);
+    await fs.writeFile(skillsPath, 'keep me');
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify(
+        {
+          hooks: {
+            SessionStart: [
+              { hooks: [{ type: 'command', command: 'node /old/gitnexus-hook.cjs' }] },
+              { hooks: [{ type: 'command', command: 'echo keep-session' }] },
+            ],
+            PreToolUse: [{ hooks: [{ type: 'command', command: 'echo keep-pre' }] }],
+          },
+          permissions: { allow: ['Read'] },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand({ codingAgent: ['claude'], hooksOnly: true });
+
+    expect(await fs.readFile(claudeJsonPath, 'utf8')).toBe(claudeJson);
+    expect(await fs.readFile(skillsPath, 'utf8')).toBe('keep me');
+    const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+    expect(settings.permissions).toEqual({ allow: ['Read'] });
+    expect(JSON.stringify(settings.hooks.SessionStart)).toContain('keep-session');
+    expect(JSON.stringify(settings.hooks.SessionStart)).not.toContain('gitnexus');
+    expect(JSON.stringify(settings.hooks.PreToolUse)).toContain('keep-pre');
+    expect(JSON.stringify(settings.hooks.PreToolUse)).toContain('gitnexus-hook');
+    expect(JSON.stringify(settings.hooks.PostToolUse)).toContain('gitnexus-hook');
+    for (const file of [
+      'gitnexus-hook.cjs',
+      'hook-lock.cjs',
+      'hook-db-lock-probe.cjs',
+      'resolve-analyze-cmd.cjs',
+      'win-rm-list-json.ps1',
+    ]) {
+      await expect(
+        fs.access(path.join(tempHome, '.claude', 'hooks', 'gitnexus', file)),
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it('hooks-only requires exactly Claude and performs no writes on invalid selection', async () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const { setupCommand } = await import('../../src/cli/setup.js');
+    await setupCommand({ codingAgent: ['codex'], hooksOnly: true });
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith(
+      '`--hooks-only` requires exactly `--coding-agent claude`.\n',
+    );
+    await expect(
+      fs.access(path.join(tempHome, '.codex', 'hooks', 'gitnexus')),
+    ).rejects.toThrow();
+  });
 });


### PR DESCRIPTION
Closes #171

## Summary
- add `setup --hooks-only --coding-agent claude`; it updates only the Claude adapter/helpers and GitNexus hook registrations
- remove only obsolete GitNexus `SessionStart` commands while preserving unrelated hooks and settings
- add an eight-process user-global cap in addition to the existing three-per-repository cap
- add sanitized `doctor --integrations --json` for selected CLI version, Codex/Claude MCP consistency, and Claude hook freshness

## Proof
- `npm run build`
- hooks-only/integration-doctor/global-cap/help suite: 29 passed
- combined focused run: 281 passed, 3 platform skips
- 64 simultaneous calls admitted no more than eight and left no lock files
- live read-only integration doctor reports MCP `consistent` with two Claude entries and hooks `stale`, matching the machine state; no commands, env values, paths, or secrets are emitted.