### PR TITLE
fix: keep Codex GitNexus MCP ownership external

### DIFF
--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -3,7 +3,6 @@
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
   "version": "1.6.10-electric.9",
   "skills": "./skills",
-  "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "GitNexus",

--- a/gitnexus/test/unit/codex-plugin-mcp-ownership.test.ts
+++ b/gitnexus/test/unit/codex-plugin-mcp-ownership.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const PLUGIN_ROOT = path.join(REPO_ROOT, 'gitnexus-claude-plugin');
+
+async function readJson(relativePath: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await fs.readFile(path.join(PLUGIN_ROOT, relativePath), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe('Codex plugin MCP ownership', () => {
+  it('loads skills and hooks without declaring a second GitNexus MCP server', async () => {
+    const manifest = await readJson('.codex-plugin/plugin.json');
+
+    expect(manifest.skills).toBe('./skills');
+    expect(manifest.hooks).toBe('./hooks/hooks.json');
+    expect(manifest).not.toHaveProperty('mcpServers');
+  });
+
+  it('preserves the standalone Claude plugin MCP configuration', async () => {
+    const mcpConfig = await readJson('.mcp.json');
+
+    expect(mcpConfig).toEqual({
+      mcpServers: {
+        gitnexus: {
+          command: 'npx',
+          args: ['-y', 'gitnexus@latest', 'mcp'],
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Keep the shared GitNexus plugin's Claude MCP configuration intact, but stop the Electric Codex manifest from declaring a second GitNexus MCP owner.

Codex already receives GitNexus from its managed `[mcp_servers.gitnexus]` configuration, which launches the pinned Electric `.9` wrapper. A fresh ephemeral Codex session discovered all nine GitNexus skills and resolved the effective MCP command to that wrapper.

## Changes

- Remove only `mcpServers` from `gitnexus-claude-plugin/.codex-plugin/plugin.json`.
- Add a focused contract test proving:
  - Codex still receives the plugin's skills and hooks.
  - The Codex manifest does not declare a second MCP server.
  - The standalone Claude plugin MCP configuration is preserved.

## Validation

- `vitest run test/unit/codex-plugin-mcp-ownership.test.ts --pool=forks --maxWorkers=1`: 2/2 passed.
- `git diff --check`: passed.
- Fresh ephemeral Codex canary: nine GitNexus skills discovered; effective MCP command was `/Users/m1/Codex/bin/gitnexus-mcp-voyage-wrapper.sh mcp`.
- Current integration doctor: Electric `1.6.10-electric.9`, MCP consistent, Claude hook current.

## Non-goals

- No skill changes.
- No Claude `.mcp.json` change.
- No `.10` release, install, cache change, wrapper switch, index mutation, upstream RC integration, or Windows compatibility work.

## Proof boundary

This PR is a narrow source-packaging cleanup. It does not change the currently installed plugin or prove a released runtime.
