### PR TITLE
chore(release): prepare electric 1.6.10-electric.7

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.6",
+      "version": "1.6.10-electric.7",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.6",
+      "version": "1.6.10-electric.7",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.7.md
+++ b/Documentation/releases/1.6.10-electric.7.md
@@ -1,0 +1,38 @@
+# GitNexus 1.6.10-electric.7
+
+`1.6.10-electric.7` closes the final source defects found during installed fleet recovery and adds a safe, non-destructive Claude hook refresh path. It does not blanket-reindex healthy repositories.
+
+## Added
+
+- `gitnexus analyze --repair-vector` rebuilds only HNSW after fail-closed storage, sidecar, lock, metadata, and live VECTOR preflight. It preserves all embedding rows, verifies the rebuilt index through the eight-connection production pool, and then reconciles database-derived metadata and registry counts.
+- `gitnexus setup --hooks-only --coding-agent claude` updates only the Claude GitNexus adapter and required helpers, removes only the obsolete GitNexus `SessionStart` registration, and leaves Claude MCP, skills, and unrelated hooks unchanged.
+- `gitnexus doctor --integrations --json` reports the selected CLI, Codex and Claude MCP consistency, and Claude hook freshness without exposing configuration values or secrets.
+- Claude hook execution now has an eight-process machine-global cap in addition to the three-per-repository cap.
+
+## Fixed
+
+- Isolated staged embedding resumes validate the physical identity set before mutation, drop HNSW, recreate `CodeEmbedding`, stream-restore only an exact digest-matched preservation snapshot, regenerate the pending checkpoint window once, and rebuild HNSW. Empty, non-canonical, duplicate, orphaned, or wrong-dimension rows fail closed; the canonical in-place embedding table is never recreated by this path.
+- Embedding and node writers validate complete batches before writing, and node COPY failures no longer retry with permissive row dropping.
+- LadybugDB buffer-pool sizing is bounded, index replacement invalidates stale MCP read pools, and pool rollover waits for checked-out queries.
+- Readable repositories with zero embeddings report `not-indexed` rather than a false vector failure.
+
+## Operational Policy
+
+- Remote Voyage indexing may run for at most two different normalized remotes and index paths. It has no host memory, swap, RSS, free-memory, or pressure gate.
+- Local embedding work remains single-job and separately resource-gated.
+- Large repositories run alone unless paired with an explicitly small repository.
+- Invalid MCP repository policy remains fail-closed and agent-visible; there is no unrestricted fallback.
+- Healthy existing indexes are retained. Ordinary onboarding and refresh work runs as a detached queue and does not block interactive use of the released runtime.
+
+## Known Boundaries
+
+- Distribution is GitHub-only. Public npm dist-tags and container registries remain unchanged.
+- Publication and installation do not prove fleet repair, Claude hook parity, or live MCP retrieval; those remain separate installed-runtime gates.
+- Late P2 edge cases in Windows-only optional hook helpers, rc-derived PDG repair conflicts, asynchronous native timeout setup, and concurrent wiki-generation rollover received explicit non-blocking dispositions and are not claimed fixed by this release.
+
+## Release Verification
+
+- Included PRs: #172, #173, #174, and #176; sprint epic: #130.
+- Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.7`.
+- The release gate requires protected exact-head CI, current-head independent review, terminal dispositions for all review threads, immutable copied-artifact acceptance against the preserved ClawSweeper resume and WorldOS generation, the protected Electric Release workflow, verified tarball and `SHA256SUMS`, and side-by-side installation preserving `.6`.
+- Installed proof requires safe Claude hook refresh, integration doctor consistency, targeted vector repair, live registry doctor, and two successive non-partial semantic queries against OpenClaw and Hermes.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.6",
+  "version": "1.6.10-electric.7",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.6",
+  "version": "1.6.10-electric.7",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.7] - 2026-07-22
+
+### Added
+
+- **Safe HNSW-only repair** preserves every stored embedding while rebuilding the vector index under fail-closed storage, lock, recovery, and live eight-connection pool checks (#170, #172)
+- **Claude hook-only maintenance and integration doctor** refresh the copied Claude adapter without replacing MCP configuration, remove only obsolete GitNexus hook wiring, cap hook subprocesses globally, and report sanitized runtime consistency (#171, #174)
+
+### Fixed
+
+- **Interrupted staged embedding resumes enforce persisted identity integrity before bounded restore and regeneration**: malformed, duplicate, orphaned, non-canonical, or wrong-dimension rows fail closed; a preservation snapshot can authorize isolated reconstruction only when its exact semantic-identity digest matches; node COPY failures cannot fall through to permissive row dropping (#162, #173)
+- **LadybugDB memory and MCP pool rollover are bounded and freshness-aware**, preventing stale pooled reads after index replacement while retaining explicit operator override behavior (#175, #176)
+- **Readable zero-embedding repositories report `not-indexed`** instead of claiming a broken vector index (#170, #172)
+
+### Changed
+
+- Remote Voyage fleet work remains detached and may use at most two different-remote slots; it has no host memory, swap, RSS, free-memory, or pressure gate.
+- Distribution remains GitHub-only as one tarball plus `SHA256SUMS`; npm and container registries are unchanged.
+- Existing `1.6.10-electric.2` through `.6` installations remain available for rollback.
+
 ## [1.6.10-electric.6] - 2026-07-21
 
 ### Fixed

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.6",
+  "version": "1.6.10-electric.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-electric.6",
+      "version": "1.6.10-electric.7",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.6",
+  "version": "1.6.10-electric.7",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Summary
- bump all GitNexus and plugin release surfaces to `1.6.10-electric.7`
- document safe staged embedding identity recovery, vector repair, Claude hook-only setup, integration doctor, and bounded pool rollover
- require immutable copied-artifact acceptance for ClawSweeper and WorldOS before publication or installation

## Validation
- version agreement across package, lockfile, plugin manifests, and marketplace manifests
- `git diff --check`
- release policy is enforced by exact-head CI (local policy script could not load its root `yaml` dependency in this clean worktree)

## Release gate
This PR does not publish or install the release. After merge, the protected Electric Release workflow will build the exact tarball and pause at the protected release environment. That artifact must pass the prepared ClawSweeper resume and WorldOS malformed-rejection/fresh-index gates before publication.