### PR TITLE
fix(analyze): allow VECTOR repair through a completed embedding checkpoint

### DIFF
--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -443,7 +443,19 @@ export const assertVectorRepairPreflight = async (
 
   const meta = await loadMeta(path.dirname(paths.metaPath));
   if (!meta) throw new Error('Cannot repair VECTOR: index metadata is missing.');
-  if (meta.incrementalInProgress || meta.embeddingCheckpoint) {
+  // A checkpoint whose window is fully persisted (all nodes processed, no
+  // pending window) only means the run died between the last embedding write
+  // and finalize — the embedding table is complete, and the repair path still
+  // verifies it via inspectEmbeddingIntegrity before, during, and after the
+  // rebuild. Refusing it forces a full re-embed for an index that is already
+  // whole (#132). A pending window may hold partially persisted chunk rows, so
+  // it stays blocking, as does any in-progress incremental write.
+  const checkpoint = meta.embeddingCheckpoint;
+  const checkpointComplete =
+    checkpoint !== undefined &&
+    checkpoint.nodesProcessed === checkpoint.totalNodes &&
+    !checkpoint.pendingNodeIds?.length;
+  if (meta.incrementalInProgress || (checkpoint && !checkpointComplete)) {
     throw new Error(
       'Cannot repair VECTOR while index metadata records an incomplete analysis or embedding checkpoint.',
     );
@@ -1003,6 +1015,11 @@ const runFullAnalysisImpl = async (
       );
       repairedMeta = {
         ...existingMeta,
+        // A completed embedding checkpoint may pass the preflight (see
+        // assertVectorRepairPreflight); a successful repair must not persist
+        // the stale marker, or the next repair/resume re-enters recovery.
+        embeddingCheckpoint: undefined,
+        incrementalInProgress: undefined,
         repoPath,
         remoteUrl: repositoryRemoteUrl ?? existingMeta.remoteUrl,
         stats: {

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -936,6 +936,27 @@ const runFullAnalysisImpl = async (
       embeddingCountBefore,
     );
 
+    // A completed checkpoint passed the preflight, so repair will clear it —
+    // but the integrity scan only proves the live rows are well-formed, not
+    // that none went missing after the final checkpoint (a dirty-recovery
+    // discard can drop committed rows). stats.embeddings is the persisted
+    // expectation from the interrupted run; refuse to certify a smaller table
+    // and reconcile the count downward. An operator who deliberately removed
+    // rows must update stats.embeddings alongside (the recovery playbook's
+    // existing contract).
+    if (
+      existingMeta.embeddingCheckpoint &&
+      typeof existingMeta.stats?.embeddings === 'number' &&
+      existingMeta.stats.embeddings !== embeddingCountBefore
+    ) {
+      throw new Error(
+        `Cannot repair VECTOR: metadata expects ${existingMeta.stats.embeddings} embedding rows ` +
+          `but the table holds ${embeddingCountBefore}. Rows were lost or removed after the ` +
+          'completed checkpoint; re-run analyze --embeddings to regenerate them, or correct ' +
+          'stats.embeddings if the removal was deliberate.',
+      );
+    }
+
     const beforeProbe = await probeDoctorPool(canonicalPaths.lbugPath);
 
     try {

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -917,30 +917,29 @@ const runFullAnalysisImpl = async (
     stats = readOnlyPreflight.stats;
     embeddingCountBefore = readOnlyPreflight.embeddingCount;
 
-    // A completed checkpoint passed the preflight, so repair would clear it —
+    // A completed checkpoint passed the preflight, so repair will clear it —
     // but the integrity scan only proves the live rows are well-formed, not
     // that none went missing after the final checkpoint (a dirty-recovery
-    // discard can drop committed rows). stats.embeddings is the persisted
-    // floor from before the crash; refuse to certify a table that fell BELOW
-    // it and reconcile the count downward. A deficit-only comparison, not
-    // equality: stats.embeddings is finalized at run end, so in the supported
-    // crash window (died between the last embedding write and finalize) the
-    // live table legitimately holds MORE rows than the stale expectation —
-    // and the server checkpoint producer never persists a count at all. This
-    // must precede the zero-row branch below, or TOTAL row loss returns a
-    // successful `not-indexed` while metadata still expects a populated
-    // table. An operator who deliberately removed rows must update
-    // stats.embeddings alongside (the recovery playbook's existing contract).
+    // discard can drop committed rows). stats.embeddings cannot serve as the
+    // expectation: it is stale-low across the supported crash window (it is
+    // finalized at run end) and stale-high when re-embedding legitimately
+    // shrinks a node's chunk count (the server producer never persists a
+    // count at all) — review on #192 produced counterexamples in both
+    // directions. The only loss provable from the checkpoint alone is TOTAL
+    // loss: it records embedded nodes, so an empty table is wrong in every
+    // history. Refuse that here — before the zero-row branch below would
+    // report a successful `not-indexed` — and leave partial-loss detection
+    // to a persisted per-checkpoint row count (#194).
     if (
       existingMeta.embeddingCheckpoint &&
-      typeof existingMeta.stats?.embeddings === 'number' &&
-      embeddingCountBefore < existingMeta.stats.embeddings
+      existingMeta.embeddingCheckpoint.totalNodes > 0 &&
+      embeddingCountBefore === 0
     ) {
       throw new Error(
-        `Cannot repair VECTOR: metadata expects at least ${existingMeta.stats.embeddings} ` +
-          `embedding rows but the table holds ${embeddingCountBefore}. Rows were lost or removed ` +
-          'after the completed checkpoint; re-run analyze --embeddings to regenerate them, or ' +
-          'correct stats.embeddings if the removal was deliberate.',
+        `Cannot repair VECTOR: the completed embedding checkpoint recorded ` +
+          `${existingMeta.embeddingCheckpoint.totalNodes} embedded nodes but the table holds no ` +
+          'rows. The embedding table was lost after the checkpoint; re-run analyze --embeddings ' +
+          'to regenerate it.',
       );
     }
 

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -944,6 +944,17 @@ const runFullAnalysisImpl = async (
     }
 
     if (embeddingCountBefore === 0) {
+      // Only a zero-node completed checkpoint reaches here (a populated one
+      // threw above). Clear it before returning, or an empty repository stays
+      // permanently marked as interrupted and later repair/resume keeps
+      // observing stale recovery state.
+      if (existingMeta.embeddingCheckpoint) {
+        await saveMeta(canonicalMetaDir, {
+          ...existingMeta,
+          embeddingCheckpoint: undefined,
+          incrementalInProgress: undefined,
+        });
+      }
       progress('done', 100, 'No embeddings are indexed; VECTOR repair was not needed.');
       return {
         repoName:

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -460,6 +460,22 @@ export const assertVectorRepairPreflight = async (
       'Cannot repair VECTOR while index metadata records an incomplete analysis or embedding checkpoint.',
     );
   }
+  if (checkpoint && checkpointComplete) {
+    // The checkpoint is the only durable record of which model produced the
+    // stored vectors. The resume path refuses a model/dimension mismatch, and
+    // repair clears the checkpoint on success — so repairing through a
+    // mismatched identity would build HNSW over incompatible rows AND erase
+    // the evidence. Mirror the resume-path guard before allowing either.
+    const identity = await resolveEmbeddingIdentity();
+    if (checkpoint.model !== identity.model || checkpoint.dimensions !== identity.dimensions) {
+      throw new Error(
+        `Cannot repair VECTOR: the completed embedding checkpoint records ${checkpoint.model} at ` +
+          `${checkpoint.dimensions} dimensions, but this run resolves ${identity.model} at ` +
+          `${identity.dimensions}. Restore the matching embedding configuration, or rebuild with ` +
+          'analyze --drop-embeddings --embeddings.',
+      );
+    }
+  }
   return meta;
 };
 

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -921,22 +921,26 @@ const runFullAnalysisImpl = async (
     // but the integrity scan only proves the live rows are well-formed, not
     // that none went missing after the final checkpoint (a dirty-recovery
     // discard can drop committed rows). stats.embeddings is the persisted
-    // expectation from the interrupted run; refuse to certify a smaller table
-    // and reconcile the count downward. This must precede the zero-row branch
-    // below, or TOTAL row loss returns a successful `not-indexed` while
-    // metadata still expects a populated table. An operator who deliberately
-    // removed rows must update stats.embeddings alongside (the recovery
-    // playbook's existing contract).
+    // floor from before the crash; refuse to certify a table that fell BELOW
+    // it and reconcile the count downward. A deficit-only comparison, not
+    // equality: stats.embeddings is finalized at run end, so in the supported
+    // crash window (died between the last embedding write and finalize) the
+    // live table legitimately holds MORE rows than the stale expectation —
+    // and the server checkpoint producer never persists a count at all. This
+    // must precede the zero-row branch below, or TOTAL row loss returns a
+    // successful `not-indexed` while metadata still expects a populated
+    // table. An operator who deliberately removed rows must update
+    // stats.embeddings alongside (the recovery playbook's existing contract).
     if (
       existingMeta.embeddingCheckpoint &&
       typeof existingMeta.stats?.embeddings === 'number' &&
-      existingMeta.stats.embeddings !== embeddingCountBefore
+      embeddingCountBefore < existingMeta.stats.embeddings
     ) {
       throw new Error(
-        `Cannot repair VECTOR: metadata expects ${existingMeta.stats.embeddings} embedding rows ` +
-          `but the table holds ${embeddingCountBefore}. Rows were lost or removed after the ` +
-          'completed checkpoint; re-run analyze --embeddings to regenerate them, or correct ' +
-          'stats.embeddings if the removal was deliberate.',
+        `Cannot repair VECTOR: metadata expects at least ${existingMeta.stats.embeddings} ` +
+          `embedding rows but the table holds ${embeddingCountBefore}. Rows were lost or removed ` +
+          'after the completed checkpoint; re-run analyze --embeddings to regenerate them, or ' +
+          'correct stats.embeddings if the removal was deliberate.',
       );
     }
 

--- a/gitnexus/src/core/run-analyze.ts
+++ b/gitnexus/src/core/run-analyze.ts
@@ -917,6 +917,29 @@ const runFullAnalysisImpl = async (
     stats = readOnlyPreflight.stats;
     embeddingCountBefore = readOnlyPreflight.embeddingCount;
 
+    // A completed checkpoint passed the preflight, so repair would clear it —
+    // but the integrity scan only proves the live rows are well-formed, not
+    // that none went missing after the final checkpoint (a dirty-recovery
+    // discard can drop committed rows). stats.embeddings is the persisted
+    // expectation from the interrupted run; refuse to certify a smaller table
+    // and reconcile the count downward. This must precede the zero-row branch
+    // below, or TOTAL row loss returns a successful `not-indexed` while
+    // metadata still expects a populated table. An operator who deliberately
+    // removed rows must update stats.embeddings alongside (the recovery
+    // playbook's existing contract).
+    if (
+      existingMeta.embeddingCheckpoint &&
+      typeof existingMeta.stats?.embeddings === 'number' &&
+      existingMeta.stats.embeddings !== embeddingCountBefore
+    ) {
+      throw new Error(
+        `Cannot repair VECTOR: metadata expects ${existingMeta.stats.embeddings} embedding rows ` +
+          `but the table holds ${embeddingCountBefore}. Rows were lost or removed after the ` +
+          'completed checkpoint; re-run analyze --embeddings to regenerate them, or correct ' +
+          'stats.embeddings if the removal was deliberate.',
+      );
+    }
+
     if (embeddingCountBefore === 0) {
       progress('done', 100, 'No embeddings are indexed; VECTOR repair was not needed.');
       return {
@@ -935,27 +958,6 @@ const runFullAnalysisImpl = async (
       'Cannot repair VECTOR: source table',
       embeddingCountBefore,
     );
-
-    // A completed checkpoint passed the preflight, so repair will clear it —
-    // but the integrity scan only proves the live rows are well-formed, not
-    // that none went missing after the final checkpoint (a dirty-recovery
-    // discard can drop committed rows). stats.embeddings is the persisted
-    // expectation from the interrupted run; refuse to certify a smaller table
-    // and reconcile the count downward. An operator who deliberately removed
-    // rows must update stats.embeddings alongside (the recovery playbook's
-    // existing contract).
-    if (
-      existingMeta.embeddingCheckpoint &&
-      typeof existingMeta.stats?.embeddings === 'number' &&
-      existingMeta.stats.embeddings !== embeddingCountBefore
-    ) {
-      throw new Error(
-        `Cannot repair VECTOR: metadata expects ${existingMeta.stats.embeddings} embedding rows ` +
-          `but the table holds ${embeddingCountBefore}. Rows were lost or removed after the ` +
-          'completed checkpoint; re-run analyze --embeddings to regenerate them, or correct ' +
-          'stats.embeddings if the removal was deliberate.',
-      );
-    }
 
     const beforeProbe = await probeDoctorPool(canonicalPaths.lbugPath);
 

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -45,14 +45,33 @@ async function createIndexedFixture(embeddings = 3, metaExtras: Partial<RepoMeta
   return { fixture, paths, meta };
 }
 
+// Matches the identity resolveEmbeddingIdentity() yields when no
+// GITNEXUS_EMBEDDING_* env is set (DEFAULT_EMBEDDING_CONFIG, local mode).
 const completedCheckpoint = {
   at: '2026-08-19T14:39:59.336Z',
   nodesProcessed: 5,
   totalNodes: 5,
   chunksProcessed: 6,
-  model: 'voyage-code-3',
-  dimensions: 2048,
+  model: 'Snowflake/snowflake-arctic-embed-xs',
+  dimensions: 384,
 } as const;
+
+const EMBEDDING_ENV_KEYS = [
+  'GITNEXUS_EMBEDDING_MODEL',
+  'GITNEXUS_EMBEDDING_URL',
+  'GITNEXUS_EMBEDDING_DIMS',
+] as const;
+
+function pinDefaultEmbeddingIdentity() {
+  const saved = EMBEDDING_ENV_KEYS.map((key) => [key, process.env[key]] as const);
+  for (const key of EMBEDDING_ENV_KEYS) delete process.env[key];
+  return () => {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
 
 async function importRepairSubject(options: {
   counts?: number[];
@@ -434,6 +453,7 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
   });
 
   it('repairs through a completed embedding checkpoint and clears the marker (#132)', async () => {
+    const restoreEnv = pinDefaultEmbeddingIdentity();
     const indexed = await createIndexedFixture(3, {
       embeddingCheckpoint: { ...completedCheckpoint },
     });
@@ -455,6 +475,29 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       expect(repaired.incrementalInProgress).toBeUndefined();
       expect(repaired.capabilities.vectorSearch.status).toBe('vector-index');
     } finally {
+      restoreEnv();
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('refuses a completed checkpoint whose embedding identity does not match this run', async () => {
+    const restoreEnv = pinDefaultEmbeddingIdentity();
+    const indexed = await createIndexedFixture(3, {
+      embeddingCheckpoint: { ...completedCheckpoint, model: 'voyage-code-3', dimensions: 2048 },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({});
+      await expect(
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
+      ).rejects.toThrow(/records voyage-code-3 at 2048 dimensions/i);
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+
+      const untouched = JSON.parse(
+        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
+      );
+      expect(untouched.embeddingCheckpoint).toMatchObject({ model: 'voyage-code-3' });
+    } finally {
+      restoreEnv();
       await indexed.fixture.cleanup();
     }
   });

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -480,22 +480,48 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
     }
   });
 
-  it('refuses a completed checkpoint whose embedding identity does not match this run', async () => {
+  it('refuses a completed checkpoint whose model does not match this run', async () => {
     const restoreEnv = pinDefaultEmbeddingIdentity();
+    // Model differs; dimensions match the run's resolved identity. Each field
+    // must block on its own — a guard requiring BOTH to differ would let a
+    // same-dimension model swap through.
     const indexed = await createIndexedFixture(3, {
-      embeddingCheckpoint: { ...completedCheckpoint, model: 'voyage-code-3', dimensions: 2048 },
+      embeddingCheckpoint: { ...completedCheckpoint, model: 'voyage-code-3' },
     });
     try {
       const { runFullAnalysis, mocks } = await importRepairSubject({});
       await expect(
         runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
-      ).rejects.toThrow(/records voyage-code-3 at 2048 dimensions/i);
+      ).rejects.toThrow(/records voyage-code-3 at 384 dimensions/i);
       expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
 
       const untouched = JSON.parse(
         await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
       );
       expect(untouched.embeddingCheckpoint).toMatchObject({ model: 'voyage-code-3' });
+    } finally {
+      restoreEnv();
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('refuses a completed checkpoint whose dimensions do not match this run', async () => {
+    const restoreEnv = pinDefaultEmbeddingIdentity();
+    // Dimensions differ; model matches the run's resolved identity.
+    const indexed = await createIndexedFixture(3, {
+      embeddingCheckpoint: { ...completedCheckpoint, dimensions: 2048 },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({});
+      await expect(
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
+      ).rejects.toThrow(/at 2048 dimensions, but this run resolves/i);
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+
+      const untouched = JSON.parse(
+        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
+      );
+      expect(untouched.embeddingCheckpoint).toMatchObject({ dimensions: 2048 });
     } finally {
       restoreEnv();
       await indexed.fixture.cleanup();

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -527,4 +527,31 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       await indexed.fixture.cleanup();
     }
   });
+
+  it('refuses rather than returning not-indexed when ALL rows vanished after a completed checkpoint', async () => {
+    const restoreEnv = pinDefaultEmbeddingIdentity();
+    // Metadata expects 5 rows; the mocked live table holds zero. Without the
+    // pre-zero-row guard this exits as a successful `not-indexed`.
+    const indexed = await createIndexedFixture(5, {
+      embeddingCheckpoint: { ...completedCheckpoint },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [0, 0, 0, 0] });
+      await expect(
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
+      ).rejects.toThrow(/expects 5 embedding rows but the table holds 0/i);
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+
+      const untouched = JSON.parse(
+        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
+      );
+      expect(untouched.embeddingCheckpoint).toMatchObject({
+        model: completedCheckpoint.model,
+      });
+      expect(untouched.stats.embeddings).toBe(5);
+    } finally {
+      restoreEnv();
+      await indexed.fixture.cleanup();
+    }
+  });
 });

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -20,7 +20,7 @@ const brokenProbe = {
   vectorIndexReason: 'vector-index-missing-or-unqueryable' as const,
 };
 
-async function createIndexedFixture(embeddings = 3) {
+async function createIndexedFixture(embeddings = 3, metaExtras: Partial<RepoMeta> = {}) {
   const fixture = await createTempDir('gitnexus-vector-repair-');
   const paths = getStoragePaths(fixture.dbPath);
   await fs.mkdir(paths.storagePath, { recursive: true });
@@ -39,10 +39,20 @@ async function createIndexedFixture(embeddings = 3) {
         exactScanLimit: 20_000,
       },
     },
+    ...metaExtras,
   };
   await saveMeta(paths.storagePath, meta);
   return { fixture, paths, meta };
 }
+
+const completedCheckpoint = {
+  at: '2026-08-19T14:39:59.336Z',
+  nodesProcessed: 5,
+  totalNodes: 5,
+  chunksProcessed: 6,
+  model: 'voyage-code-3',
+  dimensions: 2048,
+} as const;
 
 async function importRepairSubject(options: {
   counts?: number[];
@@ -370,6 +380,80 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
         runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
       ).rejects.toThrow(/lock or recovery state is present/i);
       expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('refuses repair while an incremental analysis is in progress', async () => {
+    const indexed = await createIndexedFixture(3, {
+      incrementalInProgress: { startedAt: 1_787_151_443_267, toWriteCount: 0 },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({});
+      await expect(
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
+      ).rejects.toThrow(/incomplete analysis or embedding checkpoint/i);
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('refuses repair while an embedding checkpoint has unprocessed nodes', async () => {
+    const indexed = await createIndexedFixture(3, {
+      embeddingCheckpoint: { ...completedCheckpoint, nodesProcessed: 3 },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({});
+      await expect(
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
+      ).rejects.toThrow(/incomplete analysis or embedding checkpoint/i);
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('refuses repair while a complete-count checkpoint still has a pending window', async () => {
+    const indexed = await createIndexedFixture(3, {
+      embeddingCheckpoint: {
+        ...completedCheckpoint,
+        pendingNodeIds: ['Function:src/auth.ts:validateToken'],
+      },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({});
+      await expect(
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
+      ).rejects.toThrow(/incomplete analysis or embedding checkpoint/i);
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+    } finally {
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('repairs through a completed embedding checkpoint and clears the marker (#132)', async () => {
+    const indexed = await createIndexedFixture(3, {
+      embeddingCheckpoint: { ...completedCheckpoint },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({});
+      const result = await runFullAnalysis(
+        indexed.fixture.dbPath,
+        { repairVector: true },
+        { onProgress: () => {} },
+      );
+
+      expect(result.vectorRepairStatus).toBe('repaired');
+      expect(mocks.createVectorIndex).toHaveBeenCalledOnce();
+
+      const repaired = JSON.parse(
+        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
+      );
+      expect(repaired.embeddingCheckpoint).toBeUndefined();
+      expect(repaired.incrementalInProgress).toBeUndefined();
+      expect(repaired.capabilities.vectorSearch.status).toBe('vector-index');
     } finally {
       await indexed.fixture.cleanup();
     }

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -512,7 +512,7 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [3, 3, 3, 3] });
       await expect(
         runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
-      ).rejects.toThrow(/expects 5 embedding rows but the table holds 3/i);
+      ).rejects.toThrow(/expects at least 5 embedding rows but the table holds 3/i);
       expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
 
       const untouched = JSON.parse(
@@ -522,6 +522,38 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
         model: completedCheckpoint.model,
       });
       expect(untouched.stats.embeddings).toBe(5);
+    } finally {
+      restoreEnv();
+      await indexed.fixture.cleanup();
+    }
+  });
+
+  it('repairs when the live table holds MORE rows than the stale pre-finalize stats', async () => {
+    const restoreEnv = pinDefaultEmbeddingIdentity();
+    // The supported crash window: the run died between the last embedding
+    // write and finalize, so stats.embeddings still holds the OLD count (3)
+    // while the table already holds the completed checkpoint's rows (5).
+    // A deficit-only guard must let this repair; exact equality would refuse
+    // exactly the state this recovery path exists for.
+    const indexed = await createIndexedFixture(3, {
+      embeddingCheckpoint: { ...completedCheckpoint },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [5, 5, 5, 5] });
+      const result = await runFullAnalysis(
+        indexed.fixture.dbPath,
+        { repairVector: true },
+        { onProgress: () => {} },
+      );
+
+      expect(result.vectorRepairStatus).toBe('repaired');
+      expect(mocks.createVectorIndex).toHaveBeenCalledOnce();
+
+      const repaired = JSON.parse(
+        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
+      );
+      expect(repaired.embeddingCheckpoint).toBeUndefined();
+      expect(repaired.stats.embeddings).toBe(5);
     } finally {
       restoreEnv();
       await indexed.fixture.cleanup();
@@ -539,7 +571,7 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [0, 0, 0, 0] });
       await expect(
         runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
-      ).rejects.toThrow(/expects 5 embedding rows but the table holds 0/i);
+      ).rejects.toThrow(/expects at least 5 embedding rows but the table holds 0/i);
       expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
 
       const untouched = JSON.parse(

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -502,6 +502,41 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
     }
   });
 
+  it('clears a completed zero-node checkpoint on the not-indexed path (empty repository)', async () => {
+    const restoreEnv = pinDefaultEmbeddingIdentity();
+    // An empty repository's embed run completed trivially (totalNodes 0) and
+    // crashed before finalize. Repair must report not-indexed AND clear the
+    // checkpoint, or the repo stays permanently marked as interrupted.
+    const indexed = await createIndexedFixture(0, {
+      embeddingCheckpoint: {
+        ...completedCheckpoint,
+        nodesProcessed: 0,
+        totalNodes: 0,
+        chunksProcessed: 0,
+      },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [0, 0, 0, 0] });
+      const result = await runFullAnalysis(
+        indexed.fixture.dbPath,
+        { repairVector: true },
+        { onProgress: () => {} },
+      );
+
+      expect(result.vectorRepairStatus).toBe('not-indexed');
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+
+      const cleared = JSON.parse(
+        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
+      );
+      expect(cleared.embeddingCheckpoint).toBeUndefined();
+      expect(cleared.incrementalInProgress).toBeUndefined();
+    } finally {
+      restoreEnv();
+      await indexed.fixture.cleanup();
+    }
+  });
+
   it('refuses rather than returning not-indexed when ALL rows vanished after a completed checkpoint', async () => {
     const restoreEnv = pinDefaultEmbeddingIdentity();
     // The completed checkpoint recorded embedded nodes; the mocked live table

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -502,68 +502,11 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
     }
   });
 
-  it('refuses a completed checkpoint when embedding rows went missing after it', async () => {
-    const restoreEnv = pinDefaultEmbeddingIdentity();
-    // Metadata expects 5 rows; the mocked live table only holds 3.
-    const indexed = await createIndexedFixture(5, {
-      embeddingCheckpoint: { ...completedCheckpoint },
-    });
-    try {
-      const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [3, 3, 3, 3] });
-      await expect(
-        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
-      ).rejects.toThrow(/expects at least 5 embedding rows but the table holds 3/i);
-      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
-
-      const untouched = JSON.parse(
-        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
-      );
-      expect(untouched.embeddingCheckpoint).toMatchObject({
-        model: completedCheckpoint.model,
-      });
-      expect(untouched.stats.embeddings).toBe(5);
-    } finally {
-      restoreEnv();
-      await indexed.fixture.cleanup();
-    }
-  });
-
-  it('repairs when the live table holds MORE rows than the stale pre-finalize stats', async () => {
-    const restoreEnv = pinDefaultEmbeddingIdentity();
-    // The supported crash window: the run died between the last embedding
-    // write and finalize, so stats.embeddings still holds the OLD count (3)
-    // while the table already holds the completed checkpoint's rows (5).
-    // A deficit-only guard must let this repair; exact equality would refuse
-    // exactly the state this recovery path exists for.
-    const indexed = await createIndexedFixture(3, {
-      embeddingCheckpoint: { ...completedCheckpoint },
-    });
-    try {
-      const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [5, 5, 5, 5] });
-      const result = await runFullAnalysis(
-        indexed.fixture.dbPath,
-        { repairVector: true },
-        { onProgress: () => {} },
-      );
-
-      expect(result.vectorRepairStatus).toBe('repaired');
-      expect(mocks.createVectorIndex).toHaveBeenCalledOnce();
-
-      const repaired = JSON.parse(
-        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
-      );
-      expect(repaired.embeddingCheckpoint).toBeUndefined();
-      expect(repaired.stats.embeddings).toBe(5);
-    } finally {
-      restoreEnv();
-      await indexed.fixture.cleanup();
-    }
-  });
-
   it('refuses rather than returning not-indexed when ALL rows vanished after a completed checkpoint', async () => {
     const restoreEnv = pinDefaultEmbeddingIdentity();
-    // Metadata expects 5 rows; the mocked live table holds zero. Without the
-    // pre-zero-row guard this exits as a successful `not-indexed`.
+    // The completed checkpoint recorded embedded nodes; the mocked live table
+    // holds zero. Without the pre-zero-row guard this exits as a successful
+    // `not-indexed`.
     const indexed = await createIndexedFixture(5, {
       embeddingCheckpoint: { ...completedCheckpoint },
     });
@@ -571,7 +514,7 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [0, 0, 0, 0] });
       await expect(
         runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
-      ).rejects.toThrow(/expects at least 5 embedding rows but the table holds 0/i);
+      ).rejects.toThrow(/recorded 5 embedded nodes but the table holds no rows/i);
       expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
 
       const untouched = JSON.parse(

--- a/gitnexus/test/unit/run-analyze-vector-repair.test.ts
+++ b/gitnexus/test/unit/run-analyze-vector-repair.test.ts
@@ -501,4 +501,30 @@ describe('runFullAnalysis VECTOR-only repair (#170)', () => {
       await indexed.fixture.cleanup();
     }
   });
+
+  it('refuses a completed checkpoint when embedding rows went missing after it', async () => {
+    const restoreEnv = pinDefaultEmbeddingIdentity();
+    // Metadata expects 5 rows; the mocked live table only holds 3.
+    const indexed = await createIndexedFixture(5, {
+      embeddingCheckpoint: { ...completedCheckpoint },
+    });
+    try {
+      const { runFullAnalysis, mocks } = await importRepairSubject({ counts: [3, 3, 3, 3] });
+      await expect(
+        runFullAnalysis(indexed.fixture.dbPath, { repairVector: true }, { onProgress: () => {} }),
+      ).rejects.toThrow(/expects 5 embedding rows but the table holds 3/i);
+      expect(mocks.initLbugForMaintenance).not.toHaveBeenCalled();
+
+      const untouched = JSON.parse(
+        await fs.readFile(path.join(indexed.paths.storagePath, 'gitnexus.json'), 'utf8'),
+      );
+      expect(untouched.embeddingCheckpoint).toMatchObject({
+        model: completedCheckpoint.model,
+      });
+      expect(untouched.stats.embeddings).toBe(5);
+    } finally {
+      restoreEnv();
+      await indexed.fixture.cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Problem

`assertVectorRepairPreflight` refuses whenever `meta.embeddingCheckpoint` exists — even when the checkpoint records a fully persisted window (`nodesProcessed === totalNodes`, no `pendingNodeIds`). That state only means the run died between the last embedding write and finalize (e.g. the 08-19 buffer-pool death during HNSW build). The embedding table is whole, but the only sanctioned exit is `--force --drop-embeddings` — a full paid re-embed. Field evidence on #132 (comment 5345564857): a 3-hour, API-billed recovery for what `--repair-vector` completes in ~3 minutes once the marker is bypassed.

## Change

- Preflight: an `embeddingCheckpoint` with a fully persisted window no longer blocks repair. Incomplete checkpoints (unprocessed nodes OR a pending window, whose chunk rows may be partially persisted) and `incrementalInProgress` remain blocking, with the same error text.
- Safety: the repair path still runs `inspectEmbeddingIntegrity` three times (read-only preflight, writable recheck, pre-commit), so a checkpoint that lies about completeness is still caught by the existing guards.
- On successful repair, `repairedMeta` now explicitly clears `embeddingCheckpoint` and `incrementalInProgress` so the stale marker cannot re-enter recovery on the next run.

## Tests

4 new cases in `test/unit/run-analyze-vector-repair.test.ts` (refuses in-progress incremental; refuses unprocessed nodes; refuses complete-count-but-pending-window; repairs through a completed checkpoint and asserts `gitnexus.json` no longer carries either marker). Full unit suite: 512 files / 10,268 tests green.

Refs #132.