### PR TITLE
chore(release): prepare 1.6.10-electric.9

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.8",
+      "version": "1.6.10-electric.9",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.8",
+      "version": "1.6.10-electric.9",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.9.md
+++ b/Documentation/releases/1.6.10-electric.9.md
@@ -1,0 +1,33 @@
+# GitNexus 1.6.10-electric.9
+
+`1.6.10-electric.9` restores resilient, fail-closed MCP repository policy handling. One malformed allowlist entry can no longer make every otherwise valid repository unavailable.
+
+## Fixed
+
+- Valid allowlist entries remain usable when another entry is invalid or ambiguous.
+- Rejected entries grant no access and are reported to agents and operators only through sanitized environment-key, entry-position, and failure-class coordinates.
+- Absolute paths with equivalent filesystem capitalization or a startup-resolvable alias map to the registered repository.
+- Runtime repository selection uses a precomputed alias map and performs no synchronous `realpath` or `stat` calls.
+- `gitnexus doctor --mcp-config` exits nonzero for degraded as well as fully blocked policy, including JSON mode.
+
+## Safety Boundary
+
+- A configured allowlist that resolves zero repositories remains fully blocked.
+- An invalid, ambiguous, or outside-allowlist default remains fully blocked.
+- Rejected entries never become available through names, paths, resources, or group routing.
+- GitNexus never silently ignores policy failure by falling back to unrestricted access.
+- Diagnostics never reveal configured repository values or registry candidates.
+
+## Known Boundary
+
+- Equivalent absolute-path spelling is resolved against the local registered filesystem object at MCP startup. This release does not introduce a registry migration or an external policy database.
+- Existing MCP processes retain the policy snapshot they initialized with; new configuration takes effect on a fresh process.
+- Distribution is GitHub-only. Public npm dist-tags and container registries remain unchanged.
+
+## Release Verification
+
+- Included PR: #183. Tracking: #182.
+- Package, lockfile, Claude/Codex plugin manifests, both marketplace manifests, changelog, and this release note agree on `1.6.10-electric.9`.
+- Exact-head CI must pass on Linux, macOS, and Windows, including MCP policy unit/CLI coverage and packaged-install smoke.
+- Installed proof requires Codex, Claude Code, and Hermes to resolve the same `.9` wrapper, with fresh NeonDiff and Hive MCP queries succeeding.
+- `.8` remains available for rollback.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.8",
+  "version": "1.6.10-electric.9",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.8",
+  "version": "1.6.10-electric.9",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.9] - 2026-07-30
+
+### Fixed
+
+- **One invalid or ambiguous MCP allowlist entry no longer denies access to every valid repository**: valid entries remain available, rejected entries grant no access, and agents receive sanitized degraded-policy coordinates (#182, #183)
+- **Absolute repository paths accept equivalent filesystem capitalization and aliases during startup resolution** while runtime requests use a precomputed in-memory map instead of synchronous filesystem calls (#182, #183)
+- **MCP policy doctor exits nonzero for degraded configurations** so automation can detect rejected entries without changing the runtime's fail-closed, partial-service behavior (#182, #183)
+
+### Changed
+
+- An allowlist still blocks all repository access when none of its entries resolve. Invalid, ambiguous, or outside-allowlist defaults remain fully blocking, and GitNexus never falls back to unrestricted access.
+- Distribution remains GitHub-only as one tarball plus `SHA256SUMS`; npm and container registries are unchanged.
+- Existing `1.6.10-electric.8` remains installed as the immediate rollback runtime.
+
 ## [1.6.10-electric.8] - 2026-07-23
 
 ### Fixed

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.8",
+  "version": "1.6.10-electric.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-electric.8",
+      "version": "1.6.10-electric.9",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.8",
+  "version": "1.6.10-electric.9",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
## Summary
- bump package, plugin, and marketplace manifests to `1.6.10-electric.9`
- document the resilient fail-closed MCP allowlist behavior merged in #183
- preserve `.8` as the immediate rollback runtime

## Validation
- `npm run check:electric-release-policy`
- Prettier check for all release files
- `git diff --check`

Closes #182