### PR TITLE
fix(analyze): keep vector repair preflight byte-preserving

### DIFF
--- a/gitnexus/src/core/lbug/lbug-adapter.ts
+++ b/gitnexus/src/core/lbug/lbug-adapter.ts
@@ -736,6 +736,54 @@ export const initLbugForMaintenance = async (dbPath: string) =>
   });
 
 /**
+ * Open an existing database for a byte-preserving maintenance preflight.
+ *
+ * This deliberately bypasses the normal read-only recovery path: it never
+ * quarantines a WAL, replays shadow pages through a writable handle, creates
+ * an init lock, or opens the database writable. Callers must close the shared
+ * handle with {@link closeLbug} when their bounded read is complete.
+ */
+export const initLbugReadOnlyNonRecovering = async (dbPath: string) =>
+  runWithSessionLock(async () => {
+    if (conn || db) await safeClose();
+    resetOpenConnectionState();
+
+    const state = await fs.lstat(dbPath);
+    if (!state.isFile() || state.isSymbolicLink()) {
+      throw new Error(`Read-only preflight requires a regular database file at ${dbPath}`);
+    }
+
+    const sidecarState = await preflightLbugSidecars(dbPath, {
+      mode: 'read-only',
+      logger,
+      allowQuarantine: false,
+    });
+    if (sidecarState.kind !== 'clean') {
+      throw new Error(
+        `Read-only preflight refused: LadybugDB sidecar state is ${sidecarState.kind}; ` +
+          'recover the index before retrying.',
+      );
+    }
+
+    const opened = await openLbugConnection(lbug, dbPath, {
+      readOnly: true,
+      throwOnWalReplayFailure: true,
+    });
+    try {
+      await queryAndDrain(opened.conn, READ_ONLY_SHADOW_REPLAY_PROBE);
+    } catch (error) {
+      await closeLbugConnection(opened).catch(() => {});
+      throw error;
+    }
+
+    db = opened.db;
+    conn = opened.conn;
+    currentDbPath = dbPath;
+    currentDbReadOnly = true;
+    return { db, conn };
+  });
+
+/**
  * Execute multiple queries against one repo DB atomically.
  * While the callback runs, no other request can switch the active DB.
  *

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -17,6 +17,7 @@ import { resetDegradedParseCounter } from './tree-sitter/safe-parse.js';
 import {
   initLbug,
   initLbugForMaintenance,
+  initLbugReadOnlyNonRecovering,
   loadGraphToLbug,
   getLbugStats,
   executeQuery,
@@ -837,7 +838,6 @@ const runFullAnalysisImpl = async (
 
     const { probeDoctorPool, EXPECTED_POOL_CONNECTIONS } =
       await import('../cli/doctor-pool-probe.js');
-    const beforeProbe = await probeDoctorPool(canonicalPaths.lbugPath);
     const readEmbeddingCount = async (): Promise<number> => {
       let rows: Awaited<ReturnType<typeof executeQuery>>;
       try {
@@ -858,27 +858,64 @@ const runFullAnalysisImpl = async (
     let embeddingCountBefore = 0;
     let repairStatus: AnalyzeResult['vectorRepairStatus'] = 'healthy';
 
+    // A writable LadybugDB open can change database bytes even when no Cypher
+    // mutation is issued. Validate the source table through a native read-only
+    // connection first so malformed and empty indexes fail/return without
+    // touching the database file.
+    let readOnlyPreflight: {
+      stats: { nodes: number; edges: number };
+      embeddingCount: number;
+      integrity: EmbeddingIntegrityReport;
+    };
+    try {
+      await initLbugReadOnlyNonRecovering(canonicalPaths.lbugPath);
+      const embeddingCount = await readEmbeddingCount();
+      readOnlyPreflight = {
+        stats: await getLbugStats(),
+        embeddingCount,
+        integrity: await inspectEmbeddingIntegrity(),
+      };
+    } finally {
+      await closeLbug().catch(() => {});
+    }
+
+    stats = readOnlyPreflight.stats;
+    embeddingCountBefore = readOnlyPreflight.embeddingCount;
+
+    if (embeddingCountBefore === 0) {
+      progress('done', 100, 'No embeddings are indexed; VECTOR repair was not needed.');
+      return {
+        repoName:
+          options.registryName ??
+          getInferredRepoName(repoPath) ??
+          path.basename(resolveRepoIdentityRoot(repoPath)),
+        repoPath,
+        stats: { ...existingMeta.stats, nodes: stats.nodes, edges: stats.edges, embeddings: 0 },
+        vectorRepairStatus: 'not-indexed',
+      };
+    }
+
+    assertEmbeddingIntegrity(
+      readOnlyPreflight.integrity,
+      'Cannot repair VECTOR: source table',
+      embeddingCountBefore,
+    );
+
+    const beforeProbe = await probeDoctorPool(canonicalPaths.lbugPath);
+
     try {
       await initLbugForMaintenance(canonicalPaths.lbugPath);
       stats = await getLbugStats();
-      embeddingCountBefore = await readEmbeddingCount();
-      const integrityBefore = await inspectEmbeddingIntegrity();
-
-      if (embeddingCountBefore === 0) {
-        progress('done', 100, 'No embeddings are indexed; VECTOR repair was not needed.');
-        return {
-          repoName:
-            options.registryName ??
-            getInferredRepoName(repoPath) ??
-            path.basename(resolveRepoIdentityRoot(repoPath)),
-          repoPath,
-          stats: { ...existingMeta.stats, nodes: stats.nodes, edges: stats.edges, embeddings: 0 },
-          vectorRepairStatus: 'not-indexed',
-        };
+      const writableEmbeddingCount = await readEmbeddingCount();
+      if (writableEmbeddingCount !== embeddingCountBefore) {
+        throw new Error(
+          `Cannot repair VECTOR: embedding rows changed after read-only preflight ` +
+            `(${embeddingCountBefore} before, ${writableEmbeddingCount} current).`,
+        );
       }
 
       assertEmbeddingIntegrity(
-        integrityBefore,
+        await inspectEmbeddingIntegrity(),
         'Cannot repair VECTOR: source table',
         embeddingCountBefore,
       );

--- a/gitnexus/test/integration/vector-repair-readonly-preflight.test.ts
+++ b/gitnexus/test/integration/vector-repair-readonly-preflight.test.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
-import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getStoragePaths, saveMeta, type RepoMeta } from '../../src/storage/repo-manager.js';
 import { EMBEDDING_DIMS } from '../../src/core/lbug/schema.js';

--- a/gitnexus/test/integration/vector-repair-readonly-preflight.test.ts
+++ b/gitnexus/test/integration/vector-repair-readonly-preflight.test.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getStoragePaths, saveMeta, type RepoMeta } from '../../src/storage/repo-manager.js';
+import { EMBEDDING_DIMS } from '../../src/core/lbug/schema.js';
+import { createTempDir, type TestDBHandle } from '../helpers/test-db.js';
+
+const sha256 = (bytes: Buffer): string => createHash('sha256').update(bytes).digest('hex');
+
+describe('VECTOR repair malformed-source byte preservation', () => {
+  let fixture: TestDBHandle | undefined;
+
+  afterEach(async () => {
+    const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+    await adapter.closeLbug().catch(() => {});
+    await fixture?.cleanup();
+    fixture = undefined;
+  });
+
+  it('rejects through a strict read-only preflight without changing Ladybug bytes', async () => {
+    fixture = await createTempDir();
+    const repoPath = fixture.dbPath;
+    const paths = getStoragePaths(repoPath);
+    await fs.mkdir(paths.storagePath, { recursive: true });
+
+    const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+    await adapter.initLbug(paths.lbugPath);
+    await adapter.executeQuery(
+      "CREATE (:Function {id: 'Function:live', name: 'live', filePath: 'src/live.ts', " +
+        "startLine: 1, endLine: 2, isExported: true, content: '', description: ''})",
+    );
+    await adapter.executeWithReusedStatement(
+      'CREATE (e:CodeEmbedding {id: $id, nodeId: $nodeId, chunkIndex: 0, ' +
+        'startLine: 1, endLine: 2, embedding: $embedding, contentHash: $contentHash})',
+      [
+        {
+          id: '',
+          nodeId: 'Function:live',
+          embedding: new Array(EMBEDDING_DIMS).fill(0),
+          contentHash: 'malformed',
+        },
+      ],
+    );
+    await adapter.flushWAL();
+    await adapter.closeLbug();
+
+    const meta: RepoMeta = {
+      repoPath,
+      lastCommit: '',
+      indexedAt: '2026-07-22T00:00:00.000Z',
+      stats: { files: 1, nodes: 1, edges: 0, embeddings: 1 },
+      capabilities: {
+        graph: { provider: 'ladybugdb', status: 'available' },
+        fts: { provider: 'ladybugdb-fts', status: 'available' },
+        vectorSearch: {
+          provider: 'exact-scan',
+          status: 'exact-scan',
+          exactScanLimit: 20_000,
+        },
+      },
+    };
+    await saveMeta(paths.storagePath, meta);
+
+    const beforeBytes = await fs.readFile(paths.lbugPath);
+    const beforeHash = sha256(beforeBytes);
+    const beforeEntries = (await fs.readdir(paths.storagePath)).sort();
+    const beforeMeta = await fs.readFile(paths.metaPath);
+
+    const { runFullAnalysis } = await import('../../src/core/run-analyze.js');
+    await expect(
+      runFullAnalysis(repoPath, { repairVector: true }, { onProgress: () => {} }),
+    ).rejects.toThrow(/source table failed embedding integrity validation/i);
+
+    const afterBytes = await fs.readFile(paths.lbugPath);
+    expect(sha256(afterBytes)).toBe(beforeHash);
+    expect(afterBytes).toEqual(beforeBytes);
+    expect((await fs.readdir(paths.storagePath)).sort()).toEqual(beforeEntries);
+    expect(await fs.readFile(paths.metaPath)).toEqual(beforeMeta);
+  }, 120_000);
+});

--- a/gitnexus/test/unit/lbug-maintenance-lock.test.ts
+++ b/gitnexus/test/unit/lbug-maintenance-lock.test.ts
@@ -51,4 +51,50 @@ describe('LadybugDB maintenance open', () => {
       await fixture.cleanup();
     }
   });
+
+  it('never retries a failed strict read-only preflight with a writable open', async () => {
+    const fixture = await createTempDir('gitnexus-maintenance-lock-');
+    const dbPath = path.join(fixture.dbPath, 'lbug');
+    const lockPath = `${dbPath}.init.lock`;
+    await fs.writeFile(dbPath, 'fixture');
+
+    const query = vi.fn(async () => {
+      throw new Error('simulated read-only shadow replay requirement');
+    });
+    const openLbugConnection = vi.fn(async () => ({ db: {}, conn: { query } }));
+    const closeLbugConnection = vi.fn(async () => undefined);
+    const preflightLbugSidecars = vi.fn(async () => ({ kind: 'clean' as const }));
+
+    vi.doMock('../../src/core/lbug/lbug-config.js', async (importActual) => ({
+      ...(await importActual<typeof import('../../src/core/lbug/lbug-config.js')>()),
+      openLbugConnection,
+      closeLbugConnection,
+    }));
+    vi.doMock('../../src/core/lbug/sidecar-recovery.js', async (importActual) => ({
+      ...(await importActual<typeof import('../../src/core/lbug/sidecar-recovery.js')>()),
+      preflightLbugSidecars,
+    }));
+
+    try {
+      const adapter = await import('../../src/core/lbug/lbug-adapter.js');
+      await expect(adapter.initLbugReadOnlyNonRecovering(dbPath)).rejects.toThrow(
+        /simulated read-only shadow replay requirement/i,
+      );
+
+      expect(preflightLbugSidecars).toHaveBeenCalledWith(dbPath, {
+        mode: 'read-only',
+        logger: expect.anything(),
+        allowQuarantine: false,
+      });
+      expect(openLbugConnection).toHaveBeenCalledTimes(1);
+      expect(openLbugConnection).toHaveBeenCalledWith(expect.anything(), dbPath, {
+        readOnly: true,
+        throwOnWalReplayFailure: true,
+      });
+      expect(closeLbugConnection).toHaveBeenCalledTimes(1);
+      await expect(fs.access(lockPath)).rejects.toThrow();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -53,8 +53,9 @@ async function importRepairSubject(options: {
   malformedEmbeddingTable?: boolean;
   afterInitialPreflight?: () => Promise<void> | void;
 }) {
-  const counts = [...(options.counts ?? [3, 3, 3])];
+  const counts = [...(options.counts ?? [3, 3, 3, 3])];
   const probes = [...(options.probes ?? [brokenProbe, healthyProbe])];
+  const initLbugReadOnlyNonRecovering = vi.fn(async () => undefined);
   const initLbugForMaintenance = vi.fn(async () => undefined);
   const loadVectorExtension = vi.fn(async () => options.vectorAvailable ?? true);
   const dropVectorIndex = vi.fn(async () => true);
@@ -94,9 +95,9 @@ async function importRepairSubject(options: {
   }));
   const registerRepo = vi.fn(async () => 'fixture-repo');
   const probeDoctorPool = vi.fn(async () => probes.shift() ?? healthyProbe);
-
   vi.doMock('../../src/core/lbug/lbug-adapter.js', async (importActual) => ({
     ...(await importActual<typeof import('../../src/core/lbug/lbug-adapter.js')>()),
+    initLbugReadOnlyNonRecovering,
     initLbugForMaintenance,
     loadVectorExtension,
     dropVectorIndex,
@@ -135,6 +136,7 @@ async function importRepairSubject(options: {
   return {
     ...subject,
     mocks: {
+      initLbugReadOnlyNonRecovering,
       initLbugForMaintenance,
       loadVectorExtension,
       dropVectorIndex,
@@ -176,7 +178,9 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
         expect.stringMatching(/MATCH \(e:CodeEmbedding\).*count/i),
         expect.stringMatching(/MATCH \(e:CodeEmbedding\).*count/i),
         expect.stringMatching(/MATCH \(e:CodeEmbedding\).*count/i),
+        expect.stringMatching(/MATCH \(e:CodeEmbedding\).*count/i),
       ]);
+      expect(mocks.initLbugReadOnlyNonRecovering).toHaveBeenCalledWith(indexed.paths.lbugPath);
       expect(mocks.registerRepo).toHaveBeenCalledOnce();
 
       const repaired = JSON.parse(
@@ -205,6 +209,7 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       expect(mocks.dropVectorIndex).not.toHaveBeenCalled();
       expect(mocks.createVectorIndex).not.toHaveBeenCalled();
       expect(mocks.registerRepo).not.toHaveBeenCalled();
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
       expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(
         before,
       );
@@ -226,6 +231,8 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       expect(mocks.dropVectorIndex).not.toHaveBeenCalled();
       expect(mocks.createVectorIndex).not.toHaveBeenCalled();
       expect(mocks.registerRepo).not.toHaveBeenCalled();
+      expect(mocks.probeDoctorPool).not.toHaveBeenCalled();
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
       expect(await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'))).toEqual(
         before,
       );


### PR DESCRIPTION
Closes the release-blocking no-mutation defect tracked in #162.

The exact electric.7 artifact correctly rejected malformed WorldOS embedding identity, but a writable Ladybug open changed database bytes before rejection. This change adds a strict read-only, non-recovering preflight that never quarantines/replays/opens writable; only clean nonzero identity proceeds to writable HNSW maintenance.

Proof:
- 13 focused unit/integration tests pass
- real Ladybug malformed fixture preserves exact database bytes and storage entries
- copied 519,897,088-byte WorldOS artifact rejects with the expected integrity error and retains SHA-256 `7cc5b28a...`
- typecheck, build, formatting, and diff checks pass

Release remains held until this head merges and the exact artifact passes ClawSweeper plus immutable WorldOS acceptance.