### PR TITLE
chore(release): prepare electric 1.6.10-electric.8

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.7",
+      "version": "1.6.10-electric.8",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.7",
+      "version": "1.6.10-electric.8",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.8.md
+++ b/Documentation/releases/1.6.10-electric.8.md
@@ -1,0 +1,33 @@
+# GitNexus 1.6.10-electric.8
+
+`1.6.10-electric.8` is a containment release for the fork-only staged embedding lifecycle. It removes the production requirement to resume arbitrary dirty or unjournaled staged generations and keeps existing healthy indexes available for read-only use.
+
+## Fixed
+
+- An unjournaled staged generation is preserved for forensics and refused. GitNexus will not infer that it is safe to resume or promote, even when its metadata appears complete.
+- Replacing preserved staged state requires the explicit clean path: `gitnexus analyze --staged --drop-embeddings`.
+- A valid pending promotion journal is recovered as one terminal operation. The result is reported as recovery-only and never as `alreadyUpToDate`; the current checkout is not claimed analyzed.
+- CLI recovery output gives the clean staged retry. Server recovery fails the analyze request closed and requires `force=true` with `dropEmbeddings=true`.
+- Promotion recovery completes ignore and best-effort context-file bookkeeping before returning.
+- `--incremental-only --drop-embeddings` is rejected before repository storage or ownership-lock mutation.
+
+## Safety Boundary
+
+- Canonical indexes are never replaced by an unjournaled staged generation.
+- Malformed embedding identity, duplicate identity, orphan references, wrong vector dimensions, dirty checkpoints, unsafe storage, locks, or recovery sidecars remain fail-closed.
+- Invalid MCP repository policy remains fail-closed and agent-visible, with no unrestricted fallback.
+- Remote Voyage embeddings have no host memory, swap, RSS, or pressure gate. This release does not restart fleet writers.
+
+## Known Boundary
+
+- The explicit clean staged path still copies an existing canonical LadybugDB before wiping the isolated copy. The canonical remains safe, but the extra disk/time cost must be removed under #132 before large-repository fleet writers are re-enabled.
+- Distribution is GitHub-only. Public npm dist-tags and container registries remain unchanged.
+- Publication and installation do not prove fleet completeness or freshness. Fleet onboarding and ordinary refreshes remain separate, paused work.
+
+## Release Verification
+
+- Included PR: #180. Tracking: #162, #132, and epic #130.
+- Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.8`.
+- The exact artifact must first refuse the preserved dirty ClawSweeper generation without changing its hashes, then produce a separate clean isolated generation with zero empty, duplicate, orphaned, non-canonical, or wrong-dimension embeddings.
+- The accepted generation must pass the live eight-connection VECTOR pool and two successive non-partial semantic queries before publication or installation.
+- Installed proof requires Codex and Claude to resolve the same `.8` wrapper. `.7` remains available for rollback.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.7",
+  "version": "1.6.10-electric.8",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.7",
+  "version": "1.6.10-electric.8",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.8] - 2026-07-23
+
+### Fixed
+
+- **Staged embedding recovery is reduced to a fail-closed containment boundary**: unjournaled staged generations are preserved but never resumed or promoted automatically, and replacing one requires an explicit clean isolated rebuild with `--staged --drop-embeddings` (#162, #180)
+- **Journal recovery is terminal and truthful**: CLI callers receive a distinct recovery-only result stating that the current checkout was not analyzed, while server callers fail closed with the exact forced-clean retry requirements (#180)
+- **Recovery completes canonical bookkeeping without starting a second analysis**, and conflicting `--incremental-only --drop-embeddings` requests are rejected before storage or ownership-lock mutation (#180)
+
+### Changed
+
+- Generic dirty-stage resume and unjournaled completed-stage promotion are no longer supported production paths. Preserved artifacts remain available for forensics; recovery proceeds through a new clean isolated generation.
+- Fleet writers and onboarding remain disabled for this containment release. Existing healthy canonical indexes continue to serve read-only MCP, query, and doctor traffic.
+- Distribution remains GitHub-only as one tarball plus `SHA256SUMS`; npm and container registries are unchanged.
+- Existing `1.6.10-electric.7` remains installed as the immediate rollback runtime.
+
 ## [1.6.10-electric.7] - 2026-07-22
 
 ### Added

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.7",
+  "version": "1.6.10-electric.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-electric.7",
+      "version": "1.6.10-electric.8",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.7",
+  "version": "1.6.10-electric.8",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Summary

- bump package, lockfile, Claude/Codex plugin, and marketplace versions to `1.6.10-electric.8`
- document the PR #180 staged-lifecycle containment boundary
- keep fleet writers disabled and record the canonical-copy optimization under #132

## Validation

- JSON/version parity: passed locally
- `git diff --check`: passed
- release-policy/package tests: canonical CI required; the fresh release worktree has no installed dev dependencies

## Release boundary

This PR prepares source metadata only. Merge is not publication, installation, or runtime proof. The exact artifact must pass copied ClawSweeper refusal plus clean-generation integrity/VECTOR/MCP acceptance before the protected GitHub-only release workflow is run.

Refs #130, #132, #162.