### PR TITLE
chore(release): prepare electric 1.6.10-electric.10

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.9",
+      "version": "1.6.10-electric.10",
       "source": {
         "source": "local",
         "path": "./gitnexus-claude-plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "gitnexus",
-      "version": "1.6.10-electric.9",
+      "version": "1.6.10-electric.10",
       "source": "./gitnexus-claude-plugin",
       "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase."
     }

--- a/Documentation/releases/1.6.10-electric.10.md
+++ b/Documentation/releases/1.6.10-electric.10.md
@@ -14,9 +14,11 @@ in minutes; evidence on #132).
 - A completed checkpoint must match the run's resolved embedding identity (model AND
   dimensions), mirroring the resume-path guard. A same-dimension model swap can no longer
   rebuild HNSW over incompatible rows while erasing the only persisted model marker.
-- A completed checkpoint's repair now requires the live row count to equal the persisted
-  `stats.embeddings` expectation, so a dirty-recovery discard that dropped committed rows can
-  no longer be silently certified and reconciled downward.
+- Total embedding-table loss after a completed checkpoint is refused instead of returning a
+  successful `not-indexed`: the checkpoint records embedded nodes, so an empty table is wrong
+  in every history. Partial-loss detection requires a per-checkpoint persisted row count
+  (`stats.embeddings` was proven unusable as an expectation in both directions during review)
+  and is tracked as #194.
 - A successful repair clears `embeddingCheckpoint` and `incrementalInProgress` in the committed
   metadata (both files via the `saveMeta` dual-write), so the stale marker cannot re-enter
   recovery on the next run.
@@ -32,10 +34,11 @@ in minutes; evidence on #132).
 
 ## Release Verification
 
-- Included PR: #192 (3 commits; cross-model reviewed — codex sol·high pre-merge review, delta
-  re-review CLOSED, plus codex-connector inline P1/P2 findings fixed in-branch). Tracking: #132,
-  epic #130.
-- Unit coverage: 16 cases in `run-analyze-vector-repair.test.ts` (6 new); full unit suite green.
+- Included PR: #192 (7 commits; five review rounds — codex sol·high pre-merge review with delta
+  re-review CLOSED, codex-connector and evaos-code-review-bot inline P1/P2 findings fixed
+  in-branch or dispositioned to #193/#194, CodeRabbit approval). Tracking: #132, epic #130.
+- Unit coverage: 18 cases in `run-analyze-vector-repair.test.ts` (8 added since `.9`); full unit
+  suite green at the first commit, file-local suite green at head.
 - Real-world regression target: the electric-sheep-website-dashboard index (embeddings present,
   HNSW missing, completed checkpoint) must repair in minutes on the installed dist without
   re-embedding.

--- a/Documentation/releases/1.6.10-electric.10.md
+++ b/Documentation/releases/1.6.10-electric.10.md
@@ -20,8 +20,9 @@ in minutes; evidence on #132).
   (`stats.embeddings` was proven unusable as an expectation in both directions during review)
   and is tracked as #194.
 - A successful repair clears `embeddingCheckpoint` and `incrementalInProgress` in the committed
-  metadata (both files via the `saveMeta` dual-write), so the stale marker cannot re-enter
-  recovery on the next run.
+  metadata — authoritatively in the primary `gitnexus.json`, with the legacy `meta.json` mirror
+  updated best-effort (`saveMeta` logs and continues if the mirror write fails) — so the stale
+  marker cannot re-enter recovery on the next run.
 
 ## Safety Boundary
 
@@ -34,7 +35,7 @@ in minutes; evidence on #132).
 
 ## Release Verification
 
-- Included PR: #192 (7 commits; five review rounds — codex sol·high pre-merge review with delta
+- Included PR: #192 (8 commits; five review rounds — codex sol·high pre-merge review with delta
   re-review CLOSED, codex-connector and evaos-code-review-bot inline P1/P2 findings fixed
   in-branch or dispositioned to #193/#194, CodeRabbit approval). Tracking: #132, epic #130.
 - Unit coverage: 18 cases in `run-analyze-vector-repair.test.ts` (8 added since `.9`); full unit

