### PR TITLE
fix(analyze): resume timestamped staged snapshots safely

### DIFF
--- a/gitnexus/src/core/embeddings/cache-snapshot.ts
+++ b/gitnexus/src/core/embeddings/cache-snapshot.ts
@@ -43,6 +43,16 @@ export interface EmbeddingSnapshotInfo {
   duplicateRows?: number;
 }
 
+export interface EmbeddingSnapshotValidationOptions {
+  /**
+   * A staged checkpoint restamps metadata after the preservation snapshot is
+   * written. Only that resume path may ignore the old indexedAt value; the
+   * source commit, payload checksum, row count, dimensions, and identity
+   * digest remain mandatory.
+   */
+  allowSourceIndexedAtDriftForCheckpointResume?: boolean;
+}
+
 export const embeddingSnapshotMatchesIdentityDigest = (
   info: EmbeddingSnapshotInfo,
   identitySha256: string,
@@ -196,6 +206,7 @@ export const validateEmbeddingSnapshot = async (
   snapshotPath: string,
   source: EmbeddingSnapshotSource,
   expectedCount?: number,
+  options: EmbeddingSnapshotValidationOptions = {},
 ): Promise<EmbeddingSnapshotInfo | undefined> => {
   let input: ReturnType<typeof createReadStream>;
   try {
@@ -257,7 +268,8 @@ export const validateEmbeddingSnapshot = async (
     footer.dimensions !== dimensions ||
     footer.sha256 !== digest.digest('hex') ||
     footer.sourceLastCommit !== source.lastCommit ||
-    footer.sourceIndexedAt !== source.indexedAt ||
+    (!options.allowSourceIndexedAtDriftForCheckpointResume &&
+      footer.sourceIndexedAt !== source.indexedAt) ||
     (expectedCount !== undefined && uniqueCount !== expectedCount)
   ) {
     return undefined;
@@ -274,8 +286,9 @@ export const readEmbeddingSnapshot = async (
   source: EmbeddingSnapshotSource,
   onBatch: (batch: readonly CachedEmbedding[]) => Promise<void>,
   expectedCount?: number,
+  options: EmbeddingSnapshotValidationOptions = {},
 ): Promise<EmbeddingSnapshotInfo> => {
-  const info = await validateEmbeddingSnapshot(snapshotPath, source, expectedCount);
+  const info = await validateEmbeddingSnapshot(snapshotPath, source, expectedCount, options);
   if (!info) throw new Error('Embedding preservation snapshot failed validation');
 
   const input = createReadStream(snapshotPath, { encoding: 'utf8' });

--- a/gitnexus/src/core/lbug/lbug-config.ts
+++ b/gitnexus/src/core/lbug/lbug-config.ts
@@ -301,7 +301,10 @@ const resolveCheckpointThreshold = (): number => {
 
 const DEFAULT_BUFFER_POOL_CAP = 2 * 1024 * 1024 * 1024;
 const BUFFER_POOL_FLOOR = 64 * 1024 * 1024;
-const ANALYZE_BUFFER_POOL_FLOOR = 128 * 1024 * 1024;
+// Real staged resumes build graph/FTS state before restoring vectors. A 128 MiB
+// hint can exhaust LadybugDB even for a ~21k-element repository, so keep the
+// analyze floor at the smallest value proven by the copied ClawSweeper corpus.
+const ANALYZE_BUFFER_POOL_FLOOR = 512 * 1024 * 1024;
 
 const parseBufferPoolSize = (raw: string | undefined): number | undefined => {
   if (raw === undefined) return undefined;

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -1664,6 +1664,10 @@ const runFullAnalysisImpl = async (
     lastCommit: existingMeta?.lastCommit,
     indexedAt: resumeEmbeddingCheckpoint ? undefined : existingMeta?.indexedAt,
   };
+  const embeddingSnapshotValidationOptions =
+    stagedPaths && resumeEmbeddingCheckpoint
+      ? { allowSourceIndexedAtDriftForCheckpointResume: true as const }
+      : undefined;
   let embeddingSnapshotInfo: EmbeddingSnapshotInfo | undefined;
   let embeddingSnapshotAvailable = false;
   let embeddingTableRebuildStarted = false;
@@ -1721,6 +1725,7 @@ const runFullAnalysisImpl = async (
         embeddingSnapshotPath,
         embeddingSnapshotSource,
         expectedSnapshotCount,
+        embeddingSnapshotValidationOptions,
       );
       if (stagedPaths && resumeEmbeddingCheckpoint) {
         embeddingTableRebuildStarted = await validateEmbeddingTableRebuildMarker(
@@ -2613,6 +2618,7 @@ const runFullAnalysisImpl = async (
             }
           },
           resumeEmbeddingCheckpoint ? undefined : existingEmbeddingCount,
+          embeddingSnapshotValidationOptions,
         );
         if (skippedPendingEmbeddingRows > 0) {
           log(

--- a/gitnexus/test/unit/embedding-cache-snapshot.test.ts
+++ b/gitnexus/test/unit/embedding-cache-snapshot.test.ts
@@ -205,16 +205,30 @@ describe('bounded embedding preservation snapshot', () => {
 
   it('keeps checkpoint-resume snapshots valid across metadata timestamp rewrites', async () => {
     const snapshotPath = await makePath();
-    const source = { lastCommit: 'abc', indexedAt: undefined };
+    const source = { lastCommit: 'abc', indexedAt: '2026-07-22T00:00:00.000Z' };
     await createEmbeddingSnapshot(snapshotPath, source, async (emit) => emit(makeRows(1)));
 
     const checkpointMetadata = { lastCommit: 'abc', indexedAt: '2026-07-22T01:23:45.000Z' };
+    const resumeSource = {
+      lastCommit: checkpointMetadata.lastCommit,
+      indexedAt: undefined,
+    };
+    await expect(validateEmbeddingSnapshot(snapshotPath, resumeSource)).resolves.toBeUndefined();
     await expect(
-      validateEmbeddingSnapshot(snapshotPath, {
-        lastCommit: checkpointMetadata.lastCommit,
-        indexedAt: undefined,
+      validateEmbeddingSnapshot(snapshotPath, resumeSource, undefined, {
+        allowSourceIndexedAtDriftForCheckpointResume: true,
       }),
     ).resolves.toMatchObject({ count: 1, dimensions: 4 });
+
+    const restored: CachedEmbedding[] = [];
+    await readEmbeddingSnapshot(
+      snapshotPath,
+      resumeSource,
+      async (batch) => restored.push(...batch),
+      undefined,
+      { allowSourceIndexedAtDriftForCheckpointResume: true },
+    );
+    expect(restored).toHaveLength(1);
   });
 
   it('rejects a producer batch above the 256-vector cap and removes its temp file', async () => {

--- a/gitnexus/test/unit/lbug-config-wal.test.ts
+++ b/gitnexus/test/unit/lbug-config-wal.test.ts
@@ -222,8 +222,9 @@ describe('createLbugDatabase bounded buffer pool', () => {
   });
 
   it.each([
-    ['tiny graph uses the analyze-safe floor', 41, 128 * MiB],
-    ['mid graph scales linearly', 100_000, 100_000 * 4 * 1024],
+    ['tiny graph uses the analyze-safe floor', 41, 512 * MiB],
+    ['mid graph below the floor stays analyze-safe', 100_000, 512 * MiB],
+    ['larger graph scales linearly', 200_000, 200_000 * 4 * 1024],
     ['huge graph caps at 2 GiB', 10_000_000, 2 * GiB],
   ])('%s', (_label, elements, expected) => {
     const totalmemSpy = vi.spyOn(os, 'totalmem').mockReturnValue(32 * GiB);
@@ -240,7 +241,7 @@ describe('createLbugDatabase bounded buffer pool', () => {
       setBufferPoolSizeHint(128 * MiB);
       const hinted = vi.fn(function (this: any) {});
       createLbugDatabase({ Database: hinted } as any, '/tmp/lbug-hint');
-      expect(bufferPoolArg(hinted)).toBe(128 * MiB);
+      expect(bufferPoolArg(hinted)).toBe(512 * MiB);
 
       vi.stubEnv('GITNEXUS_LBUG_BUFFER_POOL_SIZE', '0');
       const overridden = vi.fn(function (this: any) {});


### PR DESCRIPTION
Closes the remaining P1 acceptance failure in #162.

A real copied ClawSweeper checkpoint had a valid, checksummed preservation snapshot from the pre-checkpoint timestamp, while checkpoint metadata had been restamped later. Resume deliberately omitted indexedAt, but snapshot validation still required strict indexedAt equality, bypassing the existing identity-digest recovery gate and trying to reread the malformed native table.

This change:
- permits indexedAt drift only for the explicit staged checkpoint-resume path;
- keeps last-commit, checksum, count, dimension, duplicate, orphan, and live identity-digest gates intact;
- threads the same validation mode through bounded restore;
- raises the analyze-time Ladybug pool floor from 128 MiB to 512 MiB, bounded by the existing host-memory cap, after the copied corpus exhausted 128 MiB during graph/FTS work.

Proof on the copied artifact:
- the initial exact .7 artifact failed before mutation on timestamp mismatch;
- the narrow timestamp fix reached the intended digest-gated recovery path;
- 128 MiB then reproduced a Ladybug buffer-pool exhaustion;
- the corrected default completed with 5,086 embeddings, clean DB/meta/registry counts, active vector-index, and two successive non-partial MCP queries.

Focused validation:
- 45 focused unit tests passed;
- TypeScript typecheck passed;
- Prettier and diff checks passed;
- copied ClawSweeper installed-tarball acceptance passed without an environment override.

The GitHub .7 release remains unpublished and the protected release run was cancelled. The exact post-merge artifact will repeat ClawSweeper and WorldOS acceptance before publication.