--- a/Documentation/releases/1.6.10-electric.10.md
+++ b/Documentation/releases/1.6.10-electric.10.md
@@ -1,0 +1,41 @@
+# GitNexus 1.6.10-electric.10
+
+`1.6.10-electric.10` makes `--repair-vector` reachable for the one interrupted-analyze state
+where the embedding table is already whole: a completed embedding checkpoint. Previously any
+checkpoint marker forced a full `--drop-embeddings` re-embed even when every vector was
+persisted (field incident 2026-08-19: a ~3-hour, API-billed recovery for what repair finishes
+in minutes; evidence on #132).
+
+## Fixed
+
+- `assertVectorRepairPreflight` now admits an `embeddingCheckpoint` whose window is fully
+  persisted (`nodesProcessed === totalNodes`, no `pendingNodeIds`). Incomplete checkpoints and
+  `incrementalInProgress` remain fail-closed with the same error.
+- A completed checkpoint must match the run's resolved embedding identity (model AND
+  dimensions), mirroring the resume-path guard. A same-dimension model swap can no longer
+  rebuild HNSW over incompatible rows while erasing the only persisted model marker.
+- A completed checkpoint's repair now requires the live row count to equal the persisted
+  `stats.embeddings` expectation, so a dirty-recovery discard that dropped committed rows can
+  no longer be silently certified and reconciled downward.
+- A successful repair clears `embeddingCheckpoint` and `incrementalInProgress` in the committed
+  metadata (both files via the `saveMeta` dual-write), so the stale marker cannot re-enter
+  recovery on the next run.
+
+## Safety Boundary
+
+- The three `inspectEmbeddingIntegrity` passes (read-only preflight, writable recheck,
+  pre-commit) are unchanged and still gate every repair.
+- Repair with any lock, WAL, shadow, staged-work, or promotion artifact present remains
+  fail-closed. Refusals leave the checkpoint untouched.
+- The plain (no-checkpoint) repair path is unchanged; its lack of an expected-count comparison
+  pre-dates this release and stays tracked under #132.
+
+## Release Verification
+
+- Included PR: #192 (3 commits; cross-model reviewed — codex sol·high pre-merge review, delta
+  re-review CLOSED, plus codex-connector inline P1/P2 findings fixed in-branch). Tracking: #132,
+  epic #130.
+- Unit coverage: 16 cases in `run-analyze-vector-repair.test.ts` (6 new); full unit suite green.
+- Real-world regression target: the electric-sheep-website-dashboard index (embeddings present,
+  HNSW missing, completed checkpoint) must repair in minutes on the installed dist without
+  re-embedding.

--- a/gitnexus-claude-plugin/.claude-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.9",
+  "version": "1.6.10-electric.10",
   "author": {
     "name": "GitNexus"
   },

--- a/gitnexus-claude-plugin/.codex-plugin/plugin.json
+++ b/gitnexus-claude-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitnexus",
   "description": "Code intelligence powered by a knowledge graph. Provides execution flow tracing, blast radius analysis, and augmented search across your codebase.",
-  "version": "1.6.10-electric.9",
+  "version": "1.6.10-electric.10",
   "skills": "./skills",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/hooks.json",

--- a/gitnexus/CHANGELOG.md
+++ b/gitnexus/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to GitNexus will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.10-electric.10] - 2026-08-20
+
+### Fixed
+
+- `--repair-vector` now admits a COMPLETED embedding checkpoint (fully persisted window) instead
+  of forcing a full `--drop-embeddings` re-embed for an index whose vectors are already whole
+  (#192, field evidence on #132). Incomplete checkpoints and in-progress incremental writes
+  remain fail-closed.
+- A completed checkpoint must match the run's resolved embedding identity (model AND
+  dimensions), mirroring the resume-path guard; a same-dimension model swap can no longer
+  rebuild HNSW over incompatible rows while erasing the persisted model marker (#192).
+- Total embedding-table loss after a completed checkpoint is refused instead of returning a
+  successful `not-indexed`; a completed zero-node checkpoint is cleared on the not-indexed path
+  so empty repositories cannot stay marked as interrupted (#192).
+- A successful VECTOR repair clears `embeddingCheckpoint` and `incrementalInProgress` in the
+  committed metadata, so the stale marker cannot re-enter recovery on the next run (#192).
+
 ## [1.6.10-electric.9] - 2026-07-30
 
 ### Fixed

--- a/gitnexus/package-lock.json
+++ b/gitnexus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.9",
+  "version": "1.6.10-electric.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitnexus",
-      "version": "1.6.10-electric.9",
+      "version": "1.6.10-electric.10",
       "hasInstallScript": true,
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {

--- a/gitnexus/package.json
+++ b/gitnexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitnexus",
-  "version": "1.6.10-electric.9",
+  "version": "1.6.10-electric.10",
   "description": "Graph-powered code intelligence for AI agents. Index any codebase, query via MCP or CLI.",
   "author": "Abhigyan Patwari",
   "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Release prep for `1.6.10-electric.10` — carries #192 (completed-checkpoint `--repair-vector`: preflight allowance + identity guard + checkpoint-provable total-loss guard + marker clearing).

Checklist per RUNBOOK §Electric fork releases:
- [x] `gitnexus/package.json` + lockfile → 1.6.10-electric.10
- [x] `sync-plugin-versions.mjs` run (2 plugin + 2 marketplace manifests)
- [x] `Documentation/releases/1.6.10-electric.10.md`
- [x] `CHANGELOG.md` entry
- [x] `npm run check:electric-release-policy` → passed locally

⚠ Note: a STALE `release/electric-1.6.10-electric.10` branch exists on origin (last commit 2026-08-15 by Eva, version already bumped to .10, 13 tooling commits — provenance review gaps, Windows version probes — none on main, no open PR, does not contain #192). This PR deliberately uses a distinct branch rather than clobbering it; those 13 commits need their own disposition (land via their own PR or delete the branch). Flagged for the release owner.

After merge: dispatch `electric-release.yml` with expected_version=1.6.10-electric.10; local install fallback per runbook if the protected environment gate stalls. Refs #192, #132.